### PR TITLE
fix(plugins/plugin-core-support): screenshot of repl output is glitchy

### DIFF
--- a/plugins/plugin-core-support/src/lib/cmds/screenshot.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/screenshot.ts
@@ -82,11 +82,6 @@ const selectors = {
 const hideCurrentReplBlock = [
   { selector: '#main-repl .repl-block.processing', property: 'display', value: 'none' }
 ]
-const squishRepl = (element: Element) => [
-  { selector: 'body', css: 'screenshot-squish' },
-  { selector: element.querySelector('.repl-input'), property: 'display', value: 'none' },
-  { selector: 'tab.visible', css: 'screenshot-squish' }
-]
 const squishers = {
   sidecar: [
     { selector: 'body.subwindow', css: 'screenshot-squish' },
@@ -97,11 +92,7 @@ const squishers = {
 
   // screenshot full and repl should remove the last command from the screenshot, so that "screenshot full" doesn't show
   full: hideCurrentReplBlock,
-  repl: hideCurrentReplBlock,
-
-  nth: squishRepl,
-  'last-full': squishRepl,
-  last: squishRepl
+  repl: hideCurrentReplBlock
 }
 const flatten = arrays => [].concat.apply([], arrays)
 const _squish = (tab: ITab, which: string, selector: string, op) => {


### PR DESCRIPTION
Fixes #1519

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
