### PR TITLE
style(plugins-proxy-support): lint unused-vars

### DIFF
--- a/packages/app/src/models/command.ts
+++ b/packages/app/src/models/command.ts
@@ -158,6 +158,10 @@ export interface ICommandHandlerWithEvents extends IEvaluator {
   success: (args: { tab: ITab; type: ExecType; command: string; isDrilldown: boolean; parsedOptions: { [ key: string ]: any } }) => void
   error: (command: string, err: CodedError) => CodedError
 }
+export function isCommandHandlerWithEvents (evaluator: IEvaluator): evaluator is ICommandHandlerWithEvents {
+  const handler = evaluator as ICommandHandlerWithEvents
+  return handler.options !== undefined
+}
 
 export type CommandTreeResolution = boolean | ICommandHandlerWithEvents | CodedError
 

--- a/plugins/plugin-proxy-support/.eslintrc.json
+++ b/plugins/plugin-proxy-support/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@typescript-eslint/no-unused-vars": 1
+  }
+}

--- a/plugins/plugin-proxy-support/src/lib/proxy-executor.ts
+++ b/plugins/plugin-proxy-support/src/lib/proxy-executor.ts
@@ -19,12 +19,12 @@ import * as Debug from 'debug'
 import UsageError from '@kui-shell/core/core/usage-error'
 import { IReplEval, DirectReplEval } from '@kui-shell/core/core/repl'
 import { getValidCredentials } from '@kui-shell/core/core/capabilities'
-import { IExecOptions, DefaultExecOptions } from '@kui-shell/core/models/execOptions'
+import { IExecOptions } from '@kui-shell/core/models/execOptions'
 import { config } from '@kui-shell/core/core/settings'
+import { isCommandHandlerWithEvents, IEvaluator, IEvaluatorArgs } from '@kui-shell/core/models/command'
 
 import * as needle from 'needle'
 const debug = Debug('plugins/proxy-support/executor')
-import url = require('url')
 
 /**
  * The proxy server configuration.
@@ -46,10 +46,10 @@ const directEvaluator = new DirectReplEval()
 class ProxyEvaluator implements IReplEval {
   name = 'ProxyEvaluator'
 
-  async apply (command: string, execOptions: IExecOptions, evaluator, args) {
+  async apply (command: string, execOptions: IExecOptions, evaluator: IEvaluator, args: IEvaluatorArgs) {
     debug('apply', evaluator)
 
-    if (evaluator.options && (evaluator.options.inBrowserOK || evaluator.options.inBrowserOk || evaluator.options.needsUI)) {
+    if (isCommandHandlerWithEvents(evaluator) && evaluator.options && (evaluator.options.inBrowserOk || evaluator.options.needsUI)) {
       debug('delegating to direct evaluator')
       return directEvaluator.apply(command, execOptions, evaluator, args)
     } else {

--- a/plugins/plugin-proxy-support/src/preload.ts
+++ b/plugins/plugin-proxy-support/src/preload.ts
@@ -17,14 +17,13 @@
 import * as Debug from 'debug'
 
 import { inBrowser, assertHasProxy, assertLocalAccess } from '@kui-shell/core/core/capabilities'
-import { CommandRegistrar } from '@kui-shell/core/models/command'
 const debug = Debug('plugins/proxy-support/preload')
 
 /**
  * This is the module
  *
  */
-export default async (commandTree: CommandRegistrar) => {
+export default async () => {
   if (inBrowser()) {
     const { config } = await import('@kui-shell/core/core/settings')
     debug('config', config)

--- a/plugins/plugin-tutorials/src/lib/cmds/list.ts
+++ b/plugins/plugin-tutorials/src/lib/cmds/list.ts
@@ -54,7 +54,6 @@ const doList = () => new Promise((resolve, reject) => {
           return
         }
 
-        const { skills } = await import('@kui-shell/plugin-tutorials/samples/@tutorials/' + name + '/tutorial.json')
         const attributes = []
 
         // add a "level" column


### PR DESCRIPTION
#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
