### PR TITLE
feat(plugin-core-support): Version gets build info

### DIFF
--- a/plugins/plugin-core-support/src/lib/cmds/about/about.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/about/about.ts
@@ -27,7 +27,7 @@ import { isHeadless, inElectron } from '@kui-shell/core/core/capabilities'
 
 import usage from './usage'
 import { bugs, description, homepage, license, version } from '@kui-shell/settings/package.json'
-import { theme as settings } from '@kui-shell/core/core/settings'
+import { theme as settings, config as extras } from '@kui-shell/core/core/settings'
 
 /** should we show low-level version info, e.g. electron version etc.? */
 const showVersionInfo = true
@@ -171,6 +171,7 @@ const aboutWindow = async () => { /* bringYourOwnWindow impl */
 
     const versionModel = process.versions
     versionModel[name] = version
+    versionModel['build'] = extras['build-info']
 
     const headerRow = table.insertRow(-1)
     headerRow.className = 'log-line header-row'
@@ -181,7 +182,7 @@ const aboutWindow = async () => { /* bringYourOwnWindow impl */
     column2.innerText = 'VERSION'
     column2.className = 'header-cell log-field'
 
-    for (const component of [name, 'electron', 'chrome', 'node', 'v8']) {
+    for (const component of [name, 'build', 'electron', 'chrome', 'node', 'v8']) {
       const version = versionModel[component]
 
       if (version !== undefined) {
@@ -244,6 +245,9 @@ const reportVersion = ({ argv }) => {
 
   if (!checkForUpdates) {
     // we were asked only to report the installed version
+    if (extras['build-info']) {
+      return `${version} (build ${extras['build-info']})`
+    }
     return version
   }
 


### PR DESCRIPTION
Satisfies issue #1003

In the version command, optional build information is displayed in parentheses.  In the 'about' display it occupies a line below the main version.  If there is no build information supplied, the appearance is as before.

The optional build information is supplied as member `build-info` of `theme/config.json`.  Thus, it applies to external clients but also works in the default client, if that is desired.   I believe it should be up to the client to decide what build info consists of.  We use (roughly)
```
HASH=$(git rev-parse HEAD)
DIRTY=$(git status --porcelain)
if [ -n "$DIRTY" ]; then
    DIRTY="++"
fi
BUILDINFO=${HASH:0:8}${DIRTY}
```
This takes the process completely out of manual control (a good thing IMO) but requires that the `config.json` file be git-ignored so that it doesn't affect the HASH and create a circularity.

Signed-off-by: Joshua Auerbach <josh@nimbella.com>