### PR TITLE
style(plugins-bash-like): lint unused-vars

### DIFF
--- a/plugins/plugin-bash-like/.eslintrc.json
+++ b/plugins/plugin-bash-like/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@typescript-eslint/no-unused-vars": 1
+  }
+}

--- a/plugins/plugin-bash-like/src/lib/cmds/catchall.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/catchall.ts
@@ -18,13 +18,13 @@ import * as Debug from 'debug'
 const debug = Debug('plugins/bash-like/cmds/catchall')
 
 import { inBrowser, isHeadless, hasProxy } from '@kui-shell/core/core/capabilities'
-import { CommandRegistrar, IEvaluatorArgs } from '@kui-shell/core/models/command'
+import { IEvaluatorArgs } from '@kui-shell/core/models/command'
 
 /**
  * Command handler that dispatches to an outer shell
  *
  */
-export const dispatchToShell = async ({ tab, block, command, argv, argvNoOptions, execOptions, parsedOptions, createOutputStream }: IEvaluatorArgs) => {
+export const dispatchToShell = async ({ tab, block, command, argvNoOptions, execOptions, parsedOptions, createOutputStream }: IEvaluatorArgs) => {
   debug('handling catchall', command)
 
   /** trim the first part of "/bin/sh: someNonExistentCommand: command not found" */

--- a/plugins/plugin-bash-like/src/lib/cmds/export.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/export.ts
@@ -23,7 +23,7 @@ import { key } from '@kui-shell/core/core/repl'
  * export command
  *
  */
-const exportCommand = ({ command, parsedOptions, execOptions }: IEvaluatorArgs) => {
+const exportCommand = ({ parsedOptions }: IEvaluatorArgs) => {
   const storage = JSON.parse(sessionStore().getItem(key)) || {}
 
   const tabId = getTabIndex(getCurrentTab())

--- a/plugins/plugin-bash-like/src/lib/cmds/git-commit.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/git-commit.ts
@@ -19,9 +19,7 @@ const debug = Debug('plugins/bash-like/cmds/git-commit')
 
 import { join } from 'path'
 import { writeFile } from 'fs'
-import { spawn } from 'child_process'
 
-import expandHomeDir from '@kui-shell/core/util/home'
 import eventBus from '@kui-shell/core/core/events'
 import { qexec } from '@kui-shell/core/core/repl'
 import { clearSelection as clearSidecar, showEntity as showInSidecar } from '@kui-shell/core/webapp/views/sidecar'
@@ -83,13 +81,12 @@ const doExec = ({ command, argvNoOptions, execOptions, tab }: IEvaluatorArgs) =>
  *
  */
 const doCommit = async (opts: IEvaluatorArgs) => {
-  const { tab, command, argvNoOptions, parsedOptions, execOptions } = opts
+  const { tab, command, argvNoOptions, parsedOptions } = opts
 
   if (argvNoOptions.length === 3 &&
       !(parsedOptions.F || parsedOptions.file ||
         parsedOptions.message || parsedOptions.m ||
         parsedOptions.help)) {
-    const file = argvNoOptions[argvNoOptions.length - 1]
     return new Promise(async (resolve, reject) => {
       try {
         const [ commentedStatus, toplevelDir ] = await Promise.all([ status(), toplevel() ])

--- a/plugins/plugin-bash-like/src/lib/cmds/git-diff.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/git-diff.ts
@@ -17,8 +17,6 @@
 import * as Debug from 'debug'
 const debug = Debug('plugins/bash-like/cmds/git-diff')
 
-import * as path from 'path'
-
 import { split } from '@kui-shell/core/core/repl'
 import { isPopup } from '@kui-shell/core/webapp/cli'
 import Presentation from '@kui-shell/core/webapp/views/presentation'
@@ -26,11 +24,9 @@ import { CommandRegistrar, IEvaluatorArgs } from '@kui-shell/core/models/command
 
 import { handleNonZeroExitCode } from '../util/exec'
 import { asSidecarEntity } from '../util/sidecar-support'
-import { onbranch, injectCSS } from '../util/git-support'
+import { onbranch } from '../util/git-support'
 
 const doDiff = async ({ command, execOptions }: IEvaluatorArgs) => new Promise(async (resolve, reject) => {
-  const injector = injectCSS()
-
   // purposefully imported lazily, so that we don't spoil browser mode (where shell is not available)
   const shell = await import('shelljs')
 

--- a/plugins/plugin-bash-like/src/lib/cmds/git-status.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/git-status.ts
@@ -21,15 +21,12 @@ import * as path from 'path'
 import { spawn } from 'child_process'
 
 import { partial, ITab } from '@kui-shell/core/webapp/cli'
-import { pexec } from '@kui-shell/core/core/repl'
 import pip from '@kui-shell/core/webapp/picture-in-picture'
 import { CommandRegistrar, IEvaluatorArgs } from '@kui-shell/core/models/command'
 
 import { handleNonZeroExitCode } from '../util/exec'
 import { asSidecarEntity } from '../util/sidecar-support'
 import { onbranch, injectCSS } from '../util/git-support'
-
-const modified = `<svg aria-hidden="true" class="d2h-icon d2h-changed" height="16" title="modified" version="1.1" viewBox="0 0 14 16" width="14"><path d="M13 1H1C0.45 1 0 1.45 0 2v12c0 0.55 0.45 1 1 1h12c0.55 0 1-0.45 1-1V2c0-0.55-0.45-1-1-1z m0 13H1V2h12v12zM4 8c0-1.66 1.34-3 3-3s3 1.34 3 3-1.34 3-3 3-3-1.34-3-3z"></path></svg>`
 
 /**
  * Look for modified: and turn them into git diff links

--- a/plugins/plugin-bash-like/src/lib/cmds/ls.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/ls.ts
@@ -22,7 +22,6 @@ import { dirname, isAbsolute, join } from 'path'
 
 import expandHomeDir from '@kui-shell/core/util/home'
 import * as repl from '@kui-shell/core/core/repl'
-import UsageError from '@kui-shell/core/core/usage-error'
 import { CommandRegistrar, IEvaluatorArgs, ParsedOptions } from '@kui-shell/core/models/command'
 import { Row, Table, TableStyle } from '@kui-shell/core/webapp/models/table'
 import { findFile, findFileWithViewer, isSpecialDirectory } from '@kui-shell/core/core/find-file'

--- a/plugins/plugin-bash-like/src/lib/util/git-support.ts
+++ b/plugins/plugin-bash-like/src/lib/util/git-support.ts
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-import * as Debug from 'debug'
-const debug = Debug('plugins/bash-like/util/git-support')
-
 import { dirname, join } from 'path'
-import { exec, spawn } from 'child_process'
 
 import { inBrowser } from '@kui-shell/core/core/capabilities'
-import { injectCSS as inject, injectScript } from '@kui-shell/core/webapp/util/inject'
+import { injectCSS as inject } from '@kui-shell/core/webapp/util/inject'
 
 /**
  * Load the CSS for diff2html
@@ -47,52 +43,19 @@ export const injectCSS = async () => {
  * Return git status, usually for consumption by a git commit
  *
  */
-export const status = (commentPrefix = '# ') => new Promise((resolve, reject) => {
-  const status = exec('git status', (err, status, stderr) => {
-    if (err) {
-      console.error(stderr)
-      reject(err)
-    } else {
-      debug('status', status)
-      const commentedStatus = status
-        .split(/\n/)
-        .map(line => `${commentPrefix}${line}`)
-        .join('\n')
-
-      resolve(commentedStatus)
-    }
-  })
-})
+export const status = () => new Promise(() => {})
 
 /**
  * Find the .git "toplevel" directory
  *
  */
-export const toplevel = (): Promise<string> => new Promise((resolve, reject) => {
-  const status = exec('git rev-parse --show-toplevel', (err, toplevel, stderr) => {
-    if (err) {
-      console.error(stderr)
-      reject(err)
-    } else {
-      resolve(toplevel.trim())
-    }
-  })
-})
+export const toplevel = (): Promise<string> => new Promise(() => {})
 
 /**
  * @return the current branch
  *
  */
-export const branch = (): Promise<string> => new Promise((resolve, reject) => {
-  const status = exec('git rev-parse --abbrev-ref HEAD', (err, branch, stderr) => {
-    if (err) {
-      console.error(stderr)
-      reject(err)
-    } else {
-      resolve(branch.trim())
-    }
-  })
-})
+export const branch = (): Promise<string> => new Promise(() => {})
 
 /**
  * @return "On branch <branch>"

--- a/plugins/plugin-bash-like/src/pty/copy-out.ts
+++ b/plugins/plugin-bash-like/src/pty/copy-out.ts
@@ -17,11 +17,9 @@
 import * as Debug from 'debug'
 const debug = Debug('plugins/bash-like/pty/copy-out')
 
-import * as fs from 'fs'
-import { exec } from 'child_process'
 import { basename, dirname, join } from 'path'
 import { dir as tmpDir } from 'tmp'
-import { exists, lstat, copy, ensureDir, readdir, remove, writeFile, stat } from 'fs-extra'
+import { exists, copy, ensureDir, readdir, stat } from 'fs-extra'
 
 /**
  * Copy one file out of the electron ASAR
@@ -92,25 +90,3 @@ const copyRecursive = async (src: string, dest: string) => {
     return copy(src, dest)
   }
 }
-
-/** plain file copy that is ASAR-friendly */
-const copyFile = (src: string, target: string): Promise<string> => new Promise<string>(async (resolve, reject) => {
-  debug('copyFile', src, target)
-
-  let targetFile = target
-
-  // if target is a directory a new file with the same name will be created
-  if (await exists(target)) {
-    if ((await lstat(target)).isDirectory()) {
-      targetFile = join(target, basename(src))
-    }
-  }
-
-  fs.readFile(src, (err, data) => {
-    if (err) {
-      reject(err)
-    } else {
-      resolve(writeFile(targetFile, data))
-    }
-  })
-})

--- a/plugins/plugin-bash-like/src/pty/server.ts
+++ b/plugins/plugin-bash-like/src/pty/server.ts
@@ -19,8 +19,8 @@
 
 import * as fs from 'fs'
 import { promisify } from 'util'
-import { dirname, join } from 'path'
-import { exec, spawn } from 'child_process'
+import { join } from 'path'
+import { exec } from 'child_process'
 import { createServer, Server } from 'https'
 
 import { Channel } from './channel'
@@ -91,9 +91,9 @@ export const disableBashSessions = async (): Promise<ExitHandler> => {
     }
   }
 
-  return async (exitCode: number) => { /* no-op */ }
+  return async () => { /* no-op */ }
 }
-const enableBashSessions = async (exitCode: number) => {
+const enableBashSessions = async () => {
   await promisify(fs.unlink)(BSD())
 }
 
@@ -275,8 +275,6 @@ export const main = async (N: number, server?: Server, preexistingPort?: number)
  */
 let count = 0
 // const children = []
-let cachedSelf
-let selfHome
 export default (commandTree: CommandRegistrar) => {
   commandTree.listen('/bash/websocket/open', ({ execOptions }) => new Promise(async (resolve, reject) => {
     const N = count++

--- a/plugins/plugin-bash-like/src/test/bash-like/bash-like.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/bash-like.ts
@@ -19,7 +19,6 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 const { cli, selectors } = ui
 const { localDescribe } = common
 
-import * as assert from 'assert'
 import { exec } from 'child_process'
 import { unlinkSync, rmdirSync } from 'fs'
 

--- a/plugins/plugin-bash-like/src/test/bash-like/blank-lines.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/blank-lines.ts
@@ -22,7 +22,7 @@
 import { ISuite } from '@kui-shell/core/tests/lib/common'
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localIt } = common
 
 describe('Comments and blank line handling', function (this: ISuite) {

--- a/plugins/plugin-bash-like/src/test/bash-like/cd.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/cd.ts
@@ -18,10 +18,10 @@ import expandHomeDir from '@kui-shell/core/util/home'
 import { ISuite } from '@kui-shell/core/tests/lib/common'
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
-const { cli, selectors, sidecar } = ui
+const { cli } = ui
 const { localDescribe } = common
 
-import { existsSync, unlinkSync } from 'fs'
+import { existsSync } from 'fs'
 import { dirname, join, normalize } from 'path'
 const ROOT = dirname(require.resolve('@kui-shell/core/tests/package.json'))
 const rootRelative = dir => join(ROOT, dir)

--- a/plugins/plugin-bash-like/src/test/bash-like/ctrl-c.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/ctrl-c.ts
@@ -19,7 +19,7 @@ import * as assert from 'assert'
 import { ISuite } from '@kui-shell/core/tests/lib/common'
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
-const { cli, selectors, sidecar } = ui
+const { cli, selectors } = ui
 const { localIt } = common
 
 describe('Cancel via Ctrl+C', function (this: ISuite) {

--- a/plugins/plugin-bash-like/src/test/bash-like/echo.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/echo.ts
@@ -17,7 +17,7 @@
 import { ISuite } from '@kui-shell/core/tests/lib/common'
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
-const { cli, selectors, sidecar } = ui
+const { cli } = ui
 const { localDescribe } = common
 
 localDescribe('echo command', function (this: ISuite) {

--- a/plugins/plugin-bash-like/src/test/bash-like/git-diff.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/git-diff.ts
@@ -16,10 +16,9 @@
 
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 import { copyFile, unlink, writeFile } from 'fs'
-import { dirname, join, normalize } from 'path'
 
 /** modify the top-level README.md, so that we can exhibit a git diff */
 const modifyTopLevelReadme = () => new Promise(async (resolve, reject) => {

--- a/plugins/plugin-bash-like/src/test/bash-like/headless-host.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/headless-host.ts
@@ -15,8 +15,6 @@
  */
 
 import * as common from '@kui-shell/core/tests/lib/common'
-import * as ui from '@kui-shell/core/tests/lib/ui'
-import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 import { cli } from '@kui-shell/core/tests/lib/headless'
 
 describe('bash-like host catchall', function (this: common.ISuite) {

--- a/plugins/plugin-bash-like/src/test/bash-like/pty-auto-table.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/pty-auto-table.ts
@@ -16,10 +16,9 @@
 
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
-const { cli, keys, selectors, sidecar, sleep } = ui
+const { cli } = ui
 const { dockerDescribe } = common
 
-import { existsSync, unlinkSync } from 'fs'
 import { dirname, join } from 'path'
 const ROOT = dirname(require.resolve('@kui-shell/plugin-bash-like/package.json'))
 

--- a/plugins/plugin-bash-like/src/test/bash-like/pty-copy-paste.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/pty-copy-paste.ts
@@ -16,7 +16,7 @@
 
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
-const { cli, keys, selectors, sidecar, sleep } = ui
+const { cli, keys, selectors } = ui
 const { localDescribe } = common
 
 import * as assert from 'assert'
@@ -41,8 +41,6 @@ localDescribe('xterm copy paste', function (this: common.ISuite) {
 
   it(`should echo ${emittedText}`, async () => {
     try {
-      const res = cli.do(`echo ${emittedText}`, this.app)
-
       // wait for the output to appear
       await this.app.client.waitForExist(rows(0))
 

--- a/plugins/plugin-bash-like/src/test/bash-like/vi.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/vi.ts
@@ -16,7 +16,7 @@
 
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
-const { cli, keys, selectors, sidecar, sleep } = ui
+const { cli, keys, selectors } = ui
 const { localDescribe } = common
 
 import * as assert from 'assert'


### PR DESCRIPTION
#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
