### PR TITLE
docs: remove live link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ data.
 
 - [Install a prebuilt version](docs/installation.md)
 - [Clone and contribute!](docs/dev/README.md)
-- [Try it Live](https://hello.kui-shell.org/)
 
 When running locally (the first and second options), we suggest that
 you add the `bin` directory to your PATH; the above links provide the


### PR DESCRIPTION
Live version requires more work before it's ready for users to try with kube.