### PR TITLE
feat(plugins/plugin-bash-like): only show OWNER and GROUP for ls -l

### DIFF
--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -2984,7 +2984,6 @@ body {
 }
 .result-as-table .result-table[kui-table-style="Light"] .header-row .header-cell, .result-as-table.result-table[kui-table-style="Light"] .header-row .header-cell {
     background: none;
-    border-bottom-color: var(--color-base04);
 }
 .result-as-table .log-lines[kui-table-style="Light"] .log-line .log-line-bar-field, .repl .log-lines[kui-table-style="Light"] .log-line .log-field {
     border: none;


### PR DESCRIPTION
Fixes #1440

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](../CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
