### PR TITLE
fix: ls -l and ls -la do not display properly

### DIFF
--- a/packages/app/src/webapp/models/table.ts
+++ b/packages/app/src/webapp/models/table.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Debug from 'debug'
 
 export class Row {
   attributes?: Cell[]

--- a/packages/app/src/webapp/views/table.ts
+++ b/packages/app/src/webapp/views/table.ts
@@ -22,7 +22,7 @@ import { isPopup, getCurrentPrompt } from '../cli'
 import { pexec, qexec } from '../../core/repl'
 import drilldown from '../picture-in-picture'
 import { getActiveView } from './sidecar'
-import { Table, Row, Cell, Icon } from '../models/table'
+import { Table, Row, Cell, Icon, TableStyle } from '../models/table'
 
 export const formatTable = (table: Table, resultDom: HTMLElement): void => {
   const tableDom = document.createElement('div')
@@ -95,17 +95,22 @@ export const formatTable = (table: Table, resultDom: HTMLElement): void => {
   const rows = formatTableResult(table)
   rows.map(row => tableDom.appendChild(row))
 
+  if (table.style !== undefined) {
+    tableDom.setAttribute('kui-table-style', TableStyle[table.style].toString())
+  }
+
   const rowSelection = tableDom.querySelector('.selected-row')
   if (rowSelection) {
     tableDom.classList.add('has-row-selection')
   }
 }
+
 /**
  * Format one row in the table
  *
  */
 export const formatOneRowResult = (options?) => (entity: Row) => {
-  debug('formatOneRowResult', entity)
+  // debug('formatOneRowResult', entity)
   const dom = document.createElement('div')
   dom.className = `entity ${entity.prettyType || ''} ${entity.type}`
   dom.setAttribute('data-name', entity.name)
@@ -974,6 +979,10 @@ export const formatMultiListResult = async (response, resultDom) => {
       tableOuterWrapper.classList.add('result-table-outer-wrapper')
       if (tables.length > 1) {
         tableOuterWrapper.classList.add('row-selection-context')
+      }
+
+      if (table[0].style !== undefined) {
+        tableOuter.setAttribute('kui-table-style', TableStyle[table[0].style].toString())
       }
 
       tableOuter.appendChild(titleOuter)

--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -2983,34 +2983,35 @@ body {
     }
 }
 
-body[kui-theme-option="minimal"] .result-as-table .result-table {
+.result-as-table .result-table[kui-table-style="Light"] {
     border: none;
+    margin-top: 0.5em;
 }
-body[kui-theme-option="minimal"] .result-as-table .result-table .header-row .header-cell, body[kui-theme-option="minimal"] .result-as-table.result-table .header-row .header-cell {
+.result-as-table .result-table[kui-table-style="Light"] .header-row .header-cell, .result-as-table.result-table[kui-table-style="Light"] .header-row .header-cell {
     background: none;
     border-bottom-color: var(--color-base04);
 }
-body[kui-theme-option="minimal"] .result-as-table .log-lines .log-line .log-line-bar-field, body[kui-theme-option="minimal"] .repl .log-lines .log-line .log-field {
+.result-as-table .log-lines[kui-table-style="Light"] .log-line .log-line-bar-field, .repl .log-lines[kui-table-style="Light"] .log-line .log-field {
     border: none;
 }
-body[kui-theme-option="minimal"] .result-table .entity td {
+.result-table[kui-table-style="Light"] .entity td {
     background: none;
 }
-body[kui-theme-option="minimal"] .log-lines .log-line {
+.log-lines[kui-table-style="Light"] .log-line {
     height: 2em;
 }
-body[kui-theme-option="minimal"] .result-table .entity .entity-attributes {
+.result-table[kui-table-style="Light"] .entity .entity-attributes {
     background: none !important;
     height: 2em;
 }
-body[kui-theme-option="minimal"] .entity-attributes > span {
+[kui-table-style="Light"] .entity-attributes > span {
     border: none;
 }
-body[kui-theme-option="minimal"] badge {
+[kui-table-style="Light"] badge {
     height: 1.75em;
     line-height: 1.75em;
 }
-body[kui-theme-option="minimal"] .result-as-table .result-table-title {
+.result-as-table .result-table-outer[kui-table-style="Light"] .result-table-title {
     padding-left: 0.75em;
 }
 


### PR DESCRIPTION
missing permissions column; also make `ls` use Light tables

Fixes #1296
Fixes #1278