### PR TITLE
style: avoiding npx for devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "preinstall": "cp packages/kui-builder/npmrc .npmrc",
     "build:configure": "CLIENT_HOME=./clients/default node packages/kui-builder/lib/configure.js && CLIENT_HOME=./clients/default ./packages/kui-builder/dist/dev/build.sh && CLIENT_HOME=./clients/default ./packages/kui-builder/bin/seticon.js",
     "build:electron-for-development": "npm run build:configure && npm run compile && for i in plugins/*; do if [ -d $i/node_modules ]; then (cd build/plugins/`basename $i` && rm -rf node_modules && cp -a ../../../$i/node_modules .); fi; done",
-    "build:hoist": "npx lerna bootstrap --ignore-prepublish --hoist",
-    "postinstall": "npm run build:hoist && npm run build:electron-for-development"
+    "build:hoist": "lerna bootstrap --ignore-prepublish --hoist",
+    "postinstall": "npm run build:hoist && npm run build:electron-for-development",
+    "publish": "lerna publish"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
npm adds devDependencies executables to PATH when running scripts. So we don't need to use npx.

Moreover, in this way the devs share the same lerna version. The same thing happens for publishing, it's better to use the same version we're using to develop. So I've also added a new npm task: `publish`.

More info here: https://firstdoit.com/no-need-for-globals-using-npm-dependencies-in-npm-scripts-3dfb478908
