### PR TITLE
fix(packages/kui-builder): light theme versus gray badges

### DIFF
--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/light.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/light.css
@@ -60,5 +60,9 @@ body[kui-theme="Light"] {
     --color-field-01: #f4f7fb;
 }
 
+body[kui-theme="Light"] badge.gray-background {
+    background-color: var(--color-scrollbar-thumb);
+}
+
 /* mono-blue hightlightjs theme */
 .hljs{display:block;overflow-x:auto;padding:0.5em;background:#eaeef3}.hljs{color:#00193a}.hljs-keyword,.hljs-selector-tag,.hljs-title,.hljs-section,.hljs-doctag,.hljs-name,.hljs-strong{font-weight:bold}.hljs-comment{color:#738191}.hljs-string,.hljs-title,.hljs-section,.hljs-built_in,.hljs-literal,.hljs-params,.hljs-type,.hljs-addition,.hljs-tag,.hljs-quote,.hljs-name,.hljs-selector-id,.hljs-selector-class{color:#0048ab}.hljs-meta,.hljs-subst,.hljs-symbol,.hljs-regexp,.hljs-attribute,.hljs-deletion,.hljs-variable,.hljs-template-variable,.hljs-link,.hljs-bullet{color:#4c81c9}.hljs-emphasis{font-style:italic}


### PR DESCRIPTION
Fixes #1527

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
