### PR TITLE
fix(plugins/plugin-bash-like): avoid use of bold fonts in git diff

### DIFF
--- a/plugins/plugin-bash-like/web/css/my-diff2html.css
+++ b/plugins/plugin-bash-like/web/css/my-diff2html.css
@@ -72,7 +72,7 @@ td > .d2h-code-side-linenumber {
 
 .d2h-ins, .d2h-del {
     /* inserts and deletes */
-    font-weight: bold;
+    font-weight: 500;
     border: none;
     background-color: transparent;
 }


### PR DESCRIPTION
Fixes #636