### PR TITLE
docs: remove the windows download link on installation page

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,9 +29,9 @@ However, currently, you will not be able to use Kui from your favorite
 terminal (such support should come soon); Kui's graphical shell offers
 a command line experience.
 
-[Kui-MacOS.tar.bz2](https://macos-tarball.kui-shell.org) **|** [Kui-Linux.zip](https://linux-zip.kui-shell.org) **|** [Kui-Windows.zip](https://win32-zip.kui-shell.org)
+[Kui-MacOS.tar.bz2](https://macos-tarball.kui-shell.org) **|** [Kui-Linux.zip](https://linux-zip.kui-shell.org)
 
-*Coming soon: MacOS .dmg, Linux .deb, Linux .rpm*
+*Coming soon: MacOS .dmg, Linux .deb, Linux .rpm, Windows .zip*
 
 ##### Example Download for MacOS double-clickable
 


### PR DESCRIPTION
Fixes #1603

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
