### PR TITLE
chore(plugins/plugin-k8s): port kubectl to use mode registrar

### DIFF
--- a/plugins/plugin-k8s/src/lib/controller/describe.ts
+++ b/plugins/plugin-k8s/src/lib/controller/describe.ts
@@ -30,9 +30,6 @@ import createdOn from '../util/created-on'
 import { FinalState } from '../model/states'
 import { IKubeStatus, DefaultKubeStatus, IKubeMetadata, DefaultKubeMetadata, IKubeResource, IResource } from '../model/resource'
 
-import { addConditions } from '../view/modes/conditions'
-import { addPods } from '../view/modes/pods'
-import { addContainers } from '../view/modes/containers'
 import { statusButton } from '../view/modes/status'
 import { deleteResourceButton } from '../view/modes/crud'
 import { apply as addRelevantModes } from '../view/modes/registrar'
@@ -183,9 +180,9 @@ const renderDescribe = async (command: string, getCmd: string, describeCmd: stri
     const command = 'kubectl'
     const resource: IResource = { kind: yaml.kind, name: yaml.metadata.name, yaml }
     modes.push(statusButton(command, resource, FinalState.NotPendingLike))
-    addConditions(modes, command, resource)
-    addPods(modes, command, resource)
-    addContainers(modes, command, resource)
+
+    // consult the view registrar for registered view modes
+    // relevant to this resource
     addRelevantModes(modes, command, resource)
   }
   modes.push({

--- a/plugins/plugin-k8s/src/lib/controller/kubectl.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kubectl.ts
@@ -45,9 +45,6 @@ import { redactJSON, redactYAML } from '../view/redact'
 import { registry as formatters } from '../view/registry'
 import { preprocessTable, formatTable } from '../view/formatTable'
 import { deleteResourceButton } from '../view/modes/crud'
-import { addConditions } from '../view/modes/conditions'
-import { addPods } from '../view/modes/pods'
-import { addContainers } from '../view/modes/containers'
 import { statusButton, renderAndViewStatus } from '../view/modes/status'
 import { status as statusImpl } from './status'
 import { apply as addRelevantModes } from '../view/modes/registrar'
@@ -596,9 +593,8 @@ const executeLocally = (command: string) => (opts: IEvaluatorArgs) => new Promis
         const resource: IResource = { kind: command !== 'helm' && yaml.kind, name: entity, yaml }
         modes.push(statusButton(command, resource, FinalState.NotPendingLike))
 
-        addConditions(modes, command, resource)
-        addPods(modes, command, resource)
-        addContainers(modes, command, resource)
+        // consult the view registrar for registered view modes
+        // relevant to this resource
         addRelevantModes(modes, command, resource)
 
         deleteResourceButton(() => renderAndViewStatus(opts.tab, { command, resource, finalState: FinalState.OfflineLike }))

--- a/plugins/plugin-k8s/src/lib/view/modes/conditions.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/conditions.ts
@@ -22,24 +22,29 @@ import { formatMultiListResult } from '@kui-shell/core/webapp/views/table'
 import { ISidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
 import { Row, Table } from '@kui-shell/core/webapp/models/table'
 
-import IResource from '../../model/resource'
+import { IResource, IKubeResource } from '../../model/resource'
 
 import insertView from '../insert-view'
 import { formatTable } from '../formatMultiTable'
+
+import { ModeRegistration } from '@kui-shell/plugin-k8s/lib/view/modes/registrar'
 
 /**
  * Add a Conditions mode button to the given modes model, if called
  * for by the given resource.
  *
  */
-export const addConditions = (modes: Array<ISidecarMode>, command: string, resource: IResource) => {
-  try {
-    if (resource.yaml.status && resource.yaml.status.conditions) {
-      modes.push(conditionsButton(command, resource))
+export const conditionsMode: ModeRegistration = {
+  when: (resource: IKubeResource) => {
+    return resource.status && resource.status.conditions ? true : false
+  },
+  mode: (command: string, resource: IResource) => {
+    try {
+      return conditionsButton(command, resource)
+    } catch (err) {
+      debug('error rendering conditions button')
+      console.error(err)
     }
-  } catch (err) {
-    debug('error rendering conditions button')
-    console.error(err)
   }
 }
 

--- a/plugins/plugin-k8s/src/lib/view/modes/containers.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/containers.ts
@@ -24,12 +24,14 @@ import { formatMultiListResult } from '@kui-shell/core/webapp/views/table'
 import { Row, Table } from '@kui-shell/core/webapp/models/table'
 import { ISidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
 
-import IResource from '../../model/resource'
+import { IResource, IKubeResource } from '../../model/resource'
 
 import { TrafficLight } from '../../model/states'
 
 import insertView from '../insert-view'
 import { getActiveView, formatTable } from '../formatMultiTable'
+
+import { ModeRegistration } from '@kui-shell/plugin-k8s/lib/view/modes/registrar'
 
 /** for drilldown back button */
 const viewName = 'Containers'
@@ -39,15 +41,17 @@ const viewName = 'Containers'
  * for by the given resource.
  *
  */
-export const addContainers = (modes: Array<ISidecarMode>, command: string, resource: IResource) => {
-  try {
-    if (resource.yaml.spec && resource.yaml.spec.containers) {
-      const button = containersButton(command, resource)
-      modes.push(button)
+export const containersMode: ModeRegistration = {
+  when: (resource: IKubeResource) => {
+    return resource.spec && resource.spec.containers
+  },
+  mode: (command: string, resource: IResource) => {
+    try {
+      return containersButton(command, resource)
+    } catch (err) {
+      debug('error rendering containers button')
+      console.error(err)
     }
-  } catch (err) {
-    debug('error rendering containers button')
-    console.error(err)
   }
 }
 

--- a/plugins/plugin-k8s/src/lib/view/modes/pods.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/pods.ts
@@ -26,11 +26,13 @@ import { Table } from '@kui-shell/core/webapp/models/table'
 
 import { selectorToString } from '../../util/selectors'
 
-import IResource from '../../model/resource'
+import { IResource, IKubeResource } from '../../model/resource'
 import { TrafficLight } from '../../model/states'
 
 import insertView from '../insert-view'
 import { formatTable } from '../formatMultiTable'
+
+import { ModeRegistration } from '@kui-shell/plugin-k8s/lib/view/modes/registrar'
 
 /** for drilldown back button */
 const viewName = 'Pods'
@@ -40,15 +42,18 @@ const viewName = 'Pods'
  * the given resource.
  *
  */
-export const addPods = (modes: Array<ISidecarMode>, command: string, resource: IResource) => {
-  try {
+export const podMode: ModeRegistration = {
+  when: (resource: IKubeResource) => {
+    return resource.spec && resource.spec.selector ? true : false
+  },
+  mode: (command: string, resource: IResource) => {
     debug('addPods', resource)
-    if (resource.yaml.spec && resource.yaml.spec.selector) {
-      modes.push(podsButton(command, resource))
+    try {
+      return podsButton(command, resource)
+    } catch (err) {
+      debug('error rendering pods button')
+      console.error(err)
     }
-  } catch (err) {
-    debug('error rendering pods button')
-    console.error(err)
   }
 }
 

--- a/plugins/plugin-k8s/src/preload.ts
+++ b/plugins/plugin-k8s/src/preload.ts
@@ -20,11 +20,20 @@ const debug = Debug('plugins/k8s/preload')
 import { inBrowser } from '@kui-shell/core/core/capabilities'
 import { CommandRegistrar } from '@kui-shell/core/models/command'
 
+import { podMode } from './lib/view/modes/pods'
+import { conditionsMode } from './lib/view/modes/conditions'
+import { containersMode } from './lib/view/modes/containers'
+import registerSidecarMode from './lib/view/modes/registrar'
+
 /**
  * This is the module
  *
  */
 export default async (commandTree: CommandRegistrar) => {
+  registerSidecarMode(podMode) // show pods of deployments
+  registerSidecarMode(containersMode) // show containers of pods
+  registerSidecarMode(conditionsMode) // show conditions of a variety of resource kinds
+
   if (inBrowser()) {
     debug('preload for browser')
     const { restoreAuth } = await import('./lib/model/auth')


### PR DESCRIPTION
this is an internal chore/cleanup task

Fixes #1531

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
