### PR TITLE
chore(plugin/plugin-k8s): add missing SidecarMode types to k8s plugin

### DIFF
--- a/plugins/plugin-k8s/src/lib/controller/kubectl.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kubectl.ts
@@ -27,6 +27,7 @@ import repl = require('@kui-shell/core/core/repl')
 import { oopsMessage } from '@kui-shell/core/core/oops'
 import { CommandRegistrar, CommandHandler, ExecType, IEvaluatorArgs, ParsedOptions } from '@kui-shell/core/models/command'
 import { IExecOptions } from '@kui-shell/core/models/execOptions'
+import { ISidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
 
 import abbreviations from './abbreviations'
 import { formatLogs } from '../util/log-parser'
@@ -548,7 +549,7 @@ const executeLocally = (command: string) => (opts: IEvaluatorArgs) => new Promis
         return resolve(result)
       }
 
-      const modes: Array<any> = [{
+      const modes: Array<ISidecarMode> = [{
         mode: 'result',
         direct: rawCommand,
         label: output === 'json' || output === 'yaml' ? output.toUpperCase() : output,
@@ -560,7 +561,7 @@ const executeLocally = (command: string) => (opts: IEvaluatorArgs) => new Promis
           mode: 'previous',
           direct: `${rawCommand} --previous`,
           execOptions: {
-            type: 'pexec'
+            exec: 'pexec'
           }
         })
 

--- a/plugins/plugin-k8s/src/lib/model/states.ts
+++ b/plugins/plugin-k8s/src/lib/model/states.ts
@@ -198,7 +198,8 @@ export const getStatus = async (desiredFinalState: FinalState, apiVersion: strin
 
     const response = rawState.response ? rawState.response.result : rawState // either OW invocation or direct exec
 
-    if (kind === 'Secret' ||
+    if (!response.status || // resource does not define a status; consider it Online
+        kind === 'Secret' ||
         kind === 'Ingress' ||
         kind === 'ConfigMap' ||
         kind === 'CustomResourceDefinition' ||

--- a/plugins/plugin-k8s/src/lib/view/modes/conditions.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/conditions.ts
@@ -18,19 +18,20 @@ import * as Debug from 'debug'
 const debug = Debug('k8s/view/modes/conditions')
 
 import { formatMultiListResult } from '@kui-shell/core/webapp/views/table'
+import { ISidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
+import { Row, Table } from '@kui-shell/core/webapp/models/table'
 
 import IResource from '../../model/resource'
 
 import insertView from '../insert-view'
 import { formatTable } from '../formatMultiTable'
-import { Row, Table } from '@kui-shell/core/webapp/models/table'
 
 /**
  * Add a Conditions mode button to the given modes model, if called
  * for by the given resource.
  *
  */
-export const addConditions = (modes: Array<any>, command: string, resource: IResource) => {
+export const addConditions = (modes: Array<ISidecarMode>, command: string, resource: IResource) => {
   try {
     if (resource.yaml.status && resource.yaml.status.conditions) {
       modes.push(conditionsButton(command, resource))

--- a/plugins/plugin-k8s/src/lib/view/modes/containers.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/containers.ts
@@ -21,6 +21,7 @@ import repl = require('@kui-shell/core/core/repl')
 import drilldown from '@kui-shell/core/webapp/picture-in-picture'
 import { formatMultiListResult } from '@kui-shell/core/webapp/views/table'
 import { Row, Table } from '@kui-shell/core/webapp/models/table'
+import { ISidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
 
 import IResource from '../../model/resource'
 
@@ -37,7 +38,7 @@ const viewName = 'Containers'
  * for by the given resource.
  *
  */
-export const addContainers = (modes: Array<any>, command: string, resource: IResource) => {
+export const addContainers = (modes: Array<ISidecarMode>, command: string, resource: IResource) => {
   try {
     if (resource.yaml.spec && resource.yaml.spec.containers) {
       const button = containersButton(command, resource)

--- a/plugins/plugin-k8s/src/lib/view/modes/pods.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/pods.ts
@@ -20,6 +20,8 @@ const debug = Debug('k8s/view/modes/pods')
 import { qexec as $$ } from '@kui-shell/core/core/repl'
 import drilldown from '@kui-shell/core/webapp/picture-in-picture'
 import { formatMultiListResult } from '@kui-shell/core/webapp/views/table'
+import { ISidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
+import { Table } from '@kui-shell/core/webapp/models/table'
 
 import { selectorToString } from '../../util/selectors'
 
@@ -28,7 +30,6 @@ import { TrafficLight } from '../../model/states'
 
 import insertView from '../insert-view'
 import { getActiveView, formatTable } from '../formatMultiTable'
-import { Table } from '@kui-shell/core/webapp/models/table'
 
 /** for drilldown back button */
 const viewName = 'Pods'
@@ -38,7 +39,7 @@ const viewName = 'Pods'
  * the given resource.
  *
  */
-export const addPods = (modes: Array<any>, command: string, resource: IResource) => {
+export const addPods = (modes: Array<ISidecarMode>, command: string, resource: IResource) => {
   try {
     debug('addPods', resource)
     if (resource.yaml.spec && resource.yaml.spec.selector) {


### PR DESCRIPTION
Fixes #1479

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
