### PR TITLE
docs: fix broken custom-client-documenation link in client/README.md

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -6,7 +6,7 @@ houses the custom client that Kui uses for its continuous integration
 and delivery pipeline.
 
 Please consult the [custom client
-documentation](../docs/dev/custom-clients) for more information on
+documentation](../docs/dev/custom-clients.md) for more information on
 developing a Kui client, including your development options, the
 customization opportunities, how to extend Kui by adding custom
 plugins, and how to build headless, electron, and webpack


### PR DESCRIPTION
Fixes #465 