### PR TITLE
chore: remove leftover top-level npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-runtime=electron
-target=4.0.4
-build_from_source=true
-disturl=https://atom.io/download/electron


### PR DESCRIPTION
Fixes #1231