### PR TITLE
fix: improvements for ascii-to-usage

### DIFF
--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -2350,7 +2350,7 @@ sidecar.minimized .sidecar-header-icon-wrapper {
 }
 sidecar.minimized .sidecar-header-icon {
     width: initial;
-    height: 2rem;
+    height: 2em;
     flex: 1;
     transform-origin: 0% 0%;
     justify-content: flex-start;
@@ -2467,13 +2467,13 @@ sidecar .usage-error-wrapper .hideable {
     margin-top: 0; /* override h1 defaults */
 }
 .bx--breadcrumb-item {
-    margin-right: 1rem;
+    margin-right: 1em;
     display: flex;
     align-items: center;
     color: var(--color-brand-01);
 }
 .bx--breadcrumb-item--slash {
-    margin-left: 1rem;
+    margin-left: 1em;
     color: var(--color-text-02);
 }
 .bx--breadcrumb--no-trailing-slash .bx--breadcrumb-item:last-child .bx--breadcrumb-item--slash {
@@ -2521,19 +2521,19 @@ sidecar .usage-error-wrapper .hideable {
     padding: 0 0 0.5em;
 }
 .page-content h1 {
-    font-size: 3.375rem;
+    font-size: 3.375em;
     font-weight: 300;
     letter-spacing: 0;
     line-height: 1.25;
-    margin: -1.15rem 0 0 -3px;
+    margin: -1.15em 0 0 -3px;
     padding: 0;
     transition: .25s cubic-bezier(.5,0,.1,1);
 }
 .page-content h2, .page-h2 {
-    font-size: 1.75rem;
+    font-size: 1.75em;
     font-weight: 300;
-    margin-top: 3rem;
-    padding: 1rem 0 1.5rem;
+    margin-top: 3em;
+    padding: 1em 0 0;
     position: relative;
     line-height: 1.25;
 }
@@ -2541,11 +2541,11 @@ sidecar .usage-error-wrapper .hideable {
     background-color: var(--color-carbon-components-h3);
     content: "";
     display: block;
-    height: .3rem;
+    height: .3em;
     left: 0;
     position: absolute;
-    top: -.5rem;
-    width: 5rem;
+    top: -.5em;
+    width: 5em;
 }
 .page-content > h3:first-child, .page-content > h2:first-child, .page-content hr + h3 {
     margin-top: 0;
@@ -2553,21 +2553,21 @@ sidecar .usage-error-wrapper .hideable {
 }
 .page-content h3, .page-h3 {
     color: var(--color-carbon-components-h3);
-    font-size: 1.125rem;
+    font-size: 1.125em;
     font-weight: 600;
     letter-spacing: 0;
-    padding: 1rem 0 1rem;
+    padding: 1em 0 1em;
     line-height: 1.25em;
 }
 .page-content ol, .page-content ul {
-    font-size: 1rem;
+    font-size: 1em;
     line-height: 1.75;
-    margin: 1rem 0 1rem 1.5rem;
-    margin-top: 1rem;
+    margin: 1em 0 1em 1.5em;
+    margin-top: 1em;
 }
 .page-content li {
     font-weight: 400;
-    padding-left: .25rem;
+    padding-left: .25em;
     list-style-type: disc;
 }
 sidecar .page-content pre > code {
@@ -2899,8 +2899,8 @@ body {
     --color-ok: var(--color-green);
     --color-error: var(--color-red);
 
-    --color-scrollbar-thumb: black;
-    --color-scrollbar-thumb-border: var(--color-base04);
+    --color-scrollbar-thumb: var(--color-base04);
+    --color-scrollbar-thumb-border: var(--color-base02);
     --color-scrollbar-thumb-outline: transparent;
     --color-scrollbar-track: transparent;
 

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/atelier-seaside.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/atelier-seaside.css
@@ -27,10 +27,6 @@ body[kui-theme="Atelier"] {
     --color-yellow: var(--color-base09);
     --color-light-yellow: hsla(48, 65%, 32%, 0.75);
 
-    --color-scrollbar-thumb: #121412;
-    --color-scrollbar-thumb-border: #3F433F;
-    --color-scrollbar-thumb-outline: #1C221C;
-
     --color-latency-0: #01665e;
     --color-latency-1: #5ab4ac;
     --color-latency-2: #c7eae5;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/dark.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/dark.css
@@ -23,10 +23,6 @@ body[kui-theme="Dark"] {
     --color-light-red: hsla(0, 80%, 75%, 50%);
     --color-light-green: hsla(66, 69%, 57%, 50%);
     --color-light-yellow: hsl(40, 81%, 70%);
-
-    --color-scrollbar-thumb: #141517;
-    --color-scrollbar-thumb-border: #424448;
-    --color-scrollbar-thumb-outline: #212327;
 }
 
 body[kui-theme="Dark"] #screenshot-captured {

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/dracula.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/dracula.css
@@ -26,10 +26,6 @@ body[kui-theme="Dracula"] {
     --color-yellow: var(--color-base0B);
     --color-light-yellow: hsla(70, 100%, 76%, 0.75);
 
-    --color-scrollbar-thumb: #1D1D27;
-    --color-scrollbar-thumb-border: #535364;
-    --color-scrollbar-thumb-outline: #353549;
-
     --color-latency-0: #4d4d4d;
     --color-latency-1: #999999;
     --color-latency-2: #e0e0e0;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/gruvbox-dark-medium.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/gruvbox-dark-medium.css
@@ -24,10 +24,6 @@ body[kui-theme="Gruvbox"] {
     --color-light-green: hsla(61, 66%, 44%, 0.75);
     --color-light-yellow: hsla(42, 95%, 58%, 0.75);
 
-    --color-scrollbar-thumb: #1E1C1B;
-    --color-scrollbar-thumb-border: #54514F;
-    --color-scrollbar-thumb-outline: #363230;
-
     --color-latency-0: #1b7837;
     --color-latency-1: #7fbf7b;
     --color-latency-2: #d9f0d3;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/lucario.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/lucario.css
@@ -29,10 +29,6 @@ body[kui-theme="Lucario"] {
     --color-light-green: hsla(108, 67%, 68%, 50%);
     --color-light-yellow:rgba(255, 255, 182, 50%);
 
-    --color-scrollbar-thumb: #121412;
-    --color-scrollbar-thumb-border: #3F433F;
-    --color-scrollbar-thumb-outline: #1C221C;
-
     --color-latency-0: #1b7837;
     --color-latency-1: #7fbf7b;
     --color-latency-2: #d9f0d3;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/monokai.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/monokai.css
@@ -20,10 +20,6 @@ body[kui-theme="Monokai"] {
     --color-base0E: #ae81ff;
     --color-base0F: #cc6633;
 
-    --color-scrollbar-thumb: #20201C;
-    --color-scrollbar-thumb-border: #4D4D46;
-    --color-scrollbar-thumb-outline: #33332B;
-
     --color-light-red: hsla(338, 95%, 56%, 0.75);
     --color-light-green: hsla(80, 76%, 53%, 0.75);
     --color-light-yellow: hsla(35, 85%, 71%, 0.75);

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/nord.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/nord.css
@@ -31,10 +31,6 @@ body[kui-theme="Nord"] {
     --color-light-green: hsla(92, 28%, 65%, 0.75);
     --color-light-yellow: hsla(40, 71%, 73%, 0.75);
 
-    --color-scrollbar-thumb: #1E2029;
-    --color-scrollbar-thumb-border: #545968;
-    --color-scrollbar-thumb-outline: #363B4D;
-
     --color-latency-0: #4575b4;
     --color-latency-1: #91bfdb;
     --color-latency-2: #e0f3f8;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/paraiso.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/paraiso.css
@@ -25,10 +25,6 @@ body[kui-theme="Paraiso"] {
     --color-light-green: hsla(153, 43%, 50%, 0.75);
     --color-light-yellow: hsla(45, 99%, 55%, 0.75);
 
-    --color-scrollbar-thumb: #1C151C;
-    --color-scrollbar-thumb-border: #514551;
-    --color-scrollbar-thumb-outline: #332432;
-
     --color-latency-0: #542788;
     --color-latency-1: #998ec3;
     --color-latency-2: #d8daeb;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/solarized-dark.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/solarized-dark.css
@@ -27,10 +27,6 @@ body[kui-theme="Solarized"] {
 
     --color-ui-06: hsla(194, 20%, 20%, 0.8);
 
-    --color-scrollbar-thumb: #081B21;
-    --color-scrollbar-thumb-border: #2E4F5A;
-    --color-scrollbar-thumb-outline: #05303C;
-
     --color-latency-0: #4575b4;
     --color-latency-1: #91bfdb;
     --color-latency-2: #e0f3f8;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/zenburn.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/zenburn.css
@@ -24,10 +24,6 @@ body[kui-theme="Zenburn"] {
     --color-light-green: hsla(120, 14%, 60%, 75%);
     --color-light-yellow: hsl(40, 81%, 70%);
 
-    --color-scrollbar-thumb: #202020;
-    --color-scrollbar-thumb-border: #585858;
-    --color-scrollbar-thumb-outline: #3A3A3A;
-
     --color-latency-0: #1a9850;
     --color-latency-1: #91cf60;
     --color-latency-2: #d9ef8b;

--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -599,7 +599,7 @@ export const doExec = (tab: ITab, block: HTMLElement, cmdline: string, argvNoOpt
       // will always receive a `refresh` event when the animation
       // frame is done. see https://github.com/IBM/kui/issues/1272
       terminal.on('refresh', (evt: { start: number; end: number }) => {
-        // debug('refresh', evt.start, evt.end)
+        debug('refresh', evt.start, evt.end)
         resizer.hideTrailingEmptyBlanks()
         doScroll()
         notifyOfWriteCompletion(evt)
@@ -643,7 +643,7 @@ export const doExec = (tab: ITab, block: HTMLElement, cmdline: string, argvNoOpt
 
           const maybeUsage = !resizer.wasEverInAltBufferMode() &&
             !definitelyNotUsage &&
-            (pendingUsage || formatUsage(cmdline, msg.data, { drilldownWithPip: true }))
+            (pendingUsage || formatUsage(cmdline, raw, { drilldownWithPip: true }))
 
           if (!definitelyNotTable && raw.length > 0 && !resizer.wasEverInAltBufferMode()) {
             try {
@@ -676,7 +676,9 @@ export const doExec = (tab: ITab, block: HTMLElement, cmdline: string, argvNoOpt
             debug('pending usage')
             pendingUsage = true
           } else {
-            definitelyNotUsage = true
+            if (raw.length > 500) {
+              definitelyNotUsage = true
+            }
             pendingWrites++
             terminal.write(msg.data)
           }
@@ -705,6 +707,7 @@ export const doExec = (tab: ITab, block: HTMLElement, cmdline: string, argvNoOpt
 
             if (pendingUsage) {
               execOptions.stdout(formatUsage(cmdline, raw, { drilldownWithPip: true }))
+              xtermContainer.classList.add('xterm-invisible')
             } else if (pendingTable) {
               execOptions.stdout(pendingTable)
             } else if (expectingSemiStructuredOutput) {

--- a/plugins/plugin-bash-like/web/css/xterm.css
+++ b/plugins/plugin-bash-like/web/css/xterm.css
@@ -158,3 +158,8 @@ tab:not(.xterm-alt-buffer-mode) .xterm.xterm-empty-row-heuristic .xterm-rows > d
     display: block;
     content: '';
 }
+
+/* in case we change our minds and want to hide it */
+.xterm-invisible {
+    display: none;
+}


### PR DESCRIPTION
also some small refinements to scrollbar colors versus themes (shows up mightily in ascii-to-usage output)

Fixes #1551

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
