### PR TITLE
chore(plugins/plugin-k8s): remove the leftover test-generated namespa…

### DIFF
--- a/plugins/plugin-k8s/src/test/k8s/get-namespaces-with-watch.ts
+++ b/plugins/plugin-k8s/src/test/k8s/get-namespaces-with-watch.ts
@@ -129,10 +129,9 @@ describe('electron watch namespace', function (this: common.ISuite) {
   after(common.after(this))
 
   synonyms.forEach(kubectl => {
-    const createIt = createNS.bind(this, kubectl)
-    const deleteIt = deleteNS.bind(this, kubectl)
-    const watchIt = watchNS.bind(this, kubectl)
-
+    const createIt: () => Promise<void> = createNS.bind(this, kubectl)
+    const deleteIt: ({ noExistOk }?: { noExistOk: boolean }) => void = deleteNS.bind(this, kubectl)
+    const watchIt: () => void = watchNS.bind(this, kubectl)
     //
     // here come the tests
     //
@@ -141,5 +140,6 @@ describe('electron watch namespace', function (this: common.ISuite) {
     createIt()
     deleteIt()
     watchIt()
+    deleteIt()
   })
 })

--- a/plugins/plugin-k8s/src/test/k8s1/edit.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/edit.ts
@@ -94,6 +94,7 @@ describe('electron kubectl edit', function (this: common.ISuite) {
   createIt(nginx)
   editItWithoutSaving(nginx, 3, ':wq!')
   editItWithoutSaving(nginx, 4, ':wq')
+  deleteIt(nginx)
 
   deleteNS(this, ns)
 })


### PR DESCRIPTION
…ce in k8s tests

part of #1451

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](../CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
