### PR TITLE
fix(plugins/plugin-core-support): tab completion of dirs versus ~

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -39,7 +39,6 @@
     "debug": "4.1.1",
     "electron-context-menu": "0.12.1",
     "electron-squirrel-startup": "1.0.0",
-    "expand-home-dir": "0.0.3",
     "extract-zip": "1.6.7",
     "fs-extra": "7.0.1",
     "js-beautify": "1.10.0",

--- a/packages/app/src/core/find-file.ts
+++ b/packages/app/src/core/find-file.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corporation
+ * Copyright 2017-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-const debug = require('debug')('core/find-file')
+import * as Debug from 'debug'
+const debug = Debug('core/find-file')
 debug('loading')
 
 import { basename, dirname, join, resolve } from 'path'
-import expandHomeDir = require('expand-home-dir')
+
+import expandHomeDir from '@kui-shell/core/util/home'
 import { inBrowser } from './capabilities'
 
 /**

--- a/packages/app/src/core/userdata.ts
+++ b/packages/app/src/core/userdata.ts
@@ -20,6 +20,7 @@ const debug = Debug('core/userdata')
 import { join } from 'path'
 
 import store from '@kui-shell/core/models/store'
+import expandHomeDir from '@kui-shell/core/util/home'
 import { inBrowser, inElectron } from '@kui-shell/core/core/capabilities'
 
 type Preferences = { [key: string]: string }
@@ -33,14 +34,13 @@ export const userDataDir = (): string => {
     throw new Error('Unsupported operation')
   } else {
     // headless
-    const { join } = require('path')
     const { name } = require('@kui-shell/settings/package.json')
 
     switch (process.platform) {
       case 'darwin':
         return join(process.env.HOME, 'Library', 'Application Support', name)
       case 'linux':
-        const home = process.env.XDG_CONFIG_HOME || require('expand-home-dir')('~/.config')
+        const home = process.env.XDG_CONFIG_HOME || expandHomeDir('~/.config')
         return join(home, name)
       case 'win32':
         return join(process.env.APPDATA, name)

--- a/packages/app/src/util/home.ts
+++ b/packages/app/src/util/home.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 IBM Corporation
+ * Copyright 2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-const myDebug = require('debug')('webapp/bootstrap/electron')
+import { join } from 'path'
+import { homedir as home } from 'os'
 
-if (process.cwd() === '/') {
-  // ugh, on macos, dock- and finder-launched apps have a cwd of /
-  try {
-    process.chdir(require('@kui-shell/core/util/home')('~'))
-  } catch (err) {
-    console.error(err)
+const homedir = home()
+
+export default function (path: string): string {
+  if (!path) {
+    return path
+  } else if (path === '~') {
+    return homedir
+  } else if (path.slice(0, 2) !== '~/' && path.slice(0, 2) !== '~\\') {
+    return path
+  } else {
+    return join(homedir, path.slice(2))
   }
-}
-
-try {
-  require('./boot').default()
-} catch (err) {
-  require('@kui-shell/core/webapp/bootstrap/boot').default()
 }

--- a/plugins/plugin-apache-composer/package.json
+++ b/plugins/plugin-apache-composer/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "app-module-path": "2.2.0",
     "debug": "4.1.1",
-    "expand-home-dir": "0.0.3",
     "openwhisk-composer": "0.10.0"
   },
   "publishConfig": {

--- a/plugins/plugin-apache-composer/src/lib/utility/compile.ts
+++ b/plugins/plugin-apache-composer/src/lib/utility/compile.ts
@@ -19,7 +19,7 @@ const debug = Debug('plugins/apache-composer/utility/compile')
 
 import * as fs from 'fs'
 import * as path from 'path'
-import * as expandHomeDir from 'expand-home-dir'
+import expandHomeDir from '@kui-shell/core/util/home'
 import * as fqn from 'openwhisk-composer/fqn'
 import * as Composer from 'openwhisk-composer'
 

--- a/plugins/plugin-bash-like/package.json
+++ b/plugins/plugin-bash-like/package.json
@@ -28,7 +28,6 @@
     "asciidoctor.js": "1.5.9",
     "debug": "4.1.1",
     "diff2html": "2.7.0",
-    "expand-home-dir": "0.0.3",
     "marked": "0.6.2",
     "node-pty": "0.8.1",
     "shelljs": "0.8.3",

--- a/plugins/plugin-bash-like/src/lib/cmds/bash-like.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/bash-like.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-18 IBM Corporation
+ * Copyright 2017-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ const debug = Debug('plugins/bash-like/cmds/general')
 
 import * as fs from 'fs'
 import * as path from 'path'
-import * as expandHomeDir from 'expand-home-dir'
 
+import expandHomeDir from '@kui-shell/core/util/home'
 import { inBrowser, isHeadless } from '@kui-shell/core/core/capabilities'
 import UsageError from '@kui-shell/core/core/usage-error'
 import * as repl from '@kui-shell/core/core/repl'

--- a/plugins/plugin-bash-like/src/lib/cmds/git-commit.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/git-commit.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 IBM Corporation
+ * Copyright 2018-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ const debug = Debug('plugins/bash-like/cmds/git-commit')
 import { join } from 'path'
 import { writeFile } from 'fs'
 import { spawn } from 'child_process'
-import * as expandHomeDir from 'expand-home-dir'
 
+import expandHomeDir from '@kui-shell/core/util/home'
 import eventBus from '@kui-shell/core/core/events'
 import { qexec } from '@kui-shell/core/core/repl'
 import { clearSelection as clearSidecar, showEntity as showInSidecar } from '@kui-shell/core/webapp/views/sidecar'

--- a/plugins/plugin-bash-like/src/lib/cmds/ls.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/ls.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 IBM Corporation
+ * Copyright 2018-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,7 @@ const debug = Debug('plugins/bash-like/cmds/ls')
 import { lstat, readdir, stat } from 'fs'
 import { isAbsolute, join } from 'path'
 
-import * as expandHomeDir from 'expand-home-dir'
-
+import expandHomeDir from '@kui-shell/core/util/home'
 import * as repl from '@kui-shell/core/core/repl'
 import UsageError from '@kui-shell/core/core/usage-error'
 import { CommandRegistrar, IEvaluatorArgs, ParsedOptions } from '@kui-shell/core/models/command'

--- a/plugins/plugin-bash-like/src/lib/cmds/open.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/open.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 IBM Corporation
+ * Copyright 2018-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ const debug = Debug('plugins/bash-like/cmds/open')
 
 import { basename, dirname } from 'path'
 import { readFile } from 'fs'
-import * as expandHomeDir from 'expand-home-dir'
 
+import expandHomeDir from '@kui-shell/core/util/home'
 import { isHeadless } from '@kui-shell/core/core/capabilities'
 import { qexec } from '@kui-shell/core/core/repl'
 import { findFile } from '@kui-shell/core/core/find-file'

--- a/plugins/plugin-bash-like/src/test/bash-like/cd.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/cd.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corporation
+ * Copyright 2017-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import * as expandHomeDir from 'expand-home-dir'
-
+import expandHomeDir from '@kui-shell/core/util/home'
 import { ISuite } from '@kui-shell/core/tests/lib/common'
 import * as common from '@kui-shell/core/tests/lib/common' // tslint:disable-line:no-duplicate-imports
 import * as ui from '@kui-shell/core/tests/lib/ui'

--- a/plugins/plugin-core-support/package.json
+++ b/plugins/plugin-core-support/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "colors": "1.3.3",
     "debug": "4.1.1",
-    "expand-home-dir": "0.0.3",
     "marked": "0.6.2",
     "tmp": "0.1.0"
   },

--- a/plugins/plugin-core-support/src/lib/cmds/run.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/run.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corporation
+ * Copyright 2017-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ const debug = Debug('plugins/core-support/run')
 
 import { readFile } from 'fs'
 import { dirname } from 'path'
-import * as expandHomeDir from 'expand-home-dir'
 
 import * as repl from '@kui-shell/core/core/repl'
+import expandHomeDir from '@kui-shell/core/util/home'
 import { findFile } from '@kui-shell/core/core/find-file'
 import { CommandRegistrar } from '@kui-shell/core/models/command'
 import { formatMultiListResult } from '@kui-shell/core/webapp/views/table'

--- a/plugins/plugin-core-support/src/lib/tab-completion.ts
+++ b/plugins/plugin-core-support/src/lib/tab-completion.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-18 IBM Corporation
+ * Copyright 2017-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ import * as cli from '@kui-shell/core/webapp/cli'
 import * as repl from '@kui-shell/core/core/repl'
 import { findFile } from '@kui-shell/core/core/find-file'
 import { injectCSS } from '@kui-shell/core/webapp/util/inject'
+import expandHomeDir from '@kui-shell/core/util/home'
 
 import * as fs from 'fs'
 import * as path from 'path'
-import * as expandHomeDir from 'expand-home-dir'
 
 /**
  * Escape the given string for bash happiness
@@ -438,7 +438,7 @@ const suggestLocalFile = (last: string, block: HTMLElement, prompt: HTMLInputEle
 
   if (dirname) {
     // then dirname exists! now scan the directory so we can find matches
-    fs.readdir(dirname, (err, files) => {
+    fs.readdir(expandHomeDir(dirname), (err, files) => {
       if (err) {
         debug('fs.readdir error', err)
       } else {

--- a/plugins/plugin-editor/package.json
+++ b/plugins/plugin-editor/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "debug": "4.1.1",
-    "expand-home-dir": "0.0.3",
     "monaco-editor": "0.14.3",
     "tmp": "0.1.0"
   },

--- a/plugins/plugin-editor/src/lib/fetchers.ts
+++ b/plugins/plugin-editor/src/lib/fetchers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 IBM Corporation
+ * Copyright 2018-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ const debug = Debug('plugins/editor/fetchers')
 
 import { basename } from 'path'
 import { lstat, readFile } from 'fs'
-import * as expandHomeDir from 'expand-home-dir'
 
+import expandHomeDir from '@kui-shell/core/util/home'
 import { findFile } from '@kui-shell/core/core/find-file'
 import { persisters } from './persisters'
 import { gotoReadonlyLocalFile } from './readonly'

--- a/plugins/plugin-k8s/package.json
+++ b/plugins/plugin-k8s/package.json
@@ -26,7 +26,6 @@
     "archiver": "3.0.0",
     "command-exists": "1.2.8",
     "debug": "4.1.1",
-    "expand-home-dir": "0.0.3",
     "fs-extra": "7.0.1",
     "js-yaml": "3.13.1",
     "needle": "2.3.1",

--- a/plugins/plugin-k8s/src/lib/controller/contexts.ts
+++ b/plugins/plugin-k8s/src/lib/controller/contexts.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 IBM Corporation
+ * Copyright 2018-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/plugin-k8s/src/lib/controller/kedit.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kedit.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 IBM Corporation
+ * Copyright 2018-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@ const debug = Debug('k8s/controller/kedit')
 debug('loading')
 
 import { basename, dirname, join } from 'path'
-import expandHomeDir = require('expand-home-dir')
 
 import { inBrowser } from '@kui-shell/core/core/capabilities'
 import { CommandRegistrar, IEvaluatorArgs, ParsedOptions } from '@kui-shell/core/models/command'
 import { IExecOptions } from '@kui-shell/core/models/execOptions'
 import { injectCSS } from '@kui-shell/core/webapp/util/inject'
+import expandHomeDir from '@kui-shell/core/util/home'
 import { findFile } from '@kui-shell/core/core/find-file'
 import repl = require('@kui-shell/core/core/repl')
 import { Row, Table } from '@kui-shell/core/webapp/models/table'

--- a/plugins/plugin-k8s/src/lib/controller/kubectl.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kubectl.ts
@@ -18,9 +18,8 @@ import * as Debug from 'debug'
 const debug = Debug('k8s/controller/kubectl')
 debug('loading')
 
-import * as expandHomeDir from 'expand-home-dir'
-
 import { isHeadless, inBrowser } from '@kui-shell/core/core/capabilities'
+import expandHomeDir from '@kui-shell/core/util/home'
 import { findFile } from '@kui-shell/core/core/find-file'
 import { UsageError, IUsageModel } from '@kui-shell/core/core/usage-error'
 import repl = require('@kui-shell/core/core/repl')

--- a/plugins/plugin-k8s/src/lib/util/fetch-file.ts
+++ b/plugins/plugin-k8s/src/lib/util/fetch-file.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 IBM Corporation
+ * Copyright 2018-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-const debug = require('debug')('k8s/util/fetch-file')
+import * as Debug from 'debug'
+const debug = Debug('k8s/util/fetch-file')
 
+import expandHomeDir from '@kui-shell/core/util/home'
 import { findFile } from '@kui-shell/core/core/find-file'
 
 import needle = require('needle')
-import expandHomeDir = require('expand-home-dir')
 
 /**
  * Either fetch a remote file or read a local one

--- a/plugins/plugin-k8s/src/test/k8s/contexts.ts
+++ b/plugins/plugin-k8s/src/test/k8s/contexts.ts
@@ -16,11 +16,11 @@
 
 import path = require('path')
 import assert = require('assert')
-import expandHomeDir = require('expand-home-dir')
 import { execSync } from 'child_process'
 import { readFileSync, writeFileSync } from 'fs'
 import { safeDump, safeLoad as parseYAML } from 'js-yaml'
 
+import expandHomeDir from '@kui-shell/core/util/home'
 import * as common from '@kui-shell/core/tests/lib/common'
 import { cli, expectYAMLSubset, expectSubset, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
 import { createNS, waitTillNone } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'

--- a/plugins/plugin-openwhisk/package.json
+++ b/plugins/plugin-openwhisk/package.json
@@ -29,7 +29,6 @@
     "adm-zip": "0.4.13",
     "archiver": "3.0.0",
     "debug": "4.1.1",
-    "expand-home-dir": "0.0.3",
     "htmlparser2": "3.10.1",
     "needle": "2.3.1",
     "openwhisk": "3.18.0",

--- a/plugins/plugin-openwhisk/src/lib/cmds/actions/_html.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/actions/_html.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corporation
+ * Copyright 2017-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,10 @@
 
 import { lstat, readFile } from 'fs'
 import { dirname, resolve as pathResolve } from 'path'
-import expandHomeDir = require('expand-home-dir')
 import htmlparser = require('htmlparser2')
 
 import repl = require('@kui-shell/core/core/repl')
+import expandHomeDir from '@kui-shell/core/util/home'
 
 /**
  * Deploy a linked asset

--- a/plugins/plugin-openwhisk/src/lib/cmds/actions/let.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/actions/let.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corporation
+ * Copyright 2017-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,8 @@ import { createWriteStream, existsSync, stat, lstat, readFile, readFileSync, unl
 import { basename, join } from 'path'
 import needle = require('needle')
 import withRetry = require('promise-retry')
-import expandHomeDir = require('expand-home-dir')
 
+import expandHomeDir from '@kui-shell/core/util/home'
 import { inBrowser } from '@kui-shell/core/core/capabilities'
 import { current as currentNamespace } from '../../models/namespace'
 import { findFile } from '@kui-shell/core/core/find-file'

--- a/plugins/plugin-openwhisk/src/lib/cmds/auth.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/auth.ts
@@ -31,13 +31,13 @@ import repl = require('@kui-shell/core/core/repl')
 import namespace = require('../models/namespace')
 import { apiHost } from '../models/auth'
 import { Row, Table } from '@kui-shell/core/webapp/models/table'
+import expandHomeDir from '@kui-shell/core/util/home'
 
 /**
  * Location of the wskprops file
  *
  */
 const wskpropsFile = (): string => {
-  const expandHomeDir = require('expand-home-dir')
   return expandHomeDir(process.env.WSK_CONFIG_FILE || '~/.wskprops')
 }
 

--- a/plugins/plugin-openwhisk/src/lib/cmds/openwhisk-core.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/openwhisk-core.ts
@@ -18,6 +18,7 @@ import * as Debug from 'debug'
 const debug = Debug('plugins/openwhisk/cmds/core-commands')
 debug('loading')
 
+import expandHomeDir from '@kui-shell/core/util/home'
 import { inBrowser } from '@kui-shell/core/core/capabilities'
 import { findFile } from '@kui-shell/core/core/find-file'
 import { UsageError, IUsageModel } from '@kui-shell/core/core/usage-error'
@@ -120,7 +121,6 @@ const paramFile = (M, idx, argv, type) => {
     M[type].parameters = []
   }
 
-  const expandHomeDir = require('expand-home-dir')
   const file = argv[++idx]
   const params = JSON.parse(require('fs').readFileSync(expandHomeDir(file)).toString())
   M[type].parameters = M[type].parameters.concat(toArray(params))
@@ -205,7 +205,6 @@ const handleKeyValuePairAsArray = key => (M, idx, argv, type) => {
     }
 
     const fs = require('fs')
-    const expandHomeDir = require('expand-home-dir')
     const location = expandHomeDir(paramValue.substring(1))
     if (!fs.existsSync(location)) {
       throw new Error(`Requested parameter @file does not exist: ${location}`)
@@ -738,7 +737,6 @@ specials.actions = {
 
       if (argv[0]) {
         // find the file named by argv[0]
-        const expandHomeDir = require('expand-home-dir')
         const filepath = findFile(expandHomeDir(argv[0]))
         const isZip = argv[0].endsWith('.zip')
         const isJar = argv[0].endsWith('.jar')

--- a/plugins/plugin-openwhisk/src/lib/models/auth.ts
+++ b/plugins/plugin-openwhisk/src/lib/models/auth.ts
@@ -25,10 +25,11 @@ import { getDefaultCommandContext } from '@kui-shell/core/core/command-tree'
 import { config } from '@kui-shell/core/core/settings'
 import store from '@kui-shell/core/models/store'
 
+import expandHomeDir from '@kui-shell/core/util/home'
+
 let wskprops
 try {
   const propertiesParser = require('properties-parser')
-  const expandHomeDir = require('expand-home-dir')
   if (!inBrowser()) {
     wskprops = propertiesParser.read(expandHomeDir(process.env['WSK_CONFIG_FILE'] || '~/.wskprops'))
   } else {

--- a/plugins/plugin-openwhisk/tests/lib/openwhisk/openwhisk.js
+++ b/plugins/plugin-openwhisk/tests/lib/openwhisk/openwhisk.js
@@ -16,13 +16,13 @@
 
 const ui = require('@kui-shell/core/tests/lib/ui')
 const common = require('@kui-shell/core/tests/lib/common')
+const expandHomeDir = require('@kui-shell/core/util/home')
 
 // read and cache local ~/.wskprops
 let wskprops
 const localWskProps = () => {
   if (!wskprops) {
     const propertiesParser = require('properties-parser')
-    const expandHomeDir = require('expand-home-dir')
 
     try {
       wskprops = propertiesParser.read(process.env['WSK_CONFIG_FILE'] || expandHomeDir('~/.wskprops'))

--- a/plugins/plugin-tekton/package.json
+++ b/plugins/plugin-tekton/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "debug": "4.1.1",
-    "expand-home-dir": "0.0.3",
     "js-yaml": "3.13.1"
   },
   "kui": {

--- a/plugins/plugin-tekton/src/lib/read.ts
+++ b/plugins/plugin-tekton/src/lib/read.ts
@@ -20,8 +20,8 @@ const debug = Debug('plugins/tekton/lib/read')
 import { readFile } from 'fs'
 import { promisify } from 'util'
 import { safeLoadAll } from 'js-yaml'
-import * as expandHomeDir from 'expand-home-dir'
 
+import expandHomeDir from '@kui-shell/core/util/home'
 import { findFile } from '@kui-shell/core/core/find-file'
 
 /** promisey readFile */

--- a/plugins/plugin-wrk/package.json
+++ b/plugins/plugin-wrk/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "columnify": "1.5.4",
-    "expand-home-dir": "0.0.3",
     "parse-duration": "0.1.1",
     "pretty-ms": "5.0.0",
     "properties-parser": "0.3.1",

--- a/plugins/plugin-wrk/src/lib/openwhisk.ts
+++ b/plugins/plugin-wrk/src/lib/openwhisk.ts
@@ -16,8 +16,9 @@
 
 import * as fs from 'fs'
 import * as url from 'url'
-import * as expandHomeDir from 'expand-home-dir'
 import * as propertiesParser from 'properties-parser'
+
+import expandHomeDir from '@kui-shell/core/util/home'
 
 /**
  * Get the apiHost and auth key

--- a/plugins/plugin-wskflow/package.json
+++ b/plugins/plugin-wskflow/package.json
@@ -41,7 +41,6 @@
     "debug": "4.1.1",
     "elkjs": "0.3.0",
     "es6-promise-pool": "2.5.0",
-    "expand-home-dir": "0.0.3",
     "jquery": "3.4.1",
     "tmp": "0.1.0"
   },

--- a/plugins/plugin-wskflow/src/lib/preview.ts
+++ b/plugins/plugin-wskflow/src/lib/preview.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 IBM Corporation
+ * Copyright 2017-2019 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@ debug('loading')
 
 import * as fs from 'fs'
 import * as path from 'path'
-import * as expandHomeDir from 'expand-home-dir'
 
 import * as usage from '../usage'
 
 import { CommandRegistrar, IEvaluatorArgs } from '@kui-shell/core/models/command'
 import { PluginRegistration } from '@kui-shell/core/models/plugin'
 import { inBrowser } from '@kui-shell/core/core/capabilities'
+import expandHomeDir from '@kui-shell/core/util/home'
 import { findFile } from '@kui-shell/core/core/find-file'
 import * as repl from '@kui-shell/core/core/repl'
 import Presentation from '@kui-shell/core/webapp/views/presentation'


### PR DESCRIPTION
Fixes #1483

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
