### PR TITLE
fix: optimize pty

### DIFF
--- a/packages/app/src/core/command-tree.ts
+++ b/packages/app/src/core/command-tree.ts
@@ -490,7 +490,7 @@ const disambiguate = async (argv: string[], noRetry = false) => {
   debug('disambiguate')
 
   let idx
-  const resolutions = ((((idx = 0) || true) && resolver.disambiguate(argv[idx])) || (((idx = argv.length - 1) || true) && resolver.disambiguate(argv[idx])) || [])
+  const resolutions = ((((idx = 0) || true) && resolver.disambiguate(argv[idx])) || (argv.length > 1 && ((idx = argv.length - 1) || true) && resolver.disambiguate(argv[idx])) || [])
   debug('disambiguate', idx, argv, resolutions)
 
   if (resolutions.length === 0 && !noRetry) {

--- a/packages/app/src/core/plugins.ts
+++ b/packages/app/src/core/plugins.ts
@@ -501,7 +501,7 @@ const makeResolver = (prescan: IPrescanModel) => {
       }
       if (plugin) {
         return resolveOne(plugin)
-      } else {
+      } else if (prescan.catchalls.length > 0) {
         // see if we have catchall
         debug('scanning catchalls', prescan.catchalls)
         return Promise.all(prescan.catchalls.map(_ => resolveOne(_.plugin)))

--- a/packages/app/src/webapp/cli.ts
+++ b/packages/app/src/webapp/cli.ts
@@ -99,6 +99,7 @@ const startInputQueueing = () => {
  * @return any queued input so far
  *
  */
+let _invisibleHand: HTMLInputElement
 export const disableInputQueueing = (): string => {
   if (isHeadless()) {
     return
@@ -106,14 +107,16 @@ export const disableInputQueueing = (): string => {
 
   debug('disableInputQueueing')
 
-  const invisibleHand = document.getElementById('invisible-global-input') as HTMLInputElement
+  const invisibleHand = _invisibleHand || (_invisibleHand = document.getElementById('invisible-global-input') as HTMLInputElement)
 
   // here is what might have queued up
   const queuedInput = invisibleHand.value
 
   // reset the queueing state
   invisibleHand.value = ''
-  invisibleHand.blur()
+
+  // this can be expensive; callers MUST focus on their element if they want this behavior
+  // invisibleHand.blur()
 
   return queuedInput
 }
@@ -664,7 +667,6 @@ export const printResults = (block: HTMLElement, nextBlock: HTMLElement, tab: IT
         // presentation mode
         const presentation = (isCustomSpec(response) && response.presentation) || (prettyType && Array.isArray(response) && Presentation.FixedSize) || Presentation.SidecarFullscreenForPopups
 
-        console.error('!!!!!!!!!!', response, isEntitySpec(response))
         await renderPopupContent(command, alreadyRendered !== true && resultDom, execOptions, Object.assign({}, response, {
           modes: modes || undefined,
           prettyType,

--- a/packages/app/src/webapp/util/ascii-to-usage.ts
+++ b/packages/app/src/webapp/util/ascii-to-usage.ts
@@ -64,9 +64,9 @@ const asciiToOptionsTable = (rows: Array<string>): Array<IPair> => {
 }
 
 export const formatUsage = (command: string, str: string, options: IOptions = new DefaultOptions()) => {
-  debug('raw', str)
+  // debug('raw', str)
   const rows = `\n${str}`.split(matcher)
-  debug('rows', rows)
+  // debug('rows', rows)
 
   if (rows.length > 2) {
     const sections = rows

--- a/plugins/plugin-bash-like/src/pty/server.ts
+++ b/plugins/plugin-bash-like/src/pty/server.ts
@@ -155,7 +155,7 @@ export const onConnection = (exitNow: ExitHandler) => async (ws: Channel) => {
             // termios.setattr(shell['_fd'], { lflag: { ECHO: false } })
 
             // send all PTY data out to the websocket client
-            shell.on('data', (data) => {
+            shell.on('data', (data: string) => {
               ws.send(JSON.stringify({ type: 'data', data }))
             })
 

--- a/plugins/plugin-bash-like/web/css/xterm.css
+++ b/plugins/plugin-bash-like/web/css/xterm.css
@@ -1,8 +1,3 @@
-.xterm-container .xterm-rows {
-    font-family: var(--font-monospace) !important;
-    transition: font-size 10ms ease-in-out;
-}
-
 .xterm-screen, .xterm-container .xterm-rows > div {
     transition: width 10ms ease-in-out, height 10ms ease-in-out;
 }
@@ -65,11 +60,8 @@ tab:not(.xterm-alt-buffer-mode) .xterm.xterm-empty-row-heuristic .xterm-rows > d
 }
 
 /* override the width and height pixel sizing from DomRenderer */
-.xterm-terminated .xterm-rows {
-    font-size: 1em !important;
-}
 .xterm-terminated .xterm-rows > div {
-    height: auto !important;
+    height: 1.14375em !important;
     line-height: normal !important;
 }
 .xterm-container .xterm-rows > div > span {
@@ -78,36 +70,41 @@ tab:not(.xterm-alt-buffer-mode) .xterm.xterm-empty-row-heuristic .xterm-rows > d
 }
 
 /* themes */
-.xterm-terminated .xterm-rows {
-    background: transparent !important;
-    transition: background 300ms ease-in-out;
+.xterm-container .xterm-viewport, .xterm-rows {
+    background: var(--color-base00) !important;
 }
-.xterm-terminated .xterm-rows > div > span {
+.xterm-rows {
+    font-size: 1em !important;
+    font-family: var(--font-monospace) !important;
+    color: var(--color-text-01) !important;
+    transition: font-size 10ms ease-in-out, background 300ms ease-in-out;
+}
+.xterm-rows > div > span {
     transition: color 300ms ease-in-out;
     color: var(--color-text-01) !important;
 }
-.xterm-terminated .xterm-rows .xterm-fg-0, .xterm-terminated .xterm-rows .xterm-fg-8 {
+.xterm-rows .xterm-fg-0, .xterm-rows .xterm-fg-8 {
     color: var(--color-black) !important;
 }
-.xterm-terminated .xterm-rows .xterm-fg-1, .xterm-terminated .xterm-rows .xterm-fg-9 {
+.xterm-rows .xterm-fg-1, .xterm-rows .xterm-fg-9 {
     color: var(--color-red) !important;
 }
-.xterm-terminated .xterm-rows .xterm-fg-2, .xterm-terminated .xterm-rows .xterm-fg-10 {
+.xterm-rows .xterm-fg-2, .xterm-rows .xterm-fg-10 {
     color: var(--color-green) !important;
 }
-.xterm-terminated .xterm-rows .xterm-fg-3, .xterm-terminated .xterm-rows .xterm-fg-11 {
+.xterm-rows .xterm-fg-3, .xterm-rows .xterm-fg-11 {
     color: var(--color-yellow) !important;
 }
-.xterm-terminated .xterm-rows .xterm-fg-4, .xterm-terminated .xterm-rows .xterm-fg-12 {
+.xterm-rows .xterm-fg-4, .xterm-rows .xterm-fg-12 {
     color: var(--color-blue) !important;
 }
-.xterm-terminated .xterm-rows .xterm-fg-5, .xterm-terminated .xterm-rows .xterm-fg-13 {
+.xterm-rows .xterm-fg-5, .xterm-rows .xterm-fg-13 {
     color: var(--color-magenta) !important;
 }
-.xterm-terminated .xterm-rows .xterm-fg-6, .xterm-terminated .xterm-rows .xterm-fg-14 {
+.xterm-rows .xterm-fg-6, .xterm-rows .xterm-fg-14 {
     color: var(--color-cyan) !important;
 }
-.xterm-terminated .xterm-rows .xterm-fg-7, .xterm-terminated .xterm-rows .xterm-fg-15 {
+.xterm-rows .xterm-fg-7, .xterm-rows .xterm-fg-15 {
     color: var(--color-white) !important;
 }
 


### PR DESCRIPTION
Fixes #1503

i found some fairly big performance issues in the PTY (mostly visible if you had lots of PTY output in your scroll buffer).

*Cause*: we were incurring 6 full browser forced-reflows for every bash command. oof. i've optimized that down to 1. there is still another round of optimization needed, but this should be a considerable improvement. this also seems to remove some of the jittery scrolling effects. i also optimized a few other surrounding bits.

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
