### PR TITLE
fix(plugins/plugin-k8s): fixed the issue that empty helm list returns {} as output and added tests for empty helm list

### DIFF
--- a/plugins/plugin-k8s/src/test/k8s/helm.ts
+++ b/plugins/plugin-k8s/src/test/k8s/helm.ts
@@ -14,6 +14,19 @@
  * limitations under the License.
  */
 
-export function isHTML (message: any): message is HTMLElement {
-  return (message as HTMLElement).nodeName ? true : false
-}
+import * as common from '@kui-shell/core/tests/lib/common'
+import { cli } from '@kui-shell/core/tests/lib/ui'
+import * as assert from 'assert'
+
+describe('helm commands', function (this: common.ISuite) {
+  before(common.before(this))
+  after(common.after(this))
+
+  const lists = ['list', 'ls']
+
+  lists.forEach(list => {
+    it(`should list empty releases via helm ${list}`, () => cli.do(`helm ${list}`, this.app)
+      .then(cli.expectBlank)
+      .catch(common.oops(this)))
+  })
+})


### PR DESCRIPTION
Fixes #1246