### PR TITLE
fix(packages/kui-builder): nord theme's cyan color isn't right

### DIFF
--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/nord.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/nord.css
@@ -20,6 +20,7 @@ body[kui-theme="Nord"] {
     --color-base0E: #A3BE8C;
     --color-base0F: #B48EAD;
 
+    --color-cyan: var(--color-base08);
     --color-red: var(--color-base0B);
     --color-green: var(--color-base0E);
     --color-yellow: var(--color-base0D);


### PR DESCRIPTION
Fixes #628
