### PR TITLE
docs: fix broken link and incomplete text in custom client guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,4 @@ workflows.
 - [More Kubernetes Examples](docs/readme/examples/kubernetes.md)
 - [Apache OpenWhisk Examples](docs/readme/examples/openwhisk.md)
 - [Apache Composer Examples](docs/readme/examples/composer.md)
+- [Creating your own Custom Kui Client](docs/dev/custom-clients.md)

--- a/docs/dev/custom-clients.md
+++ b/docs/dev/custom-clients.md
@@ -56,9 +56,9 @@ npx kui-build-webpack
 As above, you needn't build all three flavors of clients; this example
 is intended to enumerate the commands.
 
-## Next Steps: Customize!
+## Next Step: Customize!
 
 Now that you have made a decision on how to develop a custom Kui
 client, you are ready to begin making customization choices. For more
 information on customizing your client, please consult the
-[customization guide](customization-guide).
+[customization guide](customization-guide.md).

--- a/docs/dev/customization-guide.md
+++ b/docs/dev/customization-guide.md
@@ -1,10 +1,13 @@
-# Crafting Custom Kui Clients
+# Crafting a Custom Kui Client
 
 To develop a client, you have two choices. First, you may fork this
 repository and populate `clients/my-client`, using [the default
 client](../../clients/default) as a starting point. Second, you may
-develop your client externally to this repository. For 
+develop your client externally to this repository. For more
+information on development choice, please consult the [custom client
+guide](custom-clients.md).
 
+The remainder of this document describes how to customize your client.
 You may customize the configuration of your clients in several ways:
 
 - choose a subset of previously published plugins to incorporate


### PR DESCRIPTION
Fixes #445