### PR TITLE
style(plugins-proxy-support): lint unused-vars

### DIFF
--- a/plugins/plugin-proxy-support/.eslintrc.json
+++ b/plugins/plugin-proxy-support/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@typescript-eslint/no-unused-vars": 1
+  }
+}

--- a/plugins/plugin-proxy-support/src/lib/proxy-executor.ts
+++ b/plugins/plugin-proxy-support/src/lib/proxy-executor.ts
@@ -19,12 +19,11 @@ import * as Debug from 'debug'
 import UsageError from '@kui-shell/core/core/usage-error'
 import { IReplEval, DirectReplEval } from '@kui-shell/core/core/repl'
 import { getValidCredentials } from '@kui-shell/core/core/capabilities'
-import { IExecOptions, DefaultExecOptions } from '@kui-shell/core/models/execOptions'
+import { IExecOptions } from '@kui-shell/core/models/execOptions'
 import { config } from '@kui-shell/core/core/settings'
 
 import * as needle from 'needle'
 const debug = Debug('plugins/proxy-support/executor')
-import url = require('url')
 
 /**
  * The proxy server configuration.

--- a/plugins/plugin-proxy-support/src/preload.ts
+++ b/plugins/plugin-proxy-support/src/preload.ts
@@ -17,14 +17,13 @@
 import * as Debug from 'debug'
 
 import { inBrowser, assertHasProxy, assertLocalAccess } from '@kui-shell/core/core/capabilities'
-import { CommandRegistrar } from '@kui-shell/core/models/command'
 const debug = Debug('plugins/proxy-support/preload')
 
 /**
  * This is the module
  *
  */
-export default async (commandTree: CommandRegistrar) => {
+export default async () => {
   if (inBrowser()) {
     const { config } = await import('@kui-shell/core/core/settings')
     debug('config', config)

--- a/plugins/plugin-tutorials/src/lib/cmds/list.ts
+++ b/plugins/plugin-tutorials/src/lib/cmds/list.ts
@@ -54,7 +54,6 @@ const doList = () => new Promise((resolve, reject) => {
           return
         }
 
-        const { skills } = await import('@kui-shell/plugin-tutorials/samples/@tutorials/' + name + '/tutorial.json')
         const attributes = []
 
         // add a "level" column


### PR DESCRIPTION
#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
