### PR TITLE
fix: avoid catchall registration if in browser and no proxy

### DIFF
--- a/packages/app/src/core/capabilities.ts
+++ b/packages/app/src/core/capabilities.ts
@@ -38,6 +38,7 @@ type ICredentialsMap = { [key: string]: any }
 class State {
   assertedLocalAccess = false
   hasLocalAccess = true // may change as media changes or assertLocalAccess is called
+  hasProxy = false
   media = Media.Unknown
   validCredentials: ICredentialsMap = {} // map to the credentials
 }
@@ -51,6 +52,18 @@ export const getMedia = () => state.media
 export const isHeadless = () => state.media === Media.Headless
 export const inElectron = () => state.media === Media.Electron
 export const inBrowser = () => state.media === Media.Browser
+
+/**
+ * Is Kui supported by a remote proxy?
+ *
+ */
+export const hasProxy = () => state.hasProxy
+
+/**
+ * Assert that Kui is supported by a remote proxy
+ *
+ */
+export const assertHasProxy = () => state.hasProxy = true
 
 /**
  * Update the media, e.g. to indicate that we are running in a browser

--- a/plugins/plugin-bash-like/src/lib/cmds/catchall.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/catchall.ts
@@ -17,7 +17,7 @@
 import * as Debug from 'debug'
 const debug = Debug('plugins/bash-like/cmds/catchall')
 
-import { inBrowser, isHeadless } from '@kui-shell/core/core/capabilities'
+import { inBrowser, isHeadless, hasProxy } from '@kui-shell/core/core/capabilities'
 import { CommandRegistrar, IEvaluatorArgs } from '@kui-shell/core/models/command'
 
 /**
@@ -51,6 +51,11 @@ export const dispatchToShell = async ({ tab, block, command, argv, argvNoOptions
  *
  */
 export const preload = (commandTree) => {
+  if (inBrowser() && !hasProxy()) {
+    debug('skipping catchall registration: in browser and no remote proxy to support it')
+    return
+  }
+
   //
   // if we aren't running in a browser, then pass any command not
   // found exceptions to the outer shell

--- a/plugins/plugin-proxy-support/src/preload.ts
+++ b/plugins/plugin-proxy-support/src/preload.ts
@@ -17,7 +17,7 @@
 import * as Debug from 'debug'
 const debug = Debug('plugins/proxy-support/preload')
 
-import { inBrowser, assertLocalAccess } from '@kui-shell/core/core/capabilities'
+import { inBrowser, assertHasProxy, assertLocalAccess } from '@kui-shell/core/core/capabilities'
 import { CommandRegistrar } from '@kui-shell/core/models/command'
 
 /**
@@ -35,6 +35,10 @@ export default async (commandTree: CommandRegistrar) => {
 
       debug('attempting to establish our proxy executor')
       setEvaluatorImpl(new ProxyEvaluator())
+
+      // notify the Capabilities manager that we have extended the
+      // capabilities of Kui
+      assertHasProxy()
       assertLocalAccess()
     }
   }


### PR DESCRIPTION
this also adds a hasProxy Capability

Fixes #1494

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
