### PR TITLE
fix(apache-composer): parse error handler of compose will check error…

### DIFF
--- a/plugins/plugin-apache-composer/src/lib/model/editor/composition-persister.ts
+++ b/plugins/plugin-apache-composer/src/lib/model/editor/composition-persister.ts
@@ -44,7 +44,7 @@ export const handleParseError = (err, filepath, editor) => {
     debug('pattern', pattern1, pattern2, pattern3)
     debug('message', err.message)
     if (match) {
-      const problem = match3 ? match[2] : match[1]
+      const problem = err.cause && err.cause.code ? err.cause.message : match3 ? match[2] : match[1]
       const line = match3 ? match[1] : match[2]
       const column = match[3]
       debug('got match', problem, line, column)

--- a/plugins/plugin-apache-composer/src/lib/utility/compile.ts
+++ b/plugins/plugin-apache-composer/src/lib/utility/compile.ts
@@ -211,6 +211,7 @@ const sourceErrHandler = (error, originalCode, filename) => {
     statusCode: 'ENOPARSE', // would like to use code here, but we've already used it for code:originalCode
     message,
     ast: message,
+    cause: error,
     code: originalCode
   }
 }


### PR DESCRIPTION
… casue to avoid decorating error not ENOPARSE

Fixes #324
