### PR TITLE
test: filter out ow-related tests for non-ow developers in local testing

### DIFF
--- a/packages/tests/bin/runMochaLayers.sh
+++ b/packages/tests/bin/runMochaLayers.sh
@@ -38,7 +38,7 @@ if [ -z "$API_HOST" ]; then
         . ~/.wskprops
         export API_HOST=$APIHOST
     elif [ -z "$LAYERS" ]; then
-        export LAYERS="core bash-like core-support field-installed-plugins editor k8s"
+        export EXCLUDE_OW_TEST=true
     fi
 else
     echo "APIHOST=$API_HOST" > ~/.wskprops

--- a/packages/tests/bin/runTest.sh
+++ b/packages/tests/bin/runTest.sh
@@ -87,9 +87,17 @@ if [ -n "$LAYER" ]; then
         fi
     fi
 
-    TEST_SUITES=$(find "$TEST_SUITE_ROOT" -path "*/test/$LAYER" -maxdepth 5)
+    if [ -z $EXCLUDE_OW_TEST ]; then
+      TEST_SUITES=$(find "$TEST_SUITE_ROOT" -path "*/test/$LAYER" -maxdepth 5)
+    else
+      TEST_SUITES=$(find "$TEST_SUITE_ROOT" -path "*/test/$LAYER" ! -path "*/test/openwhisk*" ! -path "*/test/composer*" ! -path "*/test/grid" -maxdepth 5)
+    fi
 else
-    TEST_SUITES=$(find "$TEST_SUITE_ROOT" -path "*/test" -maxdepth 4)
+    if [ -z $EXCLUDE_OW_TEST ]; then
+      TEST_SUITES=$(find "$TEST_SUITE_ROOT" -path "*/test" -maxdepth 4)
+    else
+      TEST_SUITES=$(find "$TEST_SUITE_ROOT" -path "*/test/$LAYER" ! -path "*/test/openwhisk*" ! -path "*/test/composer*" ! -path "*/test/grid"  -maxdepth 4)
+    fi
 fi
 
 echo "Running these test suites: $TEST_SUITES"


### PR DESCRIPTION
Fixes #1591

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
