### PR TITLE
fix(packages/kui-builder): use webpack ignore-loader for proxy-agent

### DIFF
--- a/packages/kui-builder/dist/webpack/webpack.config.js
+++ b/packages/kui-builder/dist/webpack/webpack.config.js
@@ -164,6 +164,7 @@ module.exports = {
       { test: /jquery\.map/, use: 'ignore-loader' },
       { test: /sizzle\.min\.map/, use: 'ignore-loader' },
       { test: /\/modules\/queue-view\//, use: 'ignore-loader' },
+      { test: /\/node_modules\/proxy-agent\//, use: 'ignore-loader' },
       { test: /\/node_modules\/fsevents\//, use: 'ignore-loader' },
       { test: /\/node_modules\/nan\//, use: 'ignore-loader' },
       { test: /translation-demo\/composition.js$/, use: 'ignore-loader' },


### PR DESCRIPTION
Fixes #1061 