### PR TITLE
style(plugins-manager): lint unused-vars

### DIFF
--- a/plugins/plugin-manager/src/.eslintrc.json
+++ b/plugins/plugin-manager/src/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@typescript-eslint/no-unused-vars": 1
+  }
+}

--- a/plugins/plugin-manager/src/lib/cmds/install.ts
+++ b/plugins/plugin-manager/src/lib/cmds/install.ts
@@ -22,7 +22,6 @@ import * as path from 'path'
 import { exec, spawn } from 'child_process'
 import * as which from 'which'
 
-import * as repl from '@kui-shell/core/core/repl'
 import { userDataDir } from '@kui-shell/core/core/userdata'
 import { CommandRegistrar, IEvaluatorArgs } from '@kui-shell/core/models/command'
 import compile from '@kui-shell/core/core/plugin-assembler'
@@ -49,7 +48,7 @@ const doInstall = ({ argvNoOptions }: IEvaluatorArgs) => {
 
   // make a staging area for the npm install
   return new Promise((resolve, reject) => {
-    tmp.dir((err, pluginHome, cleanupDir) => {
+    tmp.dir((err, pluginHome) => {
       const cleanup = () => Promise.resolve(true)// fs.remove(pluginHome)//.then(cleanupDir, cleanupDir)
       const fail = err => {
         debug(err)

--- a/plugins/plugin-manager/src/lib/cmds/list.ts
+++ b/plugins/plugin-manager/src/lib/cmds/list.ts
@@ -68,7 +68,7 @@ const doList = () => {
   const type = 'plugins'
 
   return fs.pathExists(moduleDir)
-    .then(exists => fs.readdir(moduleDir)) // read the top-level directory contents
+    .then(() => fs.readdir(moduleDir)) // read the top-level directory contents
     .then(dirs => Promise.all(dirs.map(extractNested(moduleDir)))) // extract any @foo/bar nested plugins
     .then(flatten) // if there are nested plugins, we need to flatten the arrays
     .then(getVersions(moduleDir))

--- a/plugins/plugin-manager/src/plugin.ts
+++ b/plugins/plugin-manager/src/plugin.ts
@@ -16,8 +16,6 @@
 
 /* disabled for now; not compatible with webpack */
 
-import { CommandRegistrar } from '@kui-shell/core/models/command'
-
 /*
 const usagePerCommand = require('./usage')
 
@@ -40,7 +38,7 @@ const toUsage = (models, { commandPrefix, title, docs, breadcrumb = title }) => 
 }
 */
 
-export default (commandTree: CommandRegistrar) => {
+export default () => {
   /* disabled for now; not compatible with webpack */
 
   /* commandTree.subtree('/plugin', {


### PR DESCRIPTION
#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
