### PR TITLE
chore(release): publish

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,7 @@
   "command": {
     "publish": {
       "conventionalCommits": true,
-      "message": "chore(release): publish %s"
+      "message": "chore(release): publish"
     }
   }
 }

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -3,6 +3,41 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 2.11.0 (2019-02-22)
+
+
+### Bug Fixes
+
+* **app:** fixes for --ui and headless to graphics transitions ([38c4e98](https://github.com/IBM/kui/commit/38c4e98)), closes [#408](https://github.com/IBM/kui/issues/408)
+* **app:** opening Kui Electron Builds from macOS Finder adds additional argv -psn ([5ac8393](https://github.com/IBM/kui/commit/5ac8393)), closes [#382](https://github.com/IBM/kui/issues/382)
+* **app:** table watch handler was installing a row-level onclick handler ([ecdd93b](https://github.com/IBM/kui/commit/ecdd93b)), closes [#388](https://github.com/IBM/kui/issues/388)
+* **app:** tone down ENOENT while precompiling plugin model ([dc99c90](https://github.com/IBM/kui/commit/dc99c90)), closes [#375](https://github.com/IBM/kui/issues/375)
+* **core:** another fix for error handling in plugin precompiler ([41c15db](https://github.com/IBM/kui/commit/41c15db)), closes [#306](https://github.com/IBM/kui/issues/306)
+* **core:** confine global repl hack to test mode ([e37d933](https://github.com/IBM/kui/commit/e37d933)), closes [#212](https://github.com/IBM/kui/issues/212)
+* **core:** more gracefully handle dom and errors in plugin compiler ([34e6f48](https://github.com/IBM/kui/commit/34e6f48)), closes [#306](https://github.com/IBM/kui/issues/306)
+* **k8s:** fix for kubectl status in headless mode ([072626f](https://github.com/IBM/kui/commit/072626f)), closes [#327](https://github.com/IBM/kui/issues/327)
+* **packages/tests:** remove bin/corral from test runner ([1f7c263](https://github.com/IBM/kui/commit/1f7c263)), closes [#510](https://github.com/IBM/kui/issues/510) [#425](https://github.com/IBM/kui/issues/425)
+* fixes for auth in browser+proxy mode ([a441c33](https://github.com/IBM/kui/commit/a441c33)), closes [#287](https://github.com/IBM/kui/issues/287) [#286](https://github.com/IBM/kui/issues/286) [#289](https://github.com/IBM/kui/issues/289)
+* local dev-mode ./bin/kui is missing theme ([e41e159](https://github.com/IBM/kui/commit/e41e159)), closes [#319](https://github.com/IBM/kui/issues/319)
+* **plugin-k8s:** add "k" alias for "kubectl" ([4611ffe](https://github.com/IBM/kui/commit/4611ffe)), closes [#498](https://github.com/IBM/kui/issues/498)
+* **plugin-k8s:** improve k8s in absence of plugin-openwhisk ([30f8a3a](https://github.com/IBM/kui/commit/30f8a3a)), closes [#457](https://github.com/IBM/kui/issues/457) [#458](https://github.com/IBM/kui/issues/458)
+* **plugin-k8s:** k8s status enters infinite loop if resources absent ([e714c3f](https://github.com/IBM/kui/commit/e714c3f)), closes [#393](https://github.com/IBM/kui/issues/393)
+* **plugin-openwhisk:** code highlight race bugs ([717b563](https://github.com/IBM/kui/commit/717b563)), closes [#475](https://github.com/IBM/kui/issues/475)
+* **plugins-editor, plugins-openwhisk-editor-extensions:** fixes for lock/unlock and deploy n editor ([d0801a1](https://github.com/IBM/kui/commit/d0801a1)), closes [#472](https://github.com/IBM/kui/issues/472)
+* **test:** refactor /tests ([98f6096](https://github.com/IBM/kui/commit/98f6096)), closes [#496](https://github.com/IBM/kui/issues/496)
+* **webpack:** fixes for webpack build regressions ([f636fb6](https://github.com/IBM/kui/commit/f636fb6)), closes [#259](https://github.com/IBM/kui/issues/259)
+* **wskflow:** fix for preview [@demos](https://github.com/demos) in webpack mode ([d1b4e75](https://github.com/IBM/kui/commit/d1b4e75)), closes [#329](https://github.com/IBM/kui/issues/329)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+* **webpack:** dockerized webpack build ([bc65dc2](https://github.com/IBM/kui/commit/bc65dc2)), closes [#274](https://github.com/IBM/kui/issues/274)
+
+
+
+
+
 # 2.10.0 (2019-02-21)
 
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/core",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "An Electron-based shell for cloud-native development",
   "homepage": "https://github.com/IBM/kui#readme",
   "license": "Apache-2.0",

--- a/packages/kui-builder/CHANGELOG.md
+++ b/packages/kui-builder/CHANGELOG.md
@@ -3,6 +3,40 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.11.0 (2019-02-22)
+
+
+### Bug Fixes
+
+* **apache-composer:** compose yoyo -t @demos/if.js broken in webpack mode ([14ac816](https://github.com/IBM/kui/commit/14ac816)), closes [#332](https://github.com/IBM/kui/issues/332)
+* **core:** more gracefully handle dom and errors in plugin compiler ([34e6f48](https://github.com/IBM/kui/commit/34e6f48)), closes [#306](https://github.com/IBM/kui/issues/306)
+* **kui-builder:** improve webpack building process for external clients ([14763ca](https://github.com/IBM/kui/commit/14763ca)), closes [#433](https://github.com/IBM/kui/issues/433)
+* **kui-builder:** more fixes for CD pipeline ([59bb0b7](https://github.com/IBM/kui/commit/59bb0b7)), closes [#482](https://github.com/IBM/kui/issues/482)
+* **kui-builder:** more fixes for CD pipeline ([184b45e](https://github.com/IBM/kui/commit/184b45e)), closes [#482](https://github.com/IBM/kui/issues/482)
+* **kui-builder:** more fixes for headless build ([3ae143c](https://github.com/IBM/kui/commit/3ae143c)), closes [#478](https://github.com/IBM/kui/issues/478)
+* **kui-builder:** update CD publisher to reflect new clients/default/dist structure ([efe753d](https://github.com/IBM/kui/commit/efe753d)), closes [#482](https://github.com/IBM/kui/issues/482)
+* **kui-builder:** update kui-watch to support external clients ([cfef146](https://github.com/IBM/kui/commit/cfef146)), closes [#448](https://github.com/IBM/kui/issues/448)
+* **packages/tests:** remove bin/corral from test runner ([1f7c263](https://github.com/IBM/kui/commit/1f7c263)), closes [#510](https://github.com/IBM/kui/issues/510) [#425](https://github.com/IBM/kui/issues/425)
+* fixes for auth in browser+proxy mode ([a441c33](https://github.com/IBM/kui/commit/a441c33)), closes [#287](https://github.com/IBM/kui/issues/287) [#286](https://github.com/IBM/kui/issues/286) [#289](https://github.com/IBM/kui/issues/289)
+* local dev-mode ./bin/kui is missing theme ([e41e159](https://github.com/IBM/kui/commit/e41e159)), closes [#319](https://github.com/IBM/kui/issues/319)
+* **plugin-k8s:** improve k8s in absence of plugin-openwhisk ([30f8a3a](https://github.com/IBM/kui/commit/30f8a3a)), closes [#457](https://github.com/IBM/kui/issues/457) [#458](https://github.com/IBM/kui/issues/458)
+* **proxy:** improve support for building proxy server from an external custom client ([177fac8](https://github.com/IBM/kui/commit/177fac8)), closes [#438](https://github.com/IBM/kui/issues/438)
+* **test:** refactor /tests ([98f6096](https://github.com/IBM/kui/commit/98f6096)), closes [#496](https://github.com/IBM/kui/issues/496)
+* **webpack:** fixes for webpack build regressions ([f636fb6](https://github.com/IBM/kui/commit/f636fb6)), closes [#259](https://github.com/IBM/kui/issues/259)
+* **webpack:** improve theme override support ([e8b943a](https://github.com/IBM/kui/commit/e8b943a)), closes [#298](https://github.com/IBM/kui/issues/298)
+* **webpack:** restore webpack publisher functionality ([2b4feeb](https://github.com/IBM/kui/commit/2b4feeb)), closes [#271](https://github.com/IBM/kui/issues/271)
+* **wskflow:** fix for preview [@demos](https://github.com/demos) in webpack mode ([d1b4e75](https://github.com/IBM/kui/commit/d1b4e75)), closes [#329](https://github.com/IBM/kui/issues/329)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+* **webpack:** dockerized webpack build ([bc65dc2](https://github.com/IBM/kui/commit/bc65dc2)), closes [#274](https://github.com/IBM/kui/issues/274)
+
+
+
+
+
 # 0.10.0 (2019-02-21)
 
 

--- a/packages/kui-builder/package.json
+++ b/packages/kui-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/builder",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Kui plugin development helpers",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/packages/proxy/CHANGELOG.md
+++ b/packages/proxy/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.11.0 (2019-02-22)
+
+
+### Bug Fixes
+
+* fixes for auth in browser+proxy mode ([a441c33](https://github.com/IBM/kui/commit/a441c33)), closes [#287](https://github.com/IBM/kui/issues/287) [#286](https://github.com/IBM/kui/issues/286) [#289](https://github.com/IBM/kui/issues/289)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+* **kui-builder:** improve webpack building process for external clients ([14763ca](https://github.com/IBM/kui/commit/14763ca)), closes [#433](https://github.com/IBM/kui/issues/433)
+* **proxy:** improve support for building proxy server from an external custom client ([177fac8](https://github.com/IBM/kui/commit/177fac8)), closes [#438](https://github.com/IBM/kui/issues/438)
+* **proxy:** we weren't handling execOptions undefined ([5a31f8d](https://github.com/IBM/kui/commit/5a31f8d)), closes [#291](https://github.com/IBM/kui/issues/291)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+* **webpack:** dockerized webpack build ([bc65dc2](https://github.com/IBM/kui/commit/bc65dc2)), closes [#274](https://github.com/IBM/kui/issues/274)
+
+
+
+
+
 # 0.10.0 (2019-02-21)
 
 

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/proxy",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Kui package that offers a proxy server",
   "author": "Nick Mitchell",
   "license": "Apache-2.0",

--- a/packages/tests/CHANGELOG.md
+++ b/packages/tests/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.7 (2019-02-22)
+
+
+### Bug Fixes
+
+* **packages/tests:** remove bin/corral from test runner ([1f7c263](https://github.com/starpit/kui/commit/1f7c263)), closes [#510](https://github.com/starpit/kui/issues/510) [#425](https://github.com/starpit/kui/issues/425)
+* **test:** refactor /tests ([98f6096](https://github.com/starpit/kui/commit/98f6096)), closes [#496](https://github.com/starpit/kui/issues/496)
+
+
+
+
+
 ## 0.0.6 (2019-02-21)
 
 

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/test",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-apache-composer/CHANGELOG.md
+++ b/plugins/plugin-apache-composer/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.16.0 (2019-02-22)
+
+
+### Bug Fixes
+
+* **apache-composer:** app create -r waits for all actions being successfully deployed ([49e1e2f](https://github.com/IBM/kui/commit/49e1e2f)), closes [#269](https://github.com/IBM/kui/issues/269)
+* **apache-composer:** compose yoyo -t @demos/if.js broken in webpack mode ([14ac816](https://github.com/IBM/kui/commit/14ac816)), closes [#332](https://github.com/IBM/kui/issues/332)
+* **apache-composer:** help editor find openwhisk-composer module by moving appModulePath to apache-composer preload ([871c2b8](https://github.com/IBM/kui/commit/871c2b8)), closes [#317](https://github.com/IBM/kui/issues/317)
+* **apache-composer:** parse error handler of compose will check error casue to avoid decorating error not ENOPARSE ([d9e5598](https://github.com/IBM/kui/commit/d9e5598)), closes [#324](https://github.com/IBM/kui/issues/324)
+* fixes for auth in browser+proxy mode ([a441c33](https://github.com/IBM/kui/commit/a441c33)), closes [#287](https://github.com/IBM/kui/issues/287) [#286](https://github.com/IBM/kui/issues/286) [#289](https://github.com/IBM/kui/issues/289)
+* **apache-composer:** remove app create -r ([af0a428](https://github.com/IBM/kui/commit/af0a428)), closes [#316](https://github.com/IBM/kui/issues/316) [#318](https://github.com/IBM/kui/issues/318)
+* **packages/tests:** remove bin/corral from test runner ([1f7c263](https://github.com/IBM/kui/commit/1f7c263)), closes [#510](https://github.com/IBM/kui/issues/510) [#425](https://github.com/IBM/kui/issues/425)
+* **plugin-apache-composer:** update to latest apache-composer API ([b4a1b8e](https://github.com/IBM/kui/commit/b4a1b8e)), closes [#435](https://github.com/IBM/kui/issues/435)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+* **plugin-apache-composer:** update to latest openwhisk-composer ([02a1a56](https://github.com/IBM/kui/commit/02a1a56)), closes [#392](https://github.com/IBM/kui/issues/392)
+* **plugin-openwhisk:** separate out the editor parts from plugin-openwhisk ([8195220](https://github.com/IBM/kui/commit/8195220)), closes [#437](https://github.com/IBM/kui/issues/437) [#441](https://github.com/IBM/kui/issues/441)
+* **plugin-wskflow:** add preview notice to sidecar header ([a65cae5](https://github.com/IBM/kui/commit/a65cae5)), closes [#455](https://github.com/IBM/kui/issues/455) [#386](https://github.com/IBM/kui/issues/386)
+* **wskflow:** fix for preview [@demos](https://github.com/demos) in webpack mode ([adc685f](https://github.com/IBM/kui/commit/adc685f)), closes [#329](https://github.com/IBM/kui/issues/329)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+
+
+
+
+
 # 0.15.0 (2019-02-21)
 
 

--- a/plugins/plugin-apache-composer/package.json
+++ b/plugins/plugin-apache-composer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-apache-composer",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Kui plugin for the Apache OpenWhisk Composer",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-bash-like/CHANGELOG.md
+++ b/plugins/plugin-bash-like/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.18 (2019-02-22)
+
+
+### Bug Fixes
+
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+* **packages/tests:** remove bin/corral from test runner ([1f7c263](https://github.com/IBM/kui/commit/1f7c263)), closes [#510](https://github.com/IBM/kui/issues/510) [#425](https://github.com/IBM/kui/issues/425)
+* **plugin-bash-like:** when cd fails, throw stderr ([85cb737](https://github.com/IBM/kui/commit/85cb737)), closes [#415](https://github.com/IBM/kui/issues/415)
+* **test:** refactor /tests ([98f6096](https://github.com/IBM/kui/commit/98f6096)), closes [#496](https://github.com/IBM/kui/issues/496)
+
+
+
+
+
 ## 0.0.17 (2019-02-21)
 
 

--- a/plugins/plugin-bash-like/package.json
+++ b/plugins/plugin-bash-like/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-bash-like",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Kui plugin that offers local bash-like shell integrations",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-core-support/CHANGELOG.md
+++ b/plugins/plugin-core-support/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.11.0 (2019-02-22)
+
+
+### Bug Fixes
+
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+* **packages/tests:** remove bin/corral from test runner ([1f7c263](https://github.com/IBM/kui/commit/1f7c263)), closes [#510](https://github.com/IBM/kui/issues/510) [#425](https://github.com/IBM/kui/issues/425)
+* **test:** refactor /tests ([98f6096](https://github.com/IBM/kui/commit/98f6096)), closes [#496](https://github.com/IBM/kui/issues/496)
+* **wskflow:** fix for preview [@demos](https://github.com/demos) in webpack mode ([d1b4e75](https://github.com/IBM/kui/commit/d1b4e75)), closes [#329](https://github.com/IBM/kui/issues/329)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+
+
+
+
+
 # 0.10.0 (2019-02-21)
 
 

--- a/plugins/plugin-core-support/package.json
+++ b/plugins/plugin-core-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-core-support",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Kui plugin offering core extensions such as help and screenshot commands",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-editor/CHANGELOG.md
+++ b/plugins/plugin-editor/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.18 (2019-02-22)
+
+
+### Bug Fixes
+
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+* **packages/tests:** remove bin/corral from test runner ([1f7c263](https://github.com/IBM/kui/commit/1f7c263)), closes [#510](https://github.com/IBM/kui/issues/510) [#425](https://github.com/IBM/kui/issues/425)
+* **plugin-openwhisk:** separate out the editor parts from plugin-openwhisk ([8195220](https://github.com/IBM/kui/commit/8195220)), closes [#437](https://github.com/IBM/kui/issues/437) [#441](https://github.com/IBM/kui/issues/441)
+* **plugins-editor, plugins-openwhisk-editor-extensions:** fixes for lock/unlock and deploy n editor ([d0801a1](https://github.com/IBM/kui/commit/d0801a1)), closes [#472](https://github.com/IBM/kui/issues/472)
+
+
+
+
+
 ## 0.0.17 (2019-02-21)
 
 

--- a/plugins/plugin-editor/package.json
+++ b/plugins/plugin-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-editor",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Kui plugin that integrates the monaco-editor component",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-grid/CHANGELOG.md
+++ b/plugins/plugin-grid/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.17 (2019-02-22)
+
+
+### Bug Fixes
+
+* **apache-composer:** compose yoyo -t @demos/if.js broken in webpack mode ([14ac816](https://github.com/IBM/kui/commit/14ac816)), closes [#332](https://github.com/IBM/kui/issues/332)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+
+
+
 ## 0.0.16 (2019-02-21)
 
 

--- a/plugins/plugin-grid/package.json
+++ b/plugins/plugin-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-grid",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Kui plugin that offers a grid visualization of OpenWhisk function invocations",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-k8s/CHANGELOG.md
+++ b/plugins/plugin-k8s/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.11.0 (2019-02-22)
+
+
+### Bug Fixes
+
+* **k8s:** fix for kubectl status in headless mode ([072626f](https://github.com/IBM/kui/commit/072626f)), closes [#327](https://github.com/IBM/kui/issues/327)
+* **packages/tests:** remove bin/corral from test runner ([1f7c263](https://github.com/IBM/kui/commit/1f7c263)), closes [#510](https://github.com/IBM/kui/issues/510) [#425](https://github.com/IBM/kui/issues/425)
+* **plugin-k8s:** add "k" alias for "kubectl" ([4611ffe](https://github.com/IBM/kui/commit/4611ffe)), closes [#498](https://github.com/IBM/kui/issues/498)
+* **plugin-k8s:** add /usr/local/bin to PATH ([a3c2f9d](https://github.com/IBM/kui/commit/a3c2f9d)), closes [#460](https://github.com/IBM/kui/issues/460)
+* **plugin-k8s:** attempt to find KUBECONFIG for double-clicked macOS electron apps ([51f8332](https://github.com/IBM/kui/commit/51f8332)), closes [#462](https://github.com/IBM/kui/issues/462)
+* **plugin-k8s:** fix for racy headless-create-pod tests ([d07792d](https://github.com/IBM/kui/commit/d07792d)), closes [#501](https://github.com/IBM/kui/issues/501)
+* **plugin-k8s:** fix helm delete (--wait not a supported option) ([7533f4e](https://github.com/IBM/kui/commit/7533f4e)), closes [#412](https://github.com/IBM/kui/issues/412)
+* **plugin-k8s:** improve k8s in absence of plugin-openwhisk ([30f8a3a](https://github.com/IBM/kui/commit/30f8a3a)), closes [#457](https://github.com/IBM/kui/issues/457) [#458](https://github.com/IBM/kui/issues/458)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+* **plugin-k8s:** improved fix for finding KUBECONFIG for double-clicked apps ([fd3f40b](https://github.com/IBM/kui/commit/fd3f40b)), closes [#487](https://github.com/IBM/kui/issues/487)
+* **plugin-k8s:** in contexts table, make context name clickable ([2c4339c](https://github.com/IBM/kui/commit/2c4339c)), closes [#494](https://github.com/IBM/kui/issues/494)
+* **plugin-k8s:** k8s status enters infinite loop if resources absent ([e714c3f](https://github.com/IBM/kui/commit/e714c3f)), closes [#393](https://github.com/IBM/kui/issues/393)
+* **plugin-k8s:** show VirtualService kind as Online ([667a0b1](https://github.com/IBM/kui/commit/667a0b1)), closes [#387](https://github.com/IBM/kui/issues/387)
+* **webpack:** fixes for webpack build regressions ([f636fb6](https://github.com/IBM/kui/commit/f636fb6)), closes [#259](https://github.com/IBM/kui/issues/259)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+
+
+
+
+
 # 0.10.0 (2019-02-21)
 
 

--- a/plugins/plugin-k8s/package.json
+++ b/plugins/plugin-k8s/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-k8s",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Kui plugin for kubernetes",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-manager/CHANGELOG.md
+++ b/plugins/plugin-manager/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.17 (2019-02-22)
+
+
+### Bug Fixes
+
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+
+
+
 ## 0.0.16 (2019-02-21)
 
 

--- a/plugins/plugin-manager/package.json
+++ b/plugins/plugin-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-manager",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Support for field installation of plugins",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-openwhisk-debug/CHANGELOG.md
+++ b/plugins/plugin-openwhisk-debug/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.17 (2019-02-22)
+
+
+### Bug Fixes
+
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+
+
+
 ## 0.0.16 (2019-02-21)
 
 

--- a/plugins/plugin-openwhisk-debug/package.json
+++ b/plugins/plugin-openwhisk-debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-openwhisk-debug",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Kui plugin that lets users run and debug actions locally in a docker container",
   "license": "Apache-2.0",
   "author": "Kerry Chang",

--- a/plugins/plugin-openwhisk-editor-extensions/CHANGELOG.md
+++ b/plugins/plugin-openwhisk-editor-extensions/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.10 (2019-02-22)
+
+
+### Bug Fixes
+
+* **plugin-openwhisk:** openwhisk action invoke not always blocking ([865cb4e](https://github.com/IBM/kui/commit/865cb4e)), closes [#419](https://github.com/IBM/kui/issues/419)
+* **plugin-openwhisk:** separate out the editor parts from plugin-openwhisk ([8195220](https://github.com/IBM/kui/commit/8195220)), closes [#437](https://github.com/IBM/kui/issues/437) [#441](https://github.com/IBM/kui/issues/441)
+* **plugins-editor, plugins-openwhisk-editor-extensions:** fixes for lock/unlock and deploy n editor ([d0801a1](https://github.com/IBM/kui/commit/d0801a1)), closes [#472](https://github.com/IBM/kui/issues/472)
+
+
+
+
+
 ## 0.0.9 (2019-02-21)
 
 

--- a/plugins/plugin-openwhisk-editor-extensions/package.json
+++ b/plugins/plugin-openwhisk-editor-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-openwhisk-editor-extensions",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Kui plugin for OpenWhisk that extends plugin-editor",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-openwhisk/CHANGELOG.md
+++ b/plugins/plugin-openwhisk/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.11.0 (2019-02-22)
+
+
+### Bug Fixes
+
+* **apache-composer:** compose yoyo -t @demos/if.js broken in webpack mode ([14ac816](https://github.com/IBM/kui/commit/14ac816)), closes [#332](https://github.com/IBM/kui/issues/332)
+* **openwhisk:** add expandHomeDir when reading process.env.WSK_CONFIG_FILE ([c441c1c](https://github.com/IBM/kui/commit/c441c1c)), closes [#253](https://github.com/IBM/kui/issues/253)
+* **openwhisk:** fix for misplaced test file ([5d3286f](https://github.com/IBM/kui/commit/5d3286f)), closes [#263](https://github.com/IBM/kui/issues/263)
+* **packages/tests:** remove bin/corral from test runner ([1f7c263](https://github.com/IBM/kui/commit/1f7c263)), closes [#510](https://github.com/IBM/kui/issues/510) [#425](https://github.com/IBM/kui/issues/425)
+* fixes for auth in browser+proxy mode ([a441c33](https://github.com/IBM/kui/commit/a441c33)), closes [#287](https://github.com/IBM/kui/issues/287) [#286](https://github.com/IBM/kui/issues/286) [#289](https://github.com/IBM/kui/issues/289)
+* **plugin-openwhisk:** code highlight race bugs ([717b563](https://github.com/IBM/kui/commit/717b563)), closes [#475](https://github.com/IBM/kui/issues/475)
+* **plugin-openwhisk:** fix for activation pagination in webpack ([379fb0e](https://github.com/IBM/kui/commit/379fb0e)), closes [#474](https://github.com/IBM/kui/issues/474)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+* **plugin-openwhisk:** openwhisk action invoke not always blocking ([865cb4e](https://github.com/IBM/kui/commit/865cb4e)), closes [#419](https://github.com/IBM/kui/issues/419)
+* **plugin-openwhisk:** openwhisk cost calculator should use duration field in activations ([e6d084e](https://github.com/IBM/kui/commit/e6d084e)), closes [#420](https://github.com/IBM/kui/issues/420)
+* **plugin-openwhisk:** remove debugging output from openwhisk-core ([eac7a13](https://github.com/IBM/kui/commit/eac7a13)), closes [#470](https://github.com/IBM/kui/issues/470)
+* **plugin-openwhisk:** separate out the editor parts from plugin-openwhisk ([8195220](https://github.com/IBM/kui/commit/8195220)), closes [#437](https://github.com/IBM/kui/issues/437) [#441](https://github.com/IBM/kui/issues/441)
+* **proxy:** improve support for building proxy server from an external custom client ([177fac8](https://github.com/IBM/kui/commit/177fac8)), closes [#438](https://github.com/IBM/kui/issues/438)
+* **test:** refactor /tests ([98f6096](https://github.com/IBM/kui/commit/98f6096)), closes [#496](https://github.com/IBM/kui/issues/496)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+* **webpack:** dockerized webpack build ([bc65dc2](https://github.com/IBM/kui/commit/bc65dc2)), closes [#274](https://github.com/IBM/kui/issues/274)
+
+
+
+
+
 # 0.10.0 (2019-02-21)
 
 

--- a/plugins/plugin-openwhisk/package.json
+++ b/plugins/plugin-openwhisk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-openwhisk",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Kui plugin for OpenWhisk",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-proxy-support/CHANGELOG.md
+++ b/plugins/plugin-proxy-support/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.11.0 (2019-02-22)
+
+
+### Bug Fixes
+
+* fixes for auth in browser+proxy mode ([a441c33](https://github.com/IBM/kui/commit/a441c33)), closes [#287](https://github.com/IBM/kui/issues/287) [#286](https://github.com/IBM/kui/issues/286) [#289](https://github.com/IBM/kui/issues/289)
+* **plugin-proxy-support:** needle url issue ([d17856f](https://github.com/IBM/kui/commit/d17856f)), closes [#310](https://github.com/IBM/kui/issues/310)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+
+
+
+
+
 # 0.10.0 (2019-02-21)
 
 

--- a/plugins/plugin-proxy-support/package.json
+++ b/plugins/plugin-proxy-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-proxy-support",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Kui plugin that adds runtime support for proxied communication",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-tutorials/CHANGELOG.md
+++ b/plugins/plugin-tutorials/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.11.0 (2019-02-22)
+
+
+### Bug Fixes
+
+* **apache-composer:** remove app create -r ([af0a428](https://github.com/IBM/kui/commit/af0a428)), closes [#316](https://github.com/IBM/kui/issues/316) [#318](https://github.com/IBM/kui/issues/318)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+
+
+### Features
+
+* kuiproxy ([530c278](https://github.com/IBM/kui/commit/530c278)), closes [#266](https://github.com/IBM/kui/issues/266) [#278](https://github.com/IBM/kui/issues/278) [#279](https://github.com/IBM/kui/issues/279)
+
+
+
+
+
 # 0.10.0 (2019-02-21)
 
 

--- a/plugins/plugin-tutorials/package.json
+++ b/plugins/plugin-tutorials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-tutorials",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "IBM Cloud shell plugin for tutorials",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-wskflow/CHANGELOG.md
+++ b/plugins/plugin-wskflow/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.17 (2019-02-22)
+
+
+### Bug Fixes
+
+* **apache-composer:** compose yoyo -t @demos/if.js broken in webpack mode ([14ac816](https://github.com/IBM/kui/commit/14ac816)), closes [#332](https://github.com/IBM/kui/issues/332)
+* proxy package and plugin have improper package.json ([d6f474d](https://github.com/IBM/kui/commit/d6f474d)), closes [#355](https://github.com/IBM/kui/issues/355)
+* **plugin-wskflow:** add preview notice to sidecar header ([a65cae5](https://github.com/IBM/kui/commit/a65cae5)), closes [#455](https://github.com/IBM/kui/issues/455) [#386](https://github.com/IBM/kui/issues/386)
+* **wskflow:** fix for preview [@demos](https://github.com/demos) in webpack mode ([adc685f](https://github.com/IBM/kui/commit/adc685f)), closes [#329](https://github.com/IBM/kui/issues/329)
+
+
+
+
+
 ## 0.0.16 (2019-02-21)
 
 

--- a/plugins/plugin-wskflow/package.json
+++ b/plugins/plugin-wskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-wskflow",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Visualizations for Composer apps",
   "license": "Apache-2.0",
   "author": "Kerry Chang",


### PR DESCRIPTION
 - @kui-shell/core@2.11.0
 - @kui-shell/builder@0.11.0
 - @kui-shell/proxy@0.11.0
 - @kui-shell/test@0.0.7
 - @kui-shell/plugin-apache-composer@0.16.0
 - @kui-shell/plugin-bash-like@0.0.18
 - @kui-shell/plugin-core-support@0.11.0
 - @kui-shell/plugin-editor@0.0.18
 - @kui-shell/plugin-grid@0.0.17
 - @kui-shell/plugin-k8s@0.11.0
 - @kui-shell/plugin-manager@0.0.17
 - @kui-shell/plugin-openwhisk-debug@0.0.17
 - @kui-shell/plugin-openwhisk-editor-extensions@0.0.10
 - @kui-shell/plugin-openwhisk@0.11.0
 - @kui-shell/plugin-proxy-support@0.11.0
 - @kui-shell/plugin-tutorials@0.11.0
 - @kui-shell/plugin-wskflow@0.0.17