### PR TITLE
fix: ascii-to-table with duplicate final column

### DIFF
--- a/packages/app/src/webapp/util/ascii-to-table.ts
+++ b/packages/app/src/webapp/util/ascii-to-table.ts
@@ -47,10 +47,12 @@ export const preprocessTable = (raw: string[]): { rows?: IPair[][], trailingStri
         ? { offset: 0, prefix: '' }
         : { offset: 1, prefix: ' ' }
 
-      jdx = header.indexOf(prefix + headerCells[idx] + ' ', jdx)
-      if (jdx < 0) {
+      const newJdx = header.indexOf(prefix + headerCells[idx] + ' ', jdx)
+      if (newJdx < 0) {
         // last column
         jdx = header.indexOf(' ' + headerCells[idx], jdx)
+      } else {
+        jdx = newJdx
       }
       columnStarts.push(jdx + offset)
     }

--- a/plugins/plugin-bash-like/src/test/bash-like/pty-auto-table.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/pty-auto-table.ts
@@ -19,6 +19,10 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 const { cli, keys, selectors, sidecar, sleep } = ui
 const { dockerDescribe } = common
 
+import { existsSync, unlinkSync } from 'fs'
+import { dirname, join } from 'path'
+const ROOT = dirname(require.resolve('@kui-shell/plugin-bash-like/package.json'))
+
 dockerDescribe('xterm auto-table', function (this: common.ISuite) {
   before(common.before(this))
   after(common.after(this))
@@ -27,6 +31,10 @@ dockerDescribe('xterm auto-table', function (this: common.ISuite) {
   // can recognize it as new in our docker images call
   const alpineVersion = '3.6.5'
   const alpine = `alpine:${alpineVersion}`
+
+  it('should cat a table from a table and have it displayed as a table', () => cli.do(`cat ${join(ROOT, 'tests/data/table-with-duplicate-columns.txt')}`, this.app)
+    .then(cli.expectOKWith('reviews-v1v2-e2etestcase1-1'))
+    .catch(common.oops(this)))
 
   it('should remove the previous alpine, from previous tests', () => cli.do(`docker rmi ${alpine}`, this.app)
     .catch(common.oops(this)))

--- a/plugins/plugin-bash-like/tests/data/table-with-duplicate-columns.txt
+++ b/plugins/plugin-bash-like/tests/data/table-with-duplicate-columns.txt
@@ -1,0 +1,2 @@
+NAME                          COMPLETED  STATUS                        BASELINE    PERCENTAGE  CANARY      PERCENTAGE
+reviews-v1v2-e2etestcase1-1   Unknown    Canary deployment is missing  reviews-v1  0           reviews-v2  0

--- a/plugins/plugin-k8s/src/lib/view/formatTable.ts
+++ b/plugins/plugin-k8s/src/lib/view/formatTable.ts
@@ -170,12 +170,18 @@ export const preprocessTable = (raw: string[]) => {
     const headerCells = header.split(/(\t|\s\s)+\s?/).filter(x => x && !x.match(/(\t|\s\s)/))
     const columnStarts: number[] = []
     for (let idx = 0, jdx = 0; idx < headerCells.length; idx++) {
-      jdx = header.indexOf(headerCells[idx] + ' ', jdx)
-      if (jdx < 0) {
+      const { offset, prefix } = idx === 0
+        ? { offset: 0, prefix: '' }
+        : { offset: 1, prefix: ' ' }
+
+      const newJdx = header.indexOf(prefix + headerCells[idx] + ' ', jdx)
+      if (newJdx < 0) {
         // last column
-        jdx = header.indexOf(headerCells[idx], jdx)
+        jdx = header.indexOf(' ' + headerCells[idx], jdx)
+      } else {
+        jdx = newJdx
       }
-      columnStarts.push(jdx)
+      columnStarts.push(jdx + offset)
     }
 
     debug('columnStarts', columnStarts, headerCells)


### PR DESCRIPTION
Fixes #1561

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
