### PR TITLE
Feat(kui-builder): Flexible compression in webpack

### DIFF
--- a/packages/kui-builder/dist/webpack/package.json
+++ b/packages/kui-builder/dist/webpack/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
+    "compression-webpack-plugin": "2.0.0",
     "brotli-webpack-plugin": "1.1.0",
     "css-loader": "2.1.1",
     "file-loader": "3.0.1",

--- a/packages/kui-builder/dist/webpack/webpack.config.js
+++ b/packages/kui-builder/dist/webpack/webpack.config.js
@@ -16,7 +16,12 @@
 
 const path = require('path')
 const TerserPlugin = require('terser-webpack-plugin')
-const CompressionPlugin = require('brotli-webpack-plugin')
+const webCompress = process.env.WEB_COMPRESS
+console.log("compression", webCompress)
+const useGzip = webCompress === "gzip"
+console.log("useGzip", useGzip)
+const CompressionPlugin = require(useGzip? 'compression-webpack-plugin' : 'brotli-webpack-plugin')
+
 // const Visualizer = require('webpack-visualizer-plugin')
 
 /** point webpack to the root directory */


### PR DESCRIPTION
Satisfies issue #1249

In the issue I said we needed to add support for "at least gzip".   In fact, this change, which we've been using in our fork for a while, supports "at most gzip" (plus the original brotli, still the default).

To select gzip compression, specify `WEB_COMPRESS=gzip` in the environment of the webpack build.

The compression plugin actually supports an `algorithm` option, which, if specified as a string, will support any compression supported (by name) in `zlib`.   We have experimented with a small variation on this change, in which the algorithm specified in the environment is passed to the plugin.  However, as shipped with node, `zlib` supports (by name) only `gzip` (it's default) and `deflate`.   To support others (e.g. `zopfli`) you have to make a more intrusive (and non-general) change to the webpack config.   So, we have stuck with the simpler version, which is sufficient unto the day and has supported our needs.

Signed-off-by: Joshua Auerbach <josh@nimbella.com>