### PR TITLE
fix(packages/kui-builder): increase contrast for key-value yaml

### DIFF
--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/atelier-seaside.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/atelier-seaside.css
@@ -13,7 +13,7 @@ body[kui-theme="Atelier"] {
     --color-base07: #f4fbf4;
     --color-base08: #e6193c;
     --color-base09: #87711d;
-    --color-base0A: #98981b;
+    --color-base0A: hsl(60, 70%, 41%); /* dialed L from 35% #98981b */
     --color-base0B: #29a329;
     --color-base0C: #1999b3;
     --color-base0D: hsl(228, 90%, 68%); /* dialed L from 60% #3d62f5 */

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/solarized-dark.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/solarized-dark.css
@@ -14,9 +14,9 @@ body[kui-theme="Solarized"] {
     --color-base07: #fdf6e3;
     --color-base08: #dc322f;
     --color-base09: #cb4b16;
-    --color-base0A: #b58900;
+    --color-base0A: hsl(45, 100%, 38%); /* dialed L from 35% #b58900 */
     --color-base0B: #859900;
-    --color-base0C: #2aa198;
+    --color-base0C: hsl(175, 59%, 42%); /* dialed L from 35% #2aa198 */
     --color-base0D: hsl(205, 69%, 58%); /* dialed up to L=58% from 49% versus: #268bd2 */
     --color-base0E: #6c71c4;
     --color-base0F: #d33682;


### PR DESCRIPTION
for atelier and solarized

Fixes #776