### PR TITLE
chore(packages/kui-builder): pin some floating depenencies

### DIFF
--- a/packages/kui-builder/package.json
+++ b/packages/kui-builder/package.json
@@ -31,10 +31,10 @@
   },
   "dependencies": {
     "@types/debug": "4.1.4",
-    "@types/js-yaml": "^3.12.1",
+    "@types/js-yaml": "3.12.1",
     "@types/mkdirp-promise": "5.0.0",
     "@types/mocha": "5.2.7",
-    "@types/needle": "^2.0.4",
+    "@types/needle": "2.0.4",
     "@types/node": "12.0.4",
     "@types/swagger-schema-official": "2.0.16",
     "@types/webdriverio": "4.13.1",
@@ -47,16 +47,16 @@
     "typescript": "3.5.1"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^1.9.0",
-    "@typescript-eslint/parser": "^1.9.0",
-    "eslint": "^5.16.0",
-    "eslint-config-standard": "^12.0.0",
-    "eslint-plugin-import": "^2.17.3",
-    "eslint-plugin-node": "^9.1.0",
-    "eslint-plugin-promise": "^4.1.1",
-    "eslint-plugin-standard": "^4.0.0",
-    "husky": "^2.3.0",
-    "lint-staged": "^8.1.7"
+    "@typescript-eslint/eslint-plugin": "1.9.0",
+    "@typescript-eslint/parser": "1.9.0",
+    "eslint": "5.16.0",
+    "eslint-config-standard": "12.0.0",
+    "eslint-plugin-import": "2.17.3",
+    "eslint-plugin-node": "9.1.0",
+    "eslint-plugin-promise": "4.1.1",
+    "eslint-plugin-standard": "4.0.0",
+    "husky": "2.4.0",
+    "lint-staged": "8.1.7"
   },
   "kui": {
     "exclude": {


### PR DESCRIPTION
Fixes #1626

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
