### PR TITLE
fix(plugins/plugin-k8s): HorizontalPodAutoscaler status support

### DIFF
--- a/packages/app/tests/lib/common.js
+++ b/packages/app/tests/lib/common.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-18 IBM Corporation
+ * Copyright 2017-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/app/tests/lib/ui.js
+++ b/packages/app/tests/lib/ui.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017-19 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const common = require('./common')
 const assert = require('assert')
 const timeout = process.env.TIMEOUT || 60000

--- a/plugins/plugin-k8s/src/lib/model/states.ts
+++ b/plugins/plugin-k8s/src/lib/model/states.ts
@@ -202,6 +202,7 @@ export const getStatus = async (desiredFinalState: FinalState, apiVersion: strin
         kind === 'Ingress' ||
         kind === 'ConfigMap' ||
         kind === 'CustomResourceDefinition' ||
+        kind === 'HorizontalPodAutoscaler' ||
         kind === 'ClusterRoleBinding' ||
         kind === 'VirtualService' ||
         kind === 'ServiceAccount') {

--- a/plugins/plugin-k8s/src/test/k8s1/hpa.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/hpa.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-19 IBM Corporation
+ * Copyright 2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import { defaultModeForGet, createNS, allocateNS, deleteNS } from '@kui-shell/pl
 import { dirname } from 'path'
 const ROOT = dirname(require.resolve('@kui-shell/plugin-k8s/tests/package.json'))
 
-const synonyms = ['kubectl', 'k']
+const synonyms = ['kubectl']
 
-describe('electron create pod', function (this: common.ISuite) {
+describe('electron create hpa HorizontalPodAutoscaler', function (this: common.ISuite) {
   before(common.before(this))
   after(common.after(this))
 
@@ -35,39 +35,25 @@ describe('electron create pod', function (this: common.ISuite) {
 
     allocateNS(this, ns)
 
-    it(`should create sample pod from URL via ${kubectl}`, async () => {
+    it(`should create a HorizontalPodAutoscaler hpa via ${kubectl}`, async () => {
       try {
-        const selector = await cli.do(`${kubectl} create -f https://raw.githubusercontent.com/kubernetes/examples/master/staging/pod ${inNamespace}`, this.app)
-          .then(cli.expectOKWithCustom({ selector: selectors.BY_NAME('nginx') }))
+        const selector: string = await cli.do(`${kubectl} apply -f "${ROOT}/data/k8s/hpa.yaml" ${inNamespace}`, this.app)
+          .then(cli.expectOKWithCustom({ selector: selectors.BY_NAME('travelapp-hpa') }))
 
         // wait for the badge to become green
         await this.app.client.waitForExist(`${selector} badge.green-background`)
 
         // now click on the table row
         this.app.client.click(`${selector} .clickable`)
-        await sidecar.expectOpen(this.app).then(sidecar.expectMode(defaultModeForGet)).then(sidecar.expectShowing('nginx'))
+        await sidecar.expectOpen(this.app).then(sidecar.expectMode(defaultModeForGet)).then(sidecar.expectShowing('travelapp-hpa'))
       } catch (err) {
         common.oops(this)(err)
       }
     })
 
-    it(`should delete the sample pod from URL via ${kubectl}`, () => {
-      return cli.do(`${kubectl} delete -f https://raw.githubusercontent.com/kubernetes/examples/master/staging/pod ${inNamespace}`, this.app)
-        .then(cli.expectOKWithCustom({ selector: selectors.BY_NAME('nginx') }))
-        .then(selector => this.app.client.waitForExist(`${selector} badge.red-background`))
-        .catch(common.oops(this))
-    })
-
-    it(`should create sample pod from local file via ${kubectl}`, () => {
-      return cli.do(`${kubectl} create -f "${ROOT}/data/k8s/headless/pod.yaml" ${inNamespace}`, this.app)
-        .then(cli.expectOKWithCustom({ selector: selectors.BY_NAME('nginx') }))
-        .then(selector => this.app.client.waitForExist(`${selector} badge.green-background`))
-        .catch(common.oops(this))
-    })
-
-    it(`should delete the sample pod by name via ${kubectl}`, () => {
-      return cli.do(`${kubectl} delete pod nginx ${inNamespace}`, this.app)
-        .then(cli.expectOKWithCustom({ selector: selectors.BY_NAME('nginx') }))
+    it(`should delete the HorizontalPodAutoscaler hpa from URL via ${kubectl}`, () => {
+      return cli.do(`${kubectl} delete -f "${ROOT}/data/k8s/hpa.yaml" ${inNamespace}`, this.app)
+        .then(cli.expectOKWithCustom({ selector: selectors.BY_NAME('travelapp-hpa') }))
         .then(selector => this.app.client.waitForExist(`${selector} badge.red-background`))
         .catch(common.oops(this))
     })

--- a/plugins/plugin-k8s/tests/data/k8s/hpa.yaml
+++ b/plugins/plugin-k8s/tests/data/k8s/hpa.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: travelapp
+  labels:
+    app: travelapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: travelapp
+  template:
+    metadata:
+      labels:
+        app: travelapp
+    spec:
+      containers:
+      - name: travelapp-container
+        image: nginx:latest
+        ports:
+        - containerPort: 3000
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: travelapp-hpa
+  labels:
+    app: travelapp
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
+    kind: Deployment
+    name: travelapp
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 50

--- a/plugins/plugin-k8s/tests/lib/k8s/utils.d.ts
+++ b/plugins/plugin-k8s/tests/lib/k8s/utils.d.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISuite } from '@kui-shell/core/tests/lib/common'
+
+/**
+ * Which sidecar mode should be visible upon loading a kubernetes entity
+ *
+ */
+declare var defaultModeForGet: string
+
+/**
+ * Allocate a new unique namespace name
+ *
+ */
+declare function createNS (): string
+
+/**
+ * Install a mocha test to allocate the given namespace `ns`
+ *
+ */
+declare function allocateNS (ctx: ISuite, ns: string, theCli?: any): string
+
+/**
+ * Install a mocha test to delete the given namespace `ns`
+ *
+ */
+declare function deleteNS (ctx: ISuite, ns: string, theCli?: any): void

--- a/plugins/plugin-k8s/tests/lib/k8s/utils.js
+++ b/plugins/plugin-k8s/tests/lib/k8s/utils.js
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+const uuid = require('uuid/v4')
+
 const common = require('@kui-shell/core/tests/lib/common')
 const ui = require('@kui-shell/core/tests/lib/ui')
 const { cli, selectors } = ui
-const uuid = require('uuid/v4')
 
 // the default tab we expect to see on "get"
 exports.defaultModeForGet = 'summary'


### PR DESCRIPTION
Fixes #1220

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](../CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
