### PR TITLE
fix(plugins/plugin-k8s): improve support for ClusterRole and PodSecur…

### DIFF
--- a/plugins/plugin-k8s/src/lib/model/states.ts
+++ b/plugins/plugin-k8s/src/lib/model/states.ts
@@ -201,6 +201,8 @@ export const getStatus = async (desiredFinalState: FinalState, apiVersion: strin
     if (kind === 'Secret' ||
         kind === 'Ingress' ||
         kind === 'ConfigMap' ||
+        kind === 'PodSecurityPolicy' ||
+        kind === 'ClusterRole' ||
         kind === 'CustomResourceDefinition' ||
         kind === 'HorizontalPodAutoscaler' ||
         kind === 'ClusterRoleBinding' ||


### PR DESCRIPTION
…ityPolicy states

Fixes #1476

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
