### PR TITLE
chore(release): publish

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 2.5.0 (2019-02-04)
+
+
+### Bug Fixes
+
+* fixes for auth in browser+proxy mode ([a441c33](https://github.com/IBM/kui/commit/a441c33)), closes [#287](https://github.com/IBM/kui/issues/287) [#286](https://github.com/IBM/kui/issues/286) [#289](https://github.com/IBM/kui/issues/289)
+* local dev-mode ./bin/kui is missing theme ([e41e159](https://github.com/IBM/kui/commit/e41e159)), closes [#319](https://github.com/IBM/kui/issues/319)
+* **core:** another fix for error handling in plugin precompiler ([41c15db](https://github.com/IBM/kui/commit/41c15db)), closes [#306](https://github.com/IBM/kui/issues/306)
+* **core:** confine global repl hack to test mode ([e37d933](https://github.com/IBM/kui/commit/e37d933)), closes [#212](https://github.com/IBM/kui/issues/212)
+* **core:** more gracefully handle dom and errors in plugin compiler ([34e6f48](https://github.com/IBM/kui/commit/34e6f48)), closes [#306](https://github.com/IBM/kui/issues/306)
+* **k8s:** fix for kubectl status in headless mode ([072626f](https://github.com/IBM/kui/commit/072626f)), closes [#327](https://github.com/IBM/kui/issues/327)
+* **webpack:** fixes for webpack build regressions ([f636fb6](https://github.com/IBM/kui/commit/f636fb6)), closes [#259](https://github.com/IBM/kui/issues/259)
+* **wskflow:** fix for preview [@demos](https://github.com/demos) in webpack mode ([d1b4e75](https://github.com/IBM/kui/commit/d1b4e75)), closes [#329](https://github.com/IBM/kui/issues/329)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+* **webpack:** dockerized webpack build ([bc65dc2](https://github.com/IBM/kui/commit/bc65dc2)), closes [#274](https://github.com/IBM/kui/issues/274)
+
+
+
+
+
 # 2.4.0 (2019-02-03)
 
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/core",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "An Electron-based shell for cloud-native development",
   "homepage": "https://github.com/IBM/kui#readme",
   "license": "Apache-2.0",

--- a/packages/kui-builder/CHANGELOG.md
+++ b/packages/kui-builder/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.5.0 (2019-02-04)
+
+
+### Bug Fixes
+
+* fixes for auth in browser+proxy mode ([a441c33](https://github.com/IBM/kui/commit/a441c33)), closes [#287](https://github.com/IBM/kui/issues/287) [#286](https://github.com/IBM/kui/issues/286) [#289](https://github.com/IBM/kui/issues/289)
+* local dev-mode ./bin/kui is missing theme ([e41e159](https://github.com/IBM/kui/commit/e41e159)), closes [#319](https://github.com/IBM/kui/issues/319)
+* **apache-composer:** compose yoyo -t [@demos](https://github.com/demos)/if.js broken in webpack mode ([14ac816](https://github.com/IBM/kui/commit/14ac816)), closes [#332](https://github.com/IBM/kui/issues/332)
+* **core:** more gracefully handle dom and errors in plugin compiler ([34e6f48](https://github.com/IBM/kui/commit/34e6f48)), closes [#306](https://github.com/IBM/kui/issues/306)
+* **webpack:** fixes for webpack build regressions ([f636fb6](https://github.com/IBM/kui/commit/f636fb6)), closes [#259](https://github.com/IBM/kui/issues/259)
+* **webpack:** improve theme override support ([e8b943a](https://github.com/IBM/kui/commit/e8b943a)), closes [#298](https://github.com/IBM/kui/issues/298)
+* **webpack:** restore webpack publisher functionality ([2b4feeb](https://github.com/IBM/kui/commit/2b4feeb)), closes [#271](https://github.com/IBM/kui/issues/271)
+* **wskflow:** fix for preview [@demos](https://github.com/demos) in webpack mode ([d1b4e75](https://github.com/IBM/kui/commit/d1b4e75)), closes [#329](https://github.com/IBM/kui/issues/329)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+* **webpack:** dockerized webpack build ([bc65dc2](https://github.com/IBM/kui/commit/bc65dc2)), closes [#274](https://github.com/IBM/kui/issues/274)
+
+
+
+
+
 # 0.4.0 (2019-02-03)
 
 

--- a/packages/kui-builder/package.json
+++ b/packages/kui-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/builder",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Kui plugin development helpers",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/packages/proxy/CHANGELOG.md
+++ b/packages/proxy/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.5.0 (2019-02-04)
+
+
+### Bug Fixes
+
+* fixes for auth in browser+proxy mode ([a441c33](https://github.com/IBM/kui/commit/a441c33)), closes [#287](https://github.com/IBM/kui/issues/287) [#286](https://github.com/IBM/kui/issues/286) [#289](https://github.com/IBM/kui/issues/289)
+* **proxy:** we weren't handling execOptions undefined ([5a31f8d](https://github.com/IBM/kui/commit/5a31f8d)), closes [#291](https://github.com/IBM/kui/issues/291)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+* **webpack:** dockerized webpack build ([bc65dc2](https://github.com/IBM/kui/commit/bc65dc2)), closes [#274](https://github.com/IBM/kui/issues/274)
+
+
+
+
+
 # 0.4.0 (2019-02-03)
 
 

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/proxy",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Kui package that offers a proxy server",
   "author": "Nick Mitchell",
   "license": "Apache-2.0",

--- a/plugins/plugin-apache-composer/CHANGELOG.md
+++ b/plugins/plugin-apache-composer/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.10.0 (2019-02-04)
+
+
+### Bug Fixes
+
+* **apache-composer:** app create -r waits for all actions being successfully deployed ([49e1e2f](https://github.com/IBM/kui/commit/49e1e2f)), closes [#269](https://github.com/IBM/kui/issues/269)
+* fixes for auth in browser+proxy mode ([a441c33](https://github.com/IBM/kui/commit/a441c33)), closes [#287](https://github.com/IBM/kui/issues/287) [#286](https://github.com/IBM/kui/issues/286) [#289](https://github.com/IBM/kui/issues/289)
+* **apache-composer:** compose yoyo -t [@demos](https://github.com/demos)/if.js broken in webpack mode ([14ac816](https://github.com/IBM/kui/commit/14ac816)), closes [#332](https://github.com/IBM/kui/issues/332)
+* **apache-composer:** help editor find openwhisk-composer module by moving appModulePath to apache-composer preload ([871c2b8](https://github.com/IBM/kui/commit/871c2b8)), closes [#317](https://github.com/IBM/kui/issues/317)
+* **apache-composer:** parse error handler of compose will check error casue to avoid decorating error not ENOPARSE ([d9e5598](https://github.com/IBM/kui/commit/d9e5598)), closes [#324](https://github.com/IBM/kui/issues/324)
+* **apache-composer:** remove app create -r ([af0a428](https://github.com/IBM/kui/commit/af0a428)), closes [#316](https://github.com/IBM/kui/issues/316) [#318](https://github.com/IBM/kui/issues/318)
+* **wskflow:** fix for preview [@demos](https://github.com/demos) in webpack mode ([adc685f](https://github.com/IBM/kui/commit/adc685f)), closes [#329](https://github.com/IBM/kui/issues/329)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+
+
+
+
+
 # 0.9.0 (2019-02-03)
 
 

--- a/plugins/plugin-apache-composer/package.json
+++ b/plugins/plugin-apache-composer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-apache-composer",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Kui plugin for the Apache OpenWhisk Composer",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-bash-like/CHANGELOG.md
+++ b/plugins/plugin-bash-like/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.7 (2019-02-04)
+
+
+### Bug Fixes
+
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+
+
+
 ## 0.0.5 (2019-02-03)
 
 

--- a/plugins/plugin-bash-like/package.json
+++ b/plugins/plugin-bash-like/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-bash-like",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Kui plugin that offers local bash-like shell integrations",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-core-support/CHANGELOG.md
+++ b/plugins/plugin-core-support/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.5.0 (2019-02-04)
+
+
+### Bug Fixes
+
+* **wskflow:** fix for preview [@demos](https://github.com/demos) in webpack mode ([d1b4e75](https://github.com/IBM/kui/commit/d1b4e75)), closes [#329](https://github.com/IBM/kui/issues/329)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+
+
+
+
+
 # 0.4.0 (2019-02-03)
 
 

--- a/plugins/plugin-core-support/package.json
+++ b/plugins/plugin-core-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-core-support",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Kui plugin offering core extensions such as help and screenshot commands",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-editor/CHANGELOG.md
+++ b/plugins/plugin-editor/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.6 (2019-02-04)
+
+
+### Bug Fixes
+
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+
+
+
 ## 0.0.5 (2019-02-03)
 
 

--- a/plugins/plugin-editor/package.json
+++ b/plugins/plugin-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-editor",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Kui plugin that integrates the monaco-editor component",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-grid/CHANGELOG.md
+++ b/plugins/plugin-grid/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.6 (2019-02-04)
+
+
+### Bug Fixes
+
+* **apache-composer:** compose yoyo -t [@demos](https://github.com/demos)/if.js broken in webpack mode ([14ac816](https://github.com/IBM/kui/commit/14ac816)), closes [#332](https://github.com/IBM/kui/issues/332)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+
+
+
 ## 0.0.5 (2019-02-03)
 
 

--- a/plugins/plugin-grid/package.json
+++ b/plugins/plugin-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-grid",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Kui plugin that offers a grid visualization of OpenWhisk function invocations",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-k8s/CHANGELOG.md
+++ b/plugins/plugin-k8s/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.5.0 (2019-02-04)
+
+
+### Bug Fixes
+
+* **k8s:** fix for kubectl status in headless mode ([072626f](https://github.com/IBM/kui/commit/072626f)), closes [#327](https://github.com/IBM/kui/issues/327)
+* **webpack:** fixes for webpack build regressions ([f636fb6](https://github.com/IBM/kui/commit/f636fb6)), closes [#259](https://github.com/IBM/kui/issues/259)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+
+
+
+
+
 # 0.4.0 (2019-02-03)
 
 

--- a/plugins/plugin-k8s/package.json
+++ b/plugins/plugin-k8s/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-k8s",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Kui plugin for kubernetes",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-manager/CHANGELOG.md
+++ b/plugins/plugin-manager/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.6 (2019-02-04)
+
+
+### Bug Fixes
+
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+
+
+
 ## 0.0.5 (2019-02-03)
 
 

--- a/plugins/plugin-manager/package.json
+++ b/plugins/plugin-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-manager",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Support for field installation of plugins",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-openwhisk-debug/CHANGELOG.md
+++ b/plugins/plugin-openwhisk-debug/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.6 (2019-02-04)
+
+
+### Bug Fixes
+
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+
+
+
 ## 0.0.5 (2019-02-03)
 
 

--- a/plugins/plugin-openwhisk-debug/package.json
+++ b/plugins/plugin-openwhisk-debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-openwhisk-debug",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Kui plugin that lets users run and debug actions locally in a docker container",
   "license": "Apache-2.0",
   "author": "Kerry Chang",

--- a/plugins/plugin-openwhisk/CHANGELOG.md
+++ b/plugins/plugin-openwhisk/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.5.0 (2019-02-04)
+
+
+### Bug Fixes
+
+* fixes for auth in browser+proxy mode ([a441c33](https://github.com/IBM/kui/commit/a441c33)), closes [#287](https://github.com/IBM/kui/issues/287) [#286](https://github.com/IBM/kui/issues/286) [#289](https://github.com/IBM/kui/issues/289)
+* **apache-composer:** compose yoyo -t [@demos](https://github.com/demos)/if.js broken in webpack mode ([14ac816](https://github.com/IBM/kui/commit/14ac816)), closes [#332](https://github.com/IBM/kui/issues/332)
+* **openwhisk:** add expandHomeDir when reading process.env.WSK_CONFIG_FILE ([c441c1c](https://github.com/IBM/kui/commit/c441c1c)), closes [#253](https://github.com/IBM/kui/issues/253)
+* **openwhisk:** fix for misplaced test file ([5d3286f](https://github.com/IBM/kui/commit/5d3286f)), closes [#263](https://github.com/IBM/kui/issues/263)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+* **webpack:** dockerized webpack build ([bc65dc2](https://github.com/IBM/kui/commit/bc65dc2)), closes [#274](https://github.com/IBM/kui/issues/274)
+
+
+
+
+
 # 0.4.0 (2019-02-03)
 
 

--- a/plugins/plugin-openwhisk/package.json
+++ b/plugins/plugin-openwhisk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-openwhisk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Kui plugin for OpenWhisk",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-proxy-support/CHANGELOG.md
+++ b/plugins/plugin-proxy-support/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.5.0 (2019-02-04)
+
+
+### Bug Fixes
+
+* fixes for auth in browser+proxy mode ([a441c33](https://github.com/IBM/kui/commit/a441c33)), closes [#287](https://github.com/IBM/kui/issues/287) [#286](https://github.com/IBM/kui/issues/286) [#289](https://github.com/IBM/kui/issues/289)
+* **plugin-proxy-support:** needle url issue ([d17856f](https://github.com/IBM/kui/commit/d17856f)), closes [#310](https://github.com/IBM/kui/issues/310)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+
+
+
+
+
 # 0.4.0 (2019-02-03)
 
 

--- a/plugins/plugin-proxy-support/package.json
+++ b/plugins/plugin-proxy-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-proxy-support",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Kui plugin that adds runtime support for proxied communication",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-tutorials/CHANGELOG.md
+++ b/plugins/plugin-tutorials/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.5.0 (2019-02-04)
+
+
+### Bug Fixes
+
+* **apache-composer:** remove app create -r ([af0a428](https://github.com/IBM/kui/commit/af0a428)), closes [#316](https://github.com/IBM/kui/issues/316) [#318](https://github.com/IBM/kui/issues/318)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+
+
+
+
+
 # 0.4.0 (2019-02-03)
 
 

--- a/plugins/plugin-tutorials/package.json
+++ b/plugins/plugin-tutorials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-tutorials",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "IBM Cloud shell plugin for tutorials",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-wskflow/CHANGELOG.md
+++ b/plugins/plugin-wskflow/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.6 (2019-02-04)
+
+
+### Bug Fixes
+
+* **apache-composer:** compose yoyo -t [@demos](https://github.com/demos)/if.js broken in webpack mode ([14ac816](https://github.com/IBM/kui/commit/14ac816)), closes [#332](https://github.com/IBM/kui/issues/332)
+* **wskflow:** fix for preview [@demos](https://github.com/demos) in webpack mode ([adc685f](https://github.com/IBM/kui/commit/adc685f)), closes [#329](https://github.com/IBM/kui/issues/329)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+
+
+
 ## 0.0.5 (2019-02-03)
 
 

--- a/plugins/plugin-wskflow/package.json
+++ b/plugins/plugin-wskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-wskflow",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Visualizations for Composer apps",
   "license": "Apache-2.0",
   "author": "Kerry Chang",


### PR DESCRIPTION
 - @kui-shell/core@2.5.0
 - @kui-shell/builder@0.5.0
 - @kui-shell/proxy@0.5.0
 - @kui-shell/plugin-apache-composer@0.10.0
 - @kui-shell/plugin-bash-like@0.0.7
 - @kui-shell/plugin-core-support@0.5.0
 - @kui-shell/plugin-editor@0.0.6
 - @kui-shell/plugin-grid@0.0.6
 - @kui-shell/plugin-k8s@0.5.0
 - @kui-shell/plugin-manager@0.0.6
 - @kui-shell/plugin-openwhisk-debug@0.0.6
 - @kui-shell/plugin-openwhisk@0.5.0
 - @kui-shell/plugin-proxy-support@0.5.0
 - @kui-shell/plugin-tutorials@0.5.0
 - @kui-shell/plugin-wskflow@0.0.6