### PR TITLE
style: fix typescript-eslint/member-delimiter-style rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,7 +44,11 @@
     "@typescript-eslint/explicit-member-accessibility": "off",
     "@typescript-eslint/indent": ["error", 2],
     "@typescript-eslint/interface-name-prefix": "off",
-    "@typescript-eslint/member-delimiter-style": "off",
+    "@typescript-eslint/member-delimiter-style": ["error", {
+      "multiline": {
+        "delimiter": "none"
+      }
+    }],
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-object-literal-type-assertion": "off",
     "@typescript-eslint/no-unused-vars": "off",

--- a/packages/app/src/core/find-file.ts
+++ b/packages/app/src/core/find-file.ts
@@ -30,7 +30,7 @@ import { inBrowser } from './capabilities'
  */
 interface ISpecialPath {
   prefix: string
-  filepath: string,
+  filepath: string
   command?: string
 }
 const specialPaths: ISpecialPath[] = [] // any special paths added via self.addPath
@@ -85,7 +85,7 @@ export const viewer = (prefix: string): string | never => {
  * Behaves like `findFile` with an extra call to `commandPrefix`
  *
  */
-export const findFileWithViewer = (filepath: string, { safe = false, keepRelative = false } = {}): { resolved: string, viewer?: string } => {
+export const findFileWithViewer = (filepath: string, { safe = false, keepRelative = false } = {}): { resolved: string; viewer?: string } => {
   if (!filepath) {
     if (!safe) {
       throw new Error('Please specify a file')

--- a/packages/app/src/core/plugins.ts
+++ b/packages/app/src/core/plugins.ts
@@ -61,7 +61,7 @@ export const scanForModules = async (dir: string, quiet = false, filter: Filter 
     const plugins = {}
     const preloads = {}
 
-    const doScan = ({ modules, moduleDir }: { modules: string[], moduleDir: string }) => {
+    const doScan = ({ modules, moduleDir }: { modules: string[]; moduleDir: string }) => {
       modules.forEach(module => {
         const modulePath = path.join(moduleDir, module)
 

--- a/packages/app/src/core/usage-error.ts
+++ b/packages/app/src/core/usage-error.ts
@@ -665,7 +665,7 @@ const format = async (message: UsageLike, options: IUsageOptions = new DefaultUs
 }
 
 interface IDetailedExample {
-  command: string,
+  command: string
   docs: string
 }
 
@@ -778,13 +778,13 @@ export interface IUsageModel {
 
   breadcrumb?: string
   title?: string
-  command?: string,
-  strict?: string,
-  docs?: string,
-  header?: string,
-  example?: string,
-  detailedExample?: IDetailedExample | IDetailedExample[],
-  sampleInputs?: IUsageRow[],
+  command?: string
+  strict?: string
+  docs?: string
+  header?: string
+  example?: string
+  detailedExample?: IDetailedExample | IDetailedExample[]
+  sampleInputs?: IUsageRow[]
   intro?: ITitledContent
   sections?: IUsageSection[]
   commandPrefix?: string

--- a/packages/app/src/main/headless-pretty-print.ts
+++ b/packages/app/src/main/headless-pretty-print.ts
@@ -69,7 +69,7 @@ export const setGraphicalShellIsOpen = () => {
  *
  */
 interface IPrettyOptions {
-  columnWidths?: { [key: number]: number },
+  columnWidths?: { [key: number]: number }
   extraColor?: string
 }
 class DefaultPrettyOptions implements IPrettyOptions {

--- a/packages/app/src/models/SubwindowPrefs.ts
+++ b/packages/app/src/models/SubwindowPrefs.ts
@@ -20,7 +20,7 @@ interface ISubwindowPrefs {
   synonymFor?: object
   width?: number
   height?: number
-  position?: { x: number, y: number },
+  position?: { x: number; y: number }
   bringYourOwnWindow?: () => void
 }
 

--- a/packages/app/src/models/command.ts
+++ b/packages/app/src/models/command.ts
@@ -155,7 +155,7 @@ export interface ICommandHandlerWithEvents extends IEvaluator {
   subtree: ICommandBase
   route: string
   options: ICommandOptions
-  success: (args: { tab: ITab, type: ExecType, command: string, isDrilldown: boolean, parsedOptions: { [ key: string ]: any } }) => void
+  success: (args: { tab: ITab; type: ExecType; command: string; isDrilldown: boolean; parsedOptions: { [ key: string ]: any } }) => void
   error: (command: string, err: CodedError) => CodedError
 }
 

--- a/packages/app/src/models/entity.ts
+++ b/packages/app/src/models/entity.ts
@@ -39,7 +39,7 @@ export interface IEntitySpec {
 
   version?: string
   namespace?: string
-  annotations?: { key: string, value: any }[]
+  annotations?: { key: string; value: any }[]
 }
 
 export interface IMessageBearingEntity {

--- a/packages/app/src/webapp/bottom-stripe.ts
+++ b/packages/app/src/webapp/bottom-stripe.ts
@@ -39,7 +39,7 @@ export interface ISidecarMode {
 
   selected?: boolean
   selectionController?: any
-  visibleWhen?: any,
+  visibleWhen?: any
   leaveBottomStripeAlone?: boolean
 
   // icon label?
@@ -57,7 +57,7 @@ export interface ISidecarMode {
   command?: any
   direct?: DirectViewController
 
-  execOptions?: IExecOptions,
+  execOptions?: IExecOptions
 
   defaultMode?: boolean
 

--- a/packages/app/src/webapp/cli.ts
+++ b/packages/app/src/webapp/cli.ts
@@ -54,7 +54,7 @@ import { ISidecarMode } from './bottom-stripe'
 interface ScrollOptions {
   when?: number
   which?: string
-  element?: HTMLElement,
+  element?: HTMLElement
   how?: string
   center?: boolean | ScrollIntoViewOptions
 }
@@ -348,7 +348,7 @@ export const createPopupContentContainer = (css: string[] = [], presentation?: P
 interface IPopupEntity {
   prettyType?: string
   modes?: ISidecarMode[]
-  badges?: IBadgeSpec[],
+  badges?: IBadgeSpec[]
   controlHeaders?: boolean | string[]
   presentation?: Presentation
   subtext?: Formattable
@@ -493,7 +493,7 @@ export const printResults = (block: HTMLElement, nextBlock: HTMLElement, tab: IT
     setStatus(block, 'valid-response')
   }
 
-  const render = async (response: Entity, { echo, resultDom }: { echo: boolean, resultDom: HTMLElement }) => {
+  const render = async (response: Entity, { echo, resultDom }: { echo: boolean; resultDom: HTMLElement }) => {
     if (response && response !== true) {
       if (isTable(response)) {
         await printTable(tab, response, resultDom, execOptions, parsedOptions)

--- a/packages/app/src/webapp/util/ascii-to-table.ts
+++ b/packages/app/src/webapp/util/ascii-to-table.ts
@@ -27,7 +27,7 @@ import { Cell, Row, Table } from '@kui-shell/core/webapp/models/table'
  * Find the column splits
  *
  */
-export const preprocessTable = (raw: string[]): { rows?: IPair[][], trailingString?: string }[] => {
+export const preprocessTable = (raw: string[]): { rows?: IPair[][]; trailingString?: string }[] => {
   debug('preprocessTable', raw)
 
   return raw.map(table => {

--- a/packages/app/src/webapp/views/sidecar.ts
+++ b/packages/app/src/webapp/views/sidecar.ts
@@ -627,7 +627,7 @@ export const linkify = (dom: Element): void => {
  */
 interface IBadgeOptions {
   css?: string
-  onclick?,
+  onclick?
   badgesDom: Element
 }
 class DefaultBadgeOptions implements IBadgeOptions {

--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -61,13 +61,13 @@ function getCachedSize (tab: ITab): ISize {
     return cachedSize
   }
 }
-function setCachedSize (tab: ITab, { rows, cols }: { rows: number, cols: number }) {
+function setCachedSize (tab: ITab, { rows, cols }: { rows: number; cols: number }) {
   tab['_kui_pty_cachedSize'] = { rows, cols, sidecarState: getSidecarState(tab), resizeGeneration }
 }
 
 interface HTerminal extends xterm.Terminal {
   _core: {
-    renderer: { _terminal: { cols: number, options: { letterSpacing: number }, charMeasure: { width: number } }, dimensions: { scaledCharWidth: number, actualCellWidth: number, actualCellHeight: number, canvasWidth: number, scaledCanvasWidth: number, scaledCellWidth: number } }
+    renderer: { _terminal: { cols: number; options: { letterSpacing: number }; charMeasure: { width: number } }; dimensions: { scaledCharWidth: number; actualCellWidth: number; actualCellHeight: number; canvasWidth: number; scaledCanvasWidth: number; scaledCellWidth: number } }
   }
 }
 
@@ -300,7 +300,7 @@ class Resizer {
  * Inject current font settings
  *
  */
-let cachedFontProperties: { fontFamily: string, fontSize: number }
+let cachedFontProperties: { fontFamily: string; fontSize: number }
 function getFontProperties (flush: boolean) {
   if (flush || !cachedFontProperties) {
     debug('computing font properties')
@@ -552,7 +552,7 @@ export const doExec = (tab: ITab, block: HTMLElement, cmdline: string, argvNoOpt
         }
       }
 
-      const notifyOfWriteCompletion = (evt: { start: number, end: number }) => {
+      const notifyOfWriteCompletion = (evt: { start: number; end: number }) => {
         if (pendingWrites > 0) {
           pendingWrites = 0
           if (cbAfterPendingWrites) {
@@ -567,7 +567,7 @@ export const doExec = (tab: ITab, block: HTMLElement, cmdline: string, argvNoOpt
       // receive updates after we receive a process exit event; but we
       // will always receive a `refresh` event when the animation
       // frame is done. see https://github.com/IBM/kui/issues/1272
-      terminal.on('refresh', (evt: { start: number, end: number }) => {
+      terminal.on('refresh', (evt: { start: number; end: number }) => {
         // debug('refresh', evt.start, evt.end)
         resizer.hideTrailingEmptyBlanks()
         doScroll()

--- a/plugins/plugin-core-support/src/lib/tab-completion.ts
+++ b/plugins/plugin-core-support/src/lib/tab-completion.ts
@@ -82,7 +82,7 @@ const isDirectory = (filepath: string): Promise<boolean> => new Promise((resolve
  * prompt, which is an <input>.
  *
  */
-const complete = (match: string, prompt: HTMLInputElement, { temporaryContainer = undefined, partial = temporaryContainer.partial, dirname = temporaryContainer.dirname, doEscape = false, addSpace = false }: { temporaryContainer?: TemporaryContainer, partial?: string, dirname?: false | string, doEscape?: boolean, addSpace?: boolean }) => {
+const complete = (match: string, prompt: HTMLInputElement, { temporaryContainer = undefined, partial = temporaryContainer.partial, dirname = temporaryContainer.dirname, doEscape = false, addSpace = false }: { temporaryContainer?: TemporaryContainer; partial?: string; dirname?: false | string; doEscape?: boolean; addSpace?: boolean }) => {
   debug('completion', match, partial, dirname)
 
   // in case match includes partial as a prefix

--- a/plugins/plugin-editor/src/lib/cmds/edit.ts
+++ b/plugins/plugin-editor/src/lib/cmds/edit.ts
@@ -67,7 +67,7 @@ export const edit = (tab: ITab, entity: IEditorEntity, options: IEditorOptions) 
  * Command handler for `edit <entity>`
  *
  */
-const editCmd = async ({ tab, argvNoOptions = [], parsedOptions = {}, execOptions = new DefaultExecOptions() }: { tab: ITab, argvNoOptions: string[], parsedOptions: IEditorOptions, execOptions: IExecOptions }) => {
+const editCmd = async ({ tab, argvNoOptions = [], parsedOptions = {}, execOptions = new DefaultExecOptions() }: { tab: ITab; argvNoOptions: string[]; parsedOptions: IEditorOptions; execOptions: IExecOptions }) => {
   debug('edit command execution started', execOptions)
 
   // maybe the caller is passing us the name and entity programmatically?

--- a/plugins/plugin-grid/src/lib/cmds/grid.ts
+++ b/plugins/plugin-grid/src/lib/cmds/grid.ts
@@ -455,7 +455,7 @@ const minTimestamp = activations => {
  * Render the grid as a timeline
  *
  */
-const drawAsTimeline = (tab: ITab, timelineData: { activations: Record<string, any>, nBuckets: number }, content: HTMLElement, gridGrid: HTMLElement, zoomLevelForDisplay: number, options) => {
+const drawAsTimeline = (tab: ITab, timelineData: { activations: Record<string, any>; nBuckets: number }, content: HTMLElement, gridGrid: HTMLElement, zoomLevelForDisplay: number, options) => {
   debug('drawAsTimeline', zoomLevelForDisplay)
 
   const { activations, nBuckets } = timelineData

--- a/plugins/plugin-grid/src/lib/util.ts
+++ b/plugins/plugin-grid/src/lib/util.ts
@@ -297,7 +297,7 @@ export const displayTimeRange = ({ minTime, maxTime, totalCount }, container) =>
  *
  */
 export interface IHeader {
-  leftHeader: Element,
+  leftHeader: Element
   rightHeader: Element
 }
 export const prepareHeader = (tab: ITab, isRedraw = false): IHeader => {

--- a/plugins/plugin-k8s/src/lib/model/resource.ts
+++ b/plugins/plugin-k8s/src/lib/model/resource.ts
@@ -62,7 +62,7 @@ interface IOwnerReferences {
 export interface IKubeMetadata {
   name: string
   namespace?: string
-  labels?: { [key: string]: string },
+  labels?: { [key: string]: string }
   annotations?: object
   creationTimestamp?: string
   generation?: string

--- a/plugins/plugin-k8s/src/lib/model/states.ts
+++ b/plugins/plugin-k8s/src/lib/model/states.ts
@@ -89,9 +89,9 @@ const isOfflineLike = (state: State): boolean => stateGroups[FinalState.OfflineL
 const isPendingLike = (state: State): boolean => !isOnlineLike(state) && !isOfflineLike(state)
 
 export interface IStatus {
-  state?: State,
-  phase?: State,
-  message?: string,
+  state?: State
+  phase?: State
+  message?: string
   startTime?: string
 }
 

--- a/plugins/plugin-openwhisk-debug/src/plugin.ts
+++ b/plugins/plugin-openwhisk-debug/src/plugin.ts
@@ -544,8 +544,8 @@ const init = async (kind, spinnerDiv) => {
  *
  */
 interface IProtoAction {
-  name: string,
-  kind?: string,
+  name: string
+  kind?: string
   input: Object
 }
 const getActionNameAndInputFromActivations = async (actId, spinnerDiv): Promise<IProtoAction> => {
@@ -1062,14 +1062,14 @@ const createTempFolder = () => new Promise((resolve, reject) => {
  *
  *
  */
-const displayAsActivation = async (tab: ITab, sessionType: string, { kind, name: actionName, name }: { kind: string, actionName: string, name: string }, start: number, protoActivation?: IProtoActivation) => {
+const displayAsActivation = async (tab: ITab, sessionType: string, { kind, name: actionName, name }: { kind: string; actionName: string; name: string }, start: number, protoActivation?: IProtoActivation) => {
   try {
     // when the session ended
     const end = Date.now()
 
     const ns = await qexec('wsk namespace current')
 
-    const annotations: { key: string, value: string | number | boolean }[] = [
+    const annotations: { key: string; value: string | number | boolean }[] = [
       { key: 'path', value: `${ns}/${name}` },
       { key: 'kind', value: kind }
     ]

--- a/plugins/plugin-openwhisk/src/lib/cmds/actions/let.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/actions/let.ts
@@ -92,7 +92,7 @@ const isRemote = location => location.includes('https:') || location.includes('h
  *
  */
 interface IRemote {
-  location: string,
+  location: string
   removeWhenDone: boolean
 }
 const fetchRemote = (location, mimeType): Promise<IRemote> => new Promise((resolve, reject) => {
@@ -537,12 +537,12 @@ export default async (commandTree, wsk) => {
      *
      */
     interface IKeyValue {
-      key: string,
+      key: string
       value: string
     }
     interface IEntity {
-      name: string,
-      namespace?: string,
+      name: string
+      namespace?: string
       annotations?: IKeyValue[]
     }
     const furlSequenceComponent = (parentActionName: string) => (component: string, idx: number): Promise<IEntity> => {

--- a/plugins/plugin-openwhisk/src/lib/cmds/copy.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/copy.ts
@@ -49,7 +49,7 @@ const usage = (type: string, command: string) => ({
  * This is the core logic
  *
  */
-const copy = (type: string) => (op: string) => ({ block: retryOK, argvNoOptions: argv, parsedOptions: options }: { block: boolean | Element, argvNoOptions: string[], parsedOptions: ParsedOptions }) => {
+const copy = (type: string) => (op: string) => ({ block: retryOK, argvNoOptions: argv, parsedOptions: options }: { block: boolean | Element; argvNoOptions: string[]; parsedOptions: ParsedOptions }) => {
   debug(`${type} ${op}`)
 
   const idx = argv.indexOf(op) + 1

--- a/plugins/plugin-openwhisk/src/lib/cmds/load-test.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/load-test.ts
@@ -189,9 +189,9 @@ const loadtest = (verb: string) => ({ argv: argvWithOptions, argvNoOptions: argv
 
   interface ITally {
     durations: {
-      success: number[],
+      success: number[]
       failure: number[]
-    },
+    }
     numErrors?: number
   }
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/popup.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/popup.ts
@@ -78,7 +78,7 @@ const waitForDelete = function (this: common.ISuite, spec: IDeleteSpec) {
 
 /** wait for the invocationion to finish */
 interface IInvokeSpec {
-  name: string,
+  name: string
   result: object
 }
 const waitForInvoke = function (this: common.ISuite, spec: IInvokeSpec) {

--- a/plugins/plugin-tekton/src/lib/tekton2graph.ts
+++ b/plugins/plugin-tekton/src/lib/tekton2graph.ts
@@ -69,8 +69,8 @@ interface INode {
   readonly visited?: string[]
   children?: readonly INode[]
   edges?: readonly IEdge[]
-  deployed?: boolean,
-  nChildren: number,
+  deployed?: boolean
+  nChildren: number
   nParents: number
 }
 
@@ -100,7 +100,7 @@ const defaultCharHeight = 10
  * @return a blank IGraph instance with optional "children" subgraphs
  *
  */
-const makeGraph = (label = 'root', { children, tooltip, tooltipColor, type, onclick }: { children: INode[], tooltip?: string, tooltipColor?: string, type?: string, onclick?: string } = { children: [] }): IGraph => {
+const makeGraph = (label = 'root', { children, tooltip, tooltipColor, type, onclick }: { children: INode[]; tooltip?: string; tooltipColor?: string; type?: string; onclick?: string } = { children: [] }): IGraph => {
   return {
     id: label,
     label,

--- a/plugins/plugin-tekton/src/model/resource.ts
+++ b/plugins/plugin-tekton/src/model/resource.ts
@@ -26,8 +26,8 @@ export interface Step {
 export interface Task extends IKubeResource {
   spec: {
     inputs: {
-      resources: { name: string, type: string, targetPath: string }[],
-      params: { name: string, description: string, default: string }[]
+      resources: { name: string; type: string; targetPath: string }[]
+      params: { name: string; description: string; default: string }[]
     }
     steps: Step[]
   }

--- a/plugins/plugin-tutorials/src/lib/cmds/modes.ts
+++ b/plugins/plugin-tutorials/src/lib/cmds/modes.ts
@@ -18,15 +18,15 @@ const { apiToDefaultParams } = require('./api')
 const { modCmd } = require('./util')
 
 interface IMode {
-  mode: string,
-  label?: string,
-  command: Function,
-  actAsButton?: boolean,
-  fontawesome?: string,
-  flush?: string,
-  balloon?: string,
-  balloonLength?: string,
-  echo?: boolean,
+  mode: string
+  label?: string
+  command: Function
+  actAsButton?: boolean
+  fontawesome?: string
+  flush?: string
+  balloon?: string
+  balloonLength?: string
+  echo?: boolean
   noHistory?: boolean
 }
 

--- a/plugins/plugin-wskflow/src/lib/graph2doms.ts
+++ b/plugins/plugin-wskflow/src/lib/graph2doms.ts
@@ -43,7 +43,7 @@ const wfColorAct = {
 
 const containerId = 'wskflowDiv'
 
-export default function graph2doms (tab: ITab, JSONgraph: Record<string, any>, ifReuseContainer?: Element, activations?: ActivationLike[], { layoutOptions = {}, composites = { label: { fontSize: '4px', offset: { x: 0, y: -2 } } } }: { layoutOptions?: Record<string, string | boolean | number>, composites?: { label: { fontSize: string, offset: { x: number, y: number } } } } = {}) {
+export default function graph2doms (tab: ITab, JSONgraph: Record<string, any>, ifReuseContainer?: Element, activations?: ActivationLike[], { layoutOptions = {}, composites = { label: { fontSize: '4px', offset: { x: 0, y: -2 } } } }: { layoutOptions?: Record<string, string | boolean | number>; composites?: { label: { fontSize: string; offset: { x: number; y: number } } } } = {}) {
   const maxLabelLength: number = (JSONgraph.properties && JSONgraph.properties.maxLabelLength) || defaultMaxLabelLength
   const defaultFontSize: string = (JSONgraph.properties && JSONgraph.properties.fontSize) || '7px'
 


### PR DESCRIPTION
Fixed automatically with the ESLint `--fix` option.

Continue with #1343.