### PR TITLE
fix(packages/app): /sidecar/maximize event comes too early

### DIFF
--- a/packages/app/src/webapp/views/sidecar.ts
+++ b/packages/app/src/webapp/views/sidecar.ts
@@ -774,7 +774,7 @@ export const setMaximization = (op = 'add') => {
   }
 
   element('tab.visible').classList[op]('sidecar-full-screen')
-  eventBus.emit('/sidecar/maximize')
+  setTimeout(() => eventBus.emit('/sidecar/maximize'), 600)
 }
 
 /**


### PR DESCRIPTION
Fixe #1136