### PR TITLE
fix(packages/app): REPL block index management versus clear command

### DIFF
--- a/packages/app/src/webapp/cli.ts
+++ b/packages/app/src/webapp/cli.ts
@@ -871,7 +871,10 @@ export const installBlock = (parentNode: Node, currentBlock: HTMLElement, nextBl
   parentNode.appendChild(nextBlock)
   listen(getPrompt(nextBlock))
   nextBlock.querySelector('input').focus()
-  nextBlock.setAttribute('data-input-count', (parseInt(currentBlock.getAttribute('data-input-count'), 10) + 1).toString())
+
+  // the currentBlock might've been detached; if so, re-start from 0
+  const currentIndex = currentBlock.parentNode ? parseInt(currentBlock.getAttribute('data-input-count'), 10) : -1
+  nextBlock.setAttribute('data-input-count', (currentIndex + 1).toString())
 
   // if you want to have the current directory displayed with the prompt
   // nextBlock.querySelector('.repl-context').innerText = process.cwd() === process.env.HOME ? '~' : basename(process.cwd());


### PR DESCRIPTION
when clearing the console, block counts do not restart from 0

Fixes #1275