### PR TITLE
chore: travis s3 publisher should use base64-encoded creds

### DIFF
--- a/dist/publishers/s3/push-cos.js
+++ b/dist/publishers/s3/push-cos.js
@@ -4,7 +4,9 @@ const path = require('path')
 const AWS = require('ibm-cos-sdk')
 const needle = require('needle')
 
-const secrets = process.env.COS_SECRETS ? JSON.parse(process.env.COS_SECRETS) : require('./secrets-cos.json')
+const secrets = process.env.COS_SECRETS
+  ? JSON.parse(Buffer.from(process.env.COS_SECRETS, 'base64').toString())
+  : require('./secrets-cos.json')
 
 const { productName } = require('../../../app/build/config.json')
 


### PR DESCRIPTION
Fixes #113

Thanks for your contribution! This project uses [Conventional Commits](https://www.conventionalcommits.org) as a guide for commit messages. Please ensure that your commit message follows this structure:

```
type(component?): message
```

*type* is one of: feat, fix, docs, chore, style, refactor, perf, test

*component* optionally is the name of the module you are fixing; either "core" or a named module in app/plugins/modules

Thanks!
