### PR TITLE
chore(packages/proxy): build proxy in the default client of monorepo

### DIFF
--- a/clients/default/package.json
+++ b/clients/default/package.json
@@ -7,6 +7,7 @@
     "link:done": "mv bak.json package.json; rm -f tests",
     "build:headless": "npm run link:init -- headless && npx --no-install kui-build-headless /tmp ../../node_modules/@kui-shell/prescan.json; npm run link:done",
     "build:electron": "build() { npm run link:init -- electron && npx --no-install kui-build-electron /tmp $1; npm run link:done; }; build",
+    "build:proxy": "npm run link:init -- webpack && npx --no-install kui-build-proxy /tmp; npm run link:done",
     "build:webpack": "npm run link:init -- webpack && npx --no-install kui-build-webpack /tmp; npm run link:done"
   },
   "author": "Nick Mitchell",


### PR DESCRIPTION
Fixes #836 