### PR TITLE
fix(packages/tests): regression in LAYER env var

### DIFF
--- a/packages/tests/bin/runMochaLayers.sh
+++ b/packages/tests/bin/runMochaLayers.sh
@@ -37,7 +37,7 @@ if [ -z "$API_HOST" ]; then
     if [ -f ~/.wskprops ]; then
         . ~/.wskprops
         export API_HOST=$APIHOST
-    else
+    elif [ -z "$LAYERS" ]; then
         export LAYERS="core bash-like core-support field-installed-plugins editor k8s"
     fi
 else


### PR DESCRIPTION
To fix a bug I added in my last commit to this file. Now the `LAYER` environment variable works in all cases like before.