### PR TITLE
fix(plugins/plugin-k8s): sidecar deletion button has incorrect direct…

### DIFF
--- a/plugins/plugin-k8s/src/lib/view/modes/button.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/button.ts
@@ -15,12 +15,13 @@
  */
 
 import repl = require('@kui-shell/core/core/repl')
+import { ITab } from '@kui-shell/core/webapp/cli'
 
 const makeButton = (overrides, fn?) => Object.assign({}, {
-  direct: async (args) => {
+  direct: async (tab: ITab, args) => {
     const { prettyType: kind = '-f', name, resourceName = name, packageName, namespace = packageName } = args
     const response = await repl.pexec(`kubectl ${overrides.mode} ${kind} ${resourceName} ${namespace ? '-n ' + namespace : ''}`,
-      { noStatus: !!fn })
+      { noStatus: !!fn, tab })
     return fn ? fn(response) : response
   },
   echo: true,

--- a/plugins/plugin-k8s/src/test/k8s1/namespace.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/namespace.ts
@@ -127,6 +127,29 @@ describe('electron namespace', function (this: common.ISuite) {
       })
     }
 
+    const deleteViaButton = (ns: string) => {
+      it('should delete the namespace via clicking deletion button in the sidecar', () => {
+        return cli.do(`${kubectl} get ns ${ns} -o yaml`, this.app)
+          .then(async (res) => {
+            await cli.expectJustOK(res)
+            await sidecar.expectOpen(this.app)
+
+            const deletionButton = selectors.SIDECAR_MODE_BUTTON('delete')
+
+            await this.app.client.waitForExist(deletionButton)
+            await this.app.client.click(deletionButton)
+
+            // exepct a deletion table
+            const deletionEntitySelector = await cli.expectOKWithCustom({ selector: selectors.BY_NAME(ns) })({ app: this.app, count: res.count + 1 })
+
+            const expectOffline = `${deletionEntitySelector} span:not(.repeating-pulse) badge.red-background`
+
+            return this.app.client.waitForExist(expectOffline)
+          })
+          .catch(common.oops(this))
+      })
+    }
+
     //
     // now start the tests
     //
@@ -137,6 +160,6 @@ describe('electron namespace', function (this: common.ISuite) {
     createPod(ns1)
     createPod(ns2)
     deleteIt(ns1)
-    deleteIt(ns2)
+    deleteViaButton(ns2)
   })
 })


### PR DESCRIPTION
… function

Fixes #1554

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
