### PR TITLE
feat(plugins/plugin-bash-like): support simple bash export command

### DIFF
--- a/packages/app/src/core/repl.ts
+++ b/packages/app/src/core/repl.ts
@@ -39,10 +39,16 @@ import cli = require('../webapp/cli') // FIXME
 import pictureInPicture from '../webapp/picture-in-picture' // FIXME
 import { currentSelection, maybeHideEntity } from '../webapp/views/sidecar' // FIXME
 import { element } from '../webapp/util/dom' // FIXME
-
+import sessionStore from '@kui-shell/core/models/sessionStore'
 import { isHTML } from '../util/types'
 
 debug('finished loading modules')
+
+/**
+ * the key in localStorage to get the symbol table
+ *
+ */
+export const key = 'kui.symbol_table'
 
 /**
  * repl.exec, and the family repl.qexec, repl.pexec, etc. are all
@@ -311,6 +317,14 @@ class InProcessExecutor implements IExecutor {
     // debug(`repl::exec ${new Date()}`)
     debug('exec', commandUntrimmed)
     const tab = cli.getCurrentTab()
+
+    if (!isHeadless()) {
+      const storage = JSON.parse(sessionStore().getItem(key)) || {}
+      const curDic = storage[cli.getTabIndex(cli.getCurrentTab())]
+      if (typeof curDic !== 'undefined') {
+        process.env = Object.assign({}, process.env, curDic)
+      }
+    }
 
     const echo = !execOptions || execOptions.echo !== false
     const nested = execOptions && execOptions.noHistory && !execOptions.replSilence

--- a/packages/app/src/models/sessionStore.ts
+++ b/packages/app/src/models/sessionStore.ts
@@ -1,0 +1,30 @@
+
+/*
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface SessionStorage {
+  getItem: (key: string) => string
+  setItem: (key: string, value: string) => void
+  removeItem: (key: string) => void
+  clear: () => void
+}
+
+  /**
+   * This shim allows clients to define a sessionStorage scheme, if they
+   * cannot provide window.sessionStorage.
+   *
+   */
+export default (): SessionStorage => window['kuiSessionStorage'] || window.sessionStorage

--- a/plugins/plugin-bash-like/src/lib/cmds/export.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/export.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommandRegistrar, IEvaluatorArgs } from '@kui-shell/core/models/command'
+import sessionStore from '@kui-shell/core/models/sessionStore'
+import { getTabIndex, getCurrentTab } from '@kui-shell/core/webapp/cli'
+import { key } from '@kui-shell/core/core/repl'
+
+/**
+ * export command
+ *
+ */
+const exportCommand = ({ command, parsedOptions, execOptions }: IEvaluatorArgs) => {
+  const storage = JSON.parse(sessionStore().getItem(key)) || {}
+
+  const tabId = getTabIndex(getCurrentTab())
+  const curDic = storage[tabId] || {}
+  const toBeParsed = parsedOptions._[1]
+
+  const arr = toBeParsed.split('=')
+
+  curDic[arr[0]] = arr[1]
+
+  storage[tabId] = curDic
+  sessionStore().setItem(key, JSON.stringify(storage))
+  return true
+}
+
+const usage = {
+  command: 'export',
+  docs: 'Export a variable or function to the environment of all the child processes running in the current shell'
+}
+
+/**
+ * Register command handlers
+ *
+ */
+export default (commandTree: CommandRegistrar) => {
+  commandTree.listen('/export', exportCommand, { usage, noAuthOk: true })
+}

--- a/plugins/plugin-bash-like/src/plugin.ts
+++ b/plugins/plugin-bash-like/src/plugin.ts
@@ -20,6 +20,7 @@ import bash from './lib/cmds/bash-like'
 import gitDiff from './lib/cmds/git-diff'
 import gitStatus from './lib/cmds/git-status'
 import ptyServer from './pty/server'
+import exportCommand from './lib/cmds/export'
 
 import { CommandRegistrar } from '@kui-shell/core/models/command'
 
@@ -34,6 +35,7 @@ export default async (commandTree: CommandRegistrar) => {
     bash(commandTree),
     ptyServer(commandTree),
     gitDiff(commandTree),
-    gitStatus(commandTree)
+    gitStatus(commandTree),
+    exportCommand(commandTree)
   ])
 }

--- a/plugins/plugin-bash-like/src/test/bash-like/export.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/export.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISuite } from '@kui-shell/core/tests/lib/common'
+import * as common from '@kui-shell/core/tests/lib/common' // tslint:disable-line:no-duplicate-imports
+import * as ui from '@kui-shell/core/tests/lib/ui'
+const { cli } = ui
+const { localDescribe } = common
+
+/*
+ * Report on export testcases
+ * yes: export FOO=bar; echo $FOO -> bar
+ * no: export FOO=(3 4); echo $FOO => 3
+ * yes: export FOO="bar baz"; echo $FOO -> bar baz
+ * no: export FOO=bar=baz; echo $FOO -> bar=baz
+ * no: export FOO=bar" "baz; echo $FOO -> bar baz
+ * yes: export FOO=bar\ baz; echo $FOO -> bar baz
+ */
+
+localDescribe('export command', function (this: ISuite) {
+  before(common.before(this))
+  after(common.after(this))
+
+  it('should export foo bar', () =>
+        cli
+            .do('export foo=bar', this.app)
+            .then(cli.expectJustOK)
+            .then(() =>
+                cli.do('echo $foo', this.app).then(cli.expectOKWithString('bar'))
+            )
+            .catch(common.oops(this)))
+
+  it('should export foo bar baz with space in string', () =>
+        cli
+            .do('export foo="bar baz"', this.app)
+            .then(cli.expectJustOK)
+            .then(() =>
+            cli.do('echo $foo', this.app).then(cli.expectOKWithString('bar baz'))
+            )
+            .catch(common.oops(this)))
+})


### PR DESCRIPTION
Signed-off-by: Xianzhi Olivia Ruan <rxianzhi@umich.edu>

Fixes #180 

Add a new command in bash-like plugin to support export feature.
Variables would be saved in sessionStorage in the structure:
```
{tabIndex:[{key:value}]}
```
#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](../CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
