### PR TITLE
feat(plugins/plugin-k8s): add a last applied tab for k8s resources

### DIFF
--- a/plugins/plugin-k8s/src/lib/view/modes/last-applied.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/last-applied.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Debug from 'debug'
+
+import { safeDump } from 'js-yaml'
+
+import { qexec as $$ } from '@kui-shell/core/core/repl'
+import { ITab } from '@kui-shell/core/webapp/cli'
+import drilldown from '@kui-shell/core/webapp/picture-in-picture'
+import { formatMultiListResult } from '@kui-shell/core/webapp/views/table'
+import { ISidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
+import { ICustomSpec } from '@kui-shell/core/webapp/views/sidecar'
+import { Table } from '@kui-shell/core/webapp/models/table'
+
+import { IResource, IKubeResource } from '../../model/resource'
+
+import { ModeRegistration } from '@kui-shell/plugin-k8s/lib/view/modes/registrar'
+
+const debug = Debug('k8s/view/modes/last-applied')
+
+/**
+ * Add a Pods mode button to the given modes model, if called for by
+ * the given resource.
+ *
+ */
+export const lastAppliedMode: ModeRegistration = {
+  when: hasLastApplied,
+  mode: (command: string, resource: IResource) => {
+    debug('lastApplied', resource)
+    try {
+      return {
+        mode: 'last applied',
+        leaveBottomStripeAlone: true,
+        direct: {
+          plugin: 'k8s',
+          module: 'lib/view/modes/last-applied',
+          operation: 'renderAndViewLastApplied',
+          parameters: { command, resource }
+        }
+      }
+    } catch (err) {
+      debug('error rendering pods button')
+      console.error(err)
+    }
+  }
+}
+
+/**
+ * Extract the last-applied-configuration annotation
+ *
+ */
+function getLastAppliedRaw (resource: IKubeResource): string {
+  // kube stores the last applied configuration (if any) in a raw json string
+  return resource.metadata.annotations &&
+    resource.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration']
+}
+
+/**
+ * @return whether the given resource has a last applied configuration annotation
+ *
+ */
+function hasLastApplied (resource: IKubeResource): boolean {
+  return getLastAppliedRaw(resource) !== undefined
+}
+
+interface IParameters {
+  command: string
+  resource: IResource
+}
+
+export const renderAndViewLastApplied = async (tab: ITab, parameters: IParameters) => {
+  const { command, resource } = parameters
+  debug('renderAndViewLastApplied', command, resource)
+
+  return toCustomSpec(getLastAppliedRaw(resource.resource))
+}
+
+function toCustomSpec (raw: string): ICustomSpec {
+  // oof, it comes in as a JSON string, but we want a YAML string
+  const resource: IKubeResource = JSON.parse(raw) // we will extract some parameters from this
+  const content = safeDump(resource) // this is what we want to show up in the UI
+
+  return {
+    type: 'custom',
+    isEntity: true,
+    name: resource.metadata.name,
+    packageName: resource.metadata.namespace,
+    namespace: resource.metadata.namespace,
+    contentType: 'yaml',
+    content
+  }
+}

--- a/plugins/plugin-k8s/src/lib/view/modes/pods.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/pods.ts
@@ -32,6 +32,7 @@ import insertView from '../insert-view'
 import { formatTable } from '../formatMultiTable'
 
 import { ModeRegistration } from '@kui-shell/plugin-k8s/lib/view/modes/registrar'
+
 const debug = Debug('k8s/view/modes/pods')
 
 /** for drilldown back button */

--- a/plugins/plugin-k8s/src/preload.ts
+++ b/plugins/plugin-k8s/src/preload.ts
@@ -22,7 +22,9 @@ import { CommandRegistrar } from '@kui-shell/core/models/command'
 import { podMode } from './lib/view/modes/pods'
 import { conditionsMode } from './lib/view/modes/conditions'
 import { containersMode } from './lib/view/modes/containers'
+import { lastAppliedMode } from './lib/view/modes/last-applied'
 import registerSidecarMode from './lib/view/modes/registrar'
+
 const debug = Debug('plugins/k8s/preload')
 
 /**
@@ -33,6 +35,7 @@ export default async (commandTree: CommandRegistrar) => {
   registerSidecarMode(podMode) // show pods of deployments
   registerSidecarMode(containersMode) // show containers of pods
   registerSidecarMode(conditionsMode) // show conditions of a variety of resource kinds
+  registerSidecarMode(lastAppliedMode) // show a last applied configuration tab
 
   if (inBrowser()) {
     debug('preload for browser')

--- a/plugins/plugin-k8s/src/test/k8s1/apply-pod.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/apply-pod.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018-19 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as common from '@kui-shell/core/tests/lib/common'
+import { cli, selectors, sidecar, getValueFromMonaco, expectYAML } from '@kui-shell/core/tests/lib/ui'
+import { defaultModeForGet, createNS, allocateNS, deleteNS } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
+
+import { dirname } from 'path'
+const ROOT = dirname(require.resolve('@kui-shell/plugin-k8s/tests/package.json'))
+
+const synonyms = ['kubectl', 'k']
+const dashFs = ['-f', '--filename']
+
+describe('electron apply pod', function (this: common.ISuite) {
+  before(common.before(this))
+  after(common.after(this))
+
+  // repeat the tests for kubectl, k, etc. i.e. any built-in
+  // synonyms/aliases we have for "kubectl"
+  synonyms.forEach(kubectl => {
+    dashFs.forEach(dashF => {
+      const ns: string = createNS()
+      const inNamespace = `-n ${ns}`
+
+      allocateNS(this, ns)
+
+      it(`should create sample pod from URL via ${kubectl} apply`, async () => {
+        try {
+          const selector = await cli.do(`${kubectl} apply ${dashF} https://raw.githubusercontent.com/kubernetes/examples/master/staging/pod ${inNamespace}`, this.app)
+            .then(cli.expectOKWithCustom({ selector: selectors.BY_NAME('nginx') }))
+
+          // wait for the badge to become green
+          await this.app.client.waitForExist(`${selector} badge.green-background`)
+
+          // now click on the table row
+          this.app.client.click(`${selector} .clickable`)
+          await sidecar.expectOpen(this.app).then(sidecar.expectMode(defaultModeForGet)).then(sidecar.expectShowing('nginx'))
+
+          // make sure we have a last applied tab
+          await this.app.client.click(selectors.SIDECAR_MODE_BUTTON('last applied'))
+
+          return this.app.client.waitUntil(() => {
+            return getValueFromMonaco(this.app)
+              .then(expectYAML({
+                apiVersion: 'v1',
+                kind: 'Pod',
+                metadata: {
+                  name: 'nginx'
+                }
+              }, true, false))
+          })
+        } catch (err) {
+          common.oops(this)(err)
+        }
+      })
+
+      it(`should delete the sample pod from URL via ${kubectl}`, () => {
+        return cli.do(`${kubectl} delete ${dashF} https://raw.githubusercontent.com/kubernetes/examples/master/staging/pod ${inNamespace}`, this.app)
+          .then(cli.expectOKWithCustom({ selector: selectors.BY_NAME('nginx') }))
+          .then(selector => this.app.client.waitForExist(`${selector} badge.red-background`))
+          .catch(common.oops(this))
+      })
+
+      deleteNS(this, ns)
+    })
+  })
+})


### PR DESCRIPTION
Fixes #1632

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
