### PR TITLE
fix(plugins/plugin-core-support): ctrl+F responds in both editor and kui

### DIFF
--- a/plugins/plugin-core-support/web/css/text-search.css
+++ b/plugins/plugin-core-support/web/css/text-search.css
@@ -69,7 +69,7 @@ body.subwindow #search-bar.visible {
     font-size: 1.5em;
 }
 #search-close-button:hover {
-    color: var(--color-ui-02);
+    color: var(--color-base0D);
     cursor: pointer;
 }
 #search-found-text.no-search-yet {


### PR DESCRIPTION
also fixes a hover effect issue with kui's text search close button -- not visible in dark themes

Fixes #1573

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
