### PR TITLE
fix(plugins/plugin-bash-like): ls versus wildcards

### DIFF
--- a/plugins/plugin-bash-like/src/lib/cmds/bash-like.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/bash-like.ts
@@ -25,6 +25,7 @@ const debug = Debug('plugins/bash-like/cmds/general')
 
 import * as fs from 'fs'
 import * as path from 'path'
+import { exec } from 'child_process'
 
 import expandHomeDir from '@kui-shell/core/util/home'
 import { inBrowser, isHeadless } from '@kui-shell/core/core/capabilities'
@@ -134,15 +135,9 @@ export const doShell = (argv: string[], options, execOptions?: IExecOptions) => 
 
 export const doExec = (cmdLine: string, execOptions: IExecOptions) => new Promise(async (resolve, reject) => {
   // purposefully imported lazily, so that we don't spoil browser mode (where shell is not available)
-  const shell = await import('shelljs')
 
-  const proc = shell.exec(cmdLine, {
-    async: true,
-    silent: true,
-    env: Object.assign({}, process.env, execOptions['env'] || {}, {
-      IBMCLOUD_COLOR: true,
-      IBMCLOUD_VERSION_CHECK: false
-    })
+  const proc = exec(cmdLine, {
+    env: Object.assign({}, process.env, execOptions['env'] || {})
   })
 
   // accumulate doms from the output of the subcommand

--- a/plugins/plugin-bash-like/src/test/bash-like/bash-like.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/bash-like.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { ISuite } from '@kui-shell/core/tests/lib/common'
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
-const { cli, selectors, sidecar } = ui
+const { cli, selectors } = ui
 const { localDescribe } = common
 
 import * as assert from 'assert'
@@ -37,7 +36,7 @@ const hasExe = (exe: string): Promise<boolean> => new Promise(resolve => {
   exec(exe, err => resolve(!err))
 })
 
-localDescribe('shell commands', function (this: ISuite) {
+localDescribe('shell commands', function (this: common.ISuite) {
   before(common.before(this))
   after(common.after(this))
 

--- a/plugins/plugin-bash-like/src/test/bash-like/ls.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/ls.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as common from '@kui-shell/core/tests/lib/common'
+import * as ui from '@kui-shell/core/tests/lib/ui'
+const { cli } = ui
+const { localDescribe } = common
+
+localDescribe('directory listing', function (this: common.ISuite) {
+  before(common.before(this))
+  after(common.after(this))
+
+  it('should use ls ../../', () => cli.do(`ls ../../`, this.app)
+    .then(cli.expectOKWith('package.json'))
+    .catch(common.oops(this)))
+
+  it('should use ls ../../README.md', () => cli.do(`ls ../../README.md`, this.app)
+    .then(cli.expectOKWith('README.md'))
+    .catch(common.oops(this)))
+
+  const Cs = ['CHANGELOG.md', 'CONTRIBUTING.md']
+  Cs.forEach(expect => {
+    it(`should use ls ../../C* and expect ${expect}`, () => cli.do(`ls ../../C*`, this.app)
+      .then(cli.expectOKWith(expect))
+      .catch(common.oops(this)))
+  })
+
+  const CsandP = Cs.concat(['package.json'])
+  CsandP.forEach(expect => {
+    it('should use ls ../../C* ../package.json', () => cli.do(`ls ../../C* ../../package.json`, this.app)
+      .then(cli.expectOKWith(expect))
+      .catch(common.oops(this)))
+  })
+
+  const CsandT = Cs.concat(['tools'])
+  CsandT.forEach(expect => {
+    it('should use ls -d ../../C* ../tool*', () => cli.do(`ls -d ../../C* ../../tool*`, this.app)
+      .then(cli.expectOKWith(expect))
+      .catch(common.oops(this)))
+  })
+})


### PR DESCRIPTION
Fixes #1557

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
