### PR TITLE
fix(plugins/plugin-core-support): sidecar screenshot of tables too wide

### DIFF
--- a/plugins/plugin-core-support/web/css/screenshot.css
+++ b/plugins/plugin-core-support/web/css/screenshot.css
@@ -13,7 +13,7 @@ body:not([data-presentation="FixedSize"]) tab.visible.screenshot-squish sidecar 
 body:not([data-presentation="FixedSize"]) tab.visible.screenshot-squish {
     flex: initial;
 }
-body:not([data-presentation="FixedSize"]) tab.visible.screenshot-squish .custom-content, body:not([data-presentation="FixedSize"]) tab.visible.screenshot-squish .sidecar-content {
+body:not([data-presentation="FixedSize"]) tab.visible.screenshot-squish sidecar .custom-content, body:not([data-presentation="FixedSize"]) tab.visible.screenshot-squish sidecar .sidecar-content {
     flex: initial;
 }
 


### PR DESCRIPTION
Fixes #1621

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
