### PR TITLE
fix(core-support): tab close, base64, window close do not require auth

### DIFF
--- a/app/plugins/modules/core-support/src/lib/cmds/base64.ts
+++ b/app/plugins/modules/core-support/src/lib/cmds/base64.ts
@@ -69,5 +69,5 @@ export default (commandTree, prequire) => {
       debug('encoding')
       return breakout(str.toString('base64'), options)
     }
-  }, { usage })
+  }, { usage, noAuthOk: true })
 }

--- a/app/plugins/modules/core-support/src/lib/cmds/window.ts
+++ b/app/plugins/modules/core-support/src/lib/cmds/window.ts
@@ -26,8 +26,8 @@ export default (commandTree, prequire) => {
 
   // commandTree.listen('/window/bigger', () => tellMain('enlarge-window'))
   // commandTree.listen('/window/smaller', () => tellMain('reduce-window'))
-  commandTree.listen('/window/max', () => tellMain('maximize-window'), { docs: 'Maximize the window' })
-  commandTree.listen('/window/unmax', () => tellMain('unmaximize-window'), { docs: 'Unmaximize the window' })
+  commandTree.listen('/window/max', () => tellMain('maximize-window'), { docs: 'Maximize the window', noAuthOk: true })
+  commandTree.listen('/window/unmax', () => tellMain('unmaximize-window'), { docs: 'Unmaximize the window', noAuthOk: true })
 
   // register a window close command handler
   commandTree.listen('/window/close', () => {
@@ -38,5 +38,5 @@ export default (commandTree, prequire) => {
       let w = remote.getCurrentWindow()
       w.close()
     }
-  })
+  }, { noAuthOk: true })
 }

--- a/app/plugins/modules/core-support/src/lib/new-tab.ts
+++ b/app/plugins/modules/core-support/src/lib/new-tab.ts
@@ -289,9 +289,9 @@ const closeTab = () => {
 
 const registerCommandHandlers = (commandTree, prequire) => {
   commandTree.listen('/tab/switch', ({ argvNoOptions }) => switchTab(argvNoOptions[argvNoOptions.length - 1]),
-                     { usage, needsUI: true })
-  commandTree.listen('/tab/new', newTabAsync, { needsUI: true })
-  commandTree.listen('/tab/close', closeTab, { needsUI: true })
+                     { usage, needsUI: true, noAuthOk: true })
+  commandTree.listen('/tab/new', newTabAsync, { needsUI: true, noAuthOk: true })
+  commandTree.listen('/tab/close', closeTab, { needsUI: true, noAuthOk: true })
 }
 
 export default async (commandTree, prequire) => {


### PR DESCRIPTION
Fixes #169
