### PR TITLE
fix: allow for log-lines tables to specify a looser layout

### DIFF
--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -1697,7 +1697,7 @@ sidecar .activation-result .log-line .log-field > div > div:first-child code {
 .log-lines .log-line .log-message {
     white-space: pre-wrap;
 }
-sidecar .log-lines .log-line {
+sidecar .log-lines:not(.log-lines-loose) .log-line {
     height: auto;
 }
 sidecar .log-lines .log-line:nth-child(2n) .log-field {

--- a/plugins/plugin-openwhisk/src/lib/views/cli/activations/list.ts
+++ b/plugins/plugin-openwhisk/src/lib/views/cli/activations/list.ts
@@ -153,7 +153,7 @@ const _render = args => {
   const newTable = !logTable
   if (newTable) {
     logTable = document.createElement('table')
-    logTable.className = 'log-lines fixed-table-layout'
+    logTable.className = 'log-lines fixed-table-layout log-lines-loose'
 
     if (entity) {
       // for the sidecar only, clean things out


### PR DESCRIPTION
Fixes #1471

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
