### PR TITLE
fix: screenshot sidecar versus escape key

### DIFF
--- a/packages/app/src/webapp/cli.ts
+++ b/packages/app/src/webapp/cli.ts
@@ -790,10 +790,10 @@ export const popupListen = (text = getSidecar().querySelector('.sidecar-header-t
   listen(input)
 }
 export const listen = (prompt: HTMLInputElement) => {
-  debug('listen', prompt)
+  debug('listen', prompt, document.activeElement)
   prompt.readOnly = false
 
-  if (!prompt.classList.contains('sidecar-header-input')) {
+  if (!prompt.classList.contains('sidecar-header-input') && !document.activeElement.classList.contains('grab-focus')) {
     prompt.focus()
   }
 
@@ -880,7 +880,10 @@ export const installBlock = (parentNode: Node, currentBlock: HTMLElement, nextBl
 
   parentNode.appendChild(nextBlock)
   listen(getPrompt(nextBlock))
-  nextBlock.querySelector('input').focus()
+
+  if (!document.activeElement.classList.contains('grab-focus')) {
+    nextBlock.querySelector('input').focus()
+  }
 
   // the currentBlock might've been detached; if so, re-start from 0
   const currentIndex = currentBlock.parentNode ? parseInt(currentBlock.getAttribute('data-input-count'), 10) : -1

--- a/plugins/plugin-core-support/src/lib/cmds/screenshot.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/screenshot.ts
@@ -247,9 +247,12 @@ export default async (commandTree: CommandRegistrar) => {
           const finish = () => {
             cleanupMouseEvents()
 
-            cli.getCurrentPrompt().readOnly = false
             snapDom.classList.add('go-away')
-            setTimeout(() => document.body.removeChild(snapDom), 1000) // match go-away-able transition-duration; see ui.css
+            setTimeout(() => {
+              document.body.removeChild(snapDom)
+              cli.getCurrentPrompt().readOnly = false
+              cli.getCurrentPrompt().focus()
+            }, 1000) // match go-away-able transition-duration; see ui.css
           }
 
           // the following bits handle mouse clicks on the underlying
@@ -391,6 +394,7 @@ export default async (commandTree: CommandRegistrar) => {
           // to capture the Escape key event
           const hiddenInput = document.createElement('input')
           hiddenInput.classList.add('hidden')
+          hiddenInput.classList.add('grab-focus') // so that the repl doesn't grab it back on `listen`
           snapDom.appendChild(hiddenInput)
           hiddenInput.focus()
 


### PR DESCRIPTION
Fixes #1445

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](../CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
