### PR TITLE
style(plugins-editor): lint unused-vars

### DIFF
--- a/plugins/plugin-editor/.eslintrc.json
+++ b/plugins/plugin-editor/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@typescript-eslint/no-unused-vars": 1
+  }
+}

--- a/plugins/plugin-editor/src/lib/cmds/edit.ts
+++ b/plugins/plugin-editor/src/lib/cmds/edit.ts
@@ -24,7 +24,6 @@ import { applyOverrides } from '../overrides'
 import { openEditor } from '../open'
 import { persisters } from '../persisters'
 
-import * as repl from '@kui-shell/core/core/repl'
 import { ITab } from '@kui-shell/core/webapp/cli'
 import { CommandRegistrar } from '@kui-shell/core/models/command'
 import { IExecOptions } from '@kui-shell/core/models/execOptions'

--- a/plugins/plugin-editor/src/lib/fetchers.ts
+++ b/plugins/plugin-editor/src/lib/fetchers.ts
@@ -24,7 +24,6 @@ import { findFile } from '@kui-shell/core/core/find-file'
 import { MetadataBearing } from '@kui-shell/core/models/entity'
 
 import { persisters } from './persisters'
-import { gotoReadonlyLocalFile } from './readonly'
 const debug = Debug('plugins/editor/fetchers')
 
 /** allows us to reassign a string code to a numeric one */

--- a/plugins/plugin-editor/src/lib/init/amd.ts
+++ b/plugins/plugin-editor/src/lib/init/amd.ts
@@ -45,7 +45,7 @@ export default (editorWrapper: HTMLElement, options) => {
   // widget
   //
   let editor
-  const ready = () => new Promise((resolve, reject) => {
+  const ready = () => new Promise((resolve) => {
     const iter = () => {
       if (typeof AMDLoader === 'undefined') {
         setTimeout(iter, 20)

--- a/plugins/plugin-editor/src/lib/init/esm.ts
+++ b/plugins/plugin-editor/src/lib/init/esm.ts
@@ -24,9 +24,6 @@ import languages from '../language-scan'
 import defaultMonacoOptions from './defaults'
 const debug = Debug('plugins/editor/init/esm')
 
-/** the monaco editor uses the AMD module loader, and smashes the global.require; we need to finagle it a bit */
-let amdRequire
-
 /** this is part of the finagling, to make sure we finagle only once */
 let initDone
 
@@ -60,7 +57,7 @@ export default (editorWrapper: HTMLElement, options) => {
   // widget
   //
   let editor
-  const ready = () => new Promise((resolve, reject) => {
+  const ready = () => new Promise((resolve) => {
     injectCSS({ css: require('monaco-editor/min/vs/editor/editor.main.css').toString(), key: 'editor.monaco.core' })
 
     /**

--- a/plugins/plugin-editor/src/lib/languages/composer-javascript.ts
+++ b/plugins/plugin-editor/src/lib/languages/composer-javascript.ts
@@ -97,7 +97,7 @@ export default monaco => ({
 
   provider: {
     triggerCharacters: ['.'],
-    provideCompletionItems: (model, position, token, context) => {
+    provideCompletionItems: (model, position) => {
       // Split everything the user has typed on the current line up at each space, and only look at the last word
       const lastChars = model.getValueInRange({ startLineNumber: position.lineNumber, startColumn: 0, endLineNumber: position.lineNumber, endColumn: position.column })
       const words = lastChars.replace('\t', '').split(' ')

--- a/plugins/plugin-editor/src/lib/open.ts
+++ b/plugins/plugin-editor/src/lib/open.ts
@@ -22,14 +22,13 @@ import * as events from 'events'
 import { ITab } from '@kui-shell/core/webapp/cli'
 import globalEventBus from '@kui-shell/core/core/events'
 import { inBrowser } from '@kui-shell/core/core/capabilities'
-import { IEntitySpec } from '@kui-shell/core/models/entity'
 import { removeAllDomChildren } from '@kui-shell/core/webapp/util/dom'
 import { injectCSS, uninjectCSS, injectScript } from '@kui-shell/core/webapp/util/inject'
 import { currentSelection, getSidecar, isVisible as isSidecarVisible, addSidecarHeaderIconText, addNameToSidecarHeader, addVersionBadge } from '@kui-shell/core/webapp/views/sidecar'
 
 import { IEntity as IEditorEntity } from './fetchers'
 import strings from '../i18n/strings'
-import { extension, language } from './file-types'
+import { language } from './file-types'
 const debug = Debug('plugins/editor/open')
 
 /**

--- a/plugins/plugin-editor/src/lib/readonly.ts
+++ b/plugins/plugin-editor/src/lib/readonly.ts
@@ -16,7 +16,7 @@
 
 import * as Debug from 'debug'
 
-import { showCustom, showEntity } from '@kui-shell/core/webapp/views/sidecar'
+import { showCustom } from '@kui-shell/core/webapp/views/sidecar'
 import * as repl from '@kui-shell/core/core/repl'
 import { ITab } from '@kui-shell/core/webapp/cli'
 const debug = Debug('plugins/editor/readonly')
@@ -25,7 +25,7 @@ const debug = Debug('plugins/editor/readonly')
  * Enter read-only mode
  *
  */
-export const gotoReadonlyLocalFile = ({ getEntity }) => async (tab: ITab, _) => {
+export const gotoReadonlyLocalFile = ({ getEntity }) => async (tab: ITab) => {
   const entity = await getEntity(tab)
   debug('readonly', entity.name, entity)
   return repl.pexec(`open ${repl.encodeComponent(entity.name)}`)
@@ -35,7 +35,7 @@ export const gotoReadonlyLocalFile = ({ getEntity }) => async (tab: ITab, _) => 
  * Enter edit mode
  *
  */
-export const edit = ({ getEntity, lock = undefined }) => async (tab: ITab, _) => {
+export const edit = ({ getEntity, lock = undefined }) => async (tab: ITab) => {
   const { namespace, name } = await getEntity(tab)
 
   return repl.qexec(`edit "/${namespace}/${name}"`, undefined, undefined, { custom: { getEntity, lock } })

--- a/plugins/plugin-editor/src/lib/util.ts
+++ b/plugins/plugin-editor/src/lib/util.ts
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-import * as Debug from 'debug'
-
 import { language } from './file-types'
 import { save, revert } from './persisters'
-const debug = Debug('plugins/editor/util')
 
 /**
  * Prepare a response for the REPL. Consumes the output of

--- a/plugins/plugin-editor/src/preload.ts
+++ b/plugins/plugin-editor/src/preload.ts
@@ -17,7 +17,6 @@
 import * as Debug from 'debug'
 
 import { isHeadless } from '@kui-shell/core/core/capabilities'
-import { CommandRegistrar } from '@kui-shell/core/models/command'
 const debug = Debug('plugins/editor/preload')
 debug('loading')
 
@@ -28,7 +27,7 @@ debug('done loading prereqs')
  * we're running in browser mode. It is slow to load.
  *
  */
-export default async (commandTree: CommandRegistrar) => {
+export default async () => {
   debug('initializing')
 
   if (!isHeadless()) {

--- a/plugins/plugin-editor/src/test/editor/edit.ts
+++ b/plugins/plugin-editor/src/test/editor/edit.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import { Application, SpectronClient } from 'spectron'
+import { Application } from 'spectron'
 import { ISuite } from '@kui-shell/core/tests/lib/common'
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
-import * as assert from 'assert'
 
 import { dirname, join } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-editor/tests/package.json'))
 


### PR DESCRIPTION
#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
