### PR TITLE
fix: window resize versus pty size cache

### DIFF
--- a/packages/app/src/webapp/views/sidecar.ts
+++ b/packages/app/src/webapp/views/sidecar.ts
@@ -787,9 +787,9 @@ export const show = (tab: ITab, block?: HTMLElement, nextBlock?: HTMLElement) =>
   }
 }
 
-export const isVisible = (tab: ITab) => {
+export const isVisible = (tab: ITab): boolean => {
   const sidecar = getSidecar(tab)
-  return sidecar.classList.contains('visible') && sidecar
+  return sidecar.classList.contains('visible') && sidecar ? true : false
 }
 
 export const isFullscreen = (tab: ITab) => {


### PR DESCRIPTION
Fixes #1505

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
