### PR TITLE
chore(packages/kui-builder): add esnext support to tsconfig.json

### DIFF
--- a/packages/kui-builder/tsconfig.json
+++ b/packages/kui-builder/tsconfig.json
@@ -8,6 +8,13 @@
     "experimentalDecorators": true,
     "resolveJsonModule": true,
     "baseUrl": "../..",
+    "lib": [
+      "dom",
+      "esnext",
+      "es6",
+      "dom.iterable",
+      "scripthost"
+    ],
     "paths": {
       "@kui-shell/core/tests/*": ["packages/app/tests/*"],
       "@kui-shell/settings/*": ["packages/app/build/*"],


### PR DESCRIPTION
Fixes #1607

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
