### PR TITLE
[Not Ready] chore: add command and output (only openwhisk activationId) to history after command evaluation

### DIFF
--- a/packages/app/src/models/entity.ts
+++ b/packages/app/src/models/entity.ts
@@ -77,6 +77,17 @@ export function isMetadataBearing (spec: IEntitySpec): spec is MetadataBearing {
 }
 
 /**
+ * An entity not stored in the history model and returns nothing
+ *
+ */
+export interface IRedact {
+  redact: true
+}
+
+export function isRedact (entity: Entity): entity is IRedact {
+  return (entity as IRedact).redact
+}
+/**
  * A mostly scalar entity
  *
  */
@@ -88,4 +99,4 @@ export type SimpleEntity = Error | string | number | HTMLElement | IMessageBeari
  * Note: Array<any> will go away once we have fully typed tables
  *
  */
-export type Entity = SimpleEntity | IEntitySpec | ICustomSpec | boolean | any[] | Table
+export type Entity = SimpleEntity | IEntitySpec | ICustomSpec | boolean | any[] | Table | IRedact

--- a/packages/app/src/models/history.ts
+++ b/packages/app/src/models/history.ts
@@ -15,14 +15,13 @@
  */
 
 import store from '@kui-shell/core/models/store'
+import { IRedact } from '@kui-shell/core/models/entity'
 
 // localStorage key; note: the value here holds no meaning, it is a
 // historical artifact, at this point
 const key = 'openwhisk.history'
 
 export interface HistoryLine {
-  entityType?: string
-  verb?: string
   response?: any
   raw?: string
 }
@@ -48,10 +47,10 @@ const guardedChange = (incr: number): number => {
  * Clear out all history
  *
  */
-export const wipe = () => {
+export const wipe = (): IRedact => {
   lines = []
   store().setItem(key, JSON.stringify(lines))
-  return true
+  return { redact: true }
 }
 
 /** add a line of repl history */

--- a/packages/app/src/webapp/cli.ts
+++ b/packages/app/src/webapp/cli.ts
@@ -22,7 +22,7 @@ import UsageError from '../core/usage-error'
 import { inBrowser, inElectron, isHeadless } from '../core/capabilities'
 import { keys } from './keys'
 
-import { Entity, SimpleEntity, isEntitySpec, isMessageBearingEntity } from '../models/entity'
+import { Entity, SimpleEntity, isEntitySpec, isMessageBearingEntity, isRedact } from '../models/entity'
 import { ICommandHandlerWithEvents } from '../models/command'
 import { IExecOptions, DefaultExecOptions, ParsedOptions } from '../models/execOptions'
 import * as historyModel from '../models/history'
@@ -496,7 +496,7 @@ export const printResults = (block: HTMLElement, nextBlock: HTMLElement, tab: IT
   }
 
   const render = async (response: Entity, { echo, resultDom }: { echo: boolean; resultDom: HTMLElement }) => {
-    if (response && response !== true) {
+    if (response && response !== true && !isRedact(response)) {
       if (isTable(response)) {
         await printTable(tab, response, resultDom, execOptions, parsedOptions)
       } else if (Array.isArray(response)) {

--- a/plugins/plugin-core-support/src/lib/cmds/history/history.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/history/history.ts
@@ -107,8 +107,11 @@ const showHistory = ({ argv, parsedOptions: options }) => {
   const filterStr = filterIdx > 0 && argv[filterIdx]
   const filter = filterStr ? line => line.raw.indexOf(filterStr) >= 0 : () => true
 
-  const startIdx = Math.max(0, historyModel.getCursor() - N - 1)
-  const endIdx = historyModel.getCursor() - 1
+  /* don't use historyModel.getCursor() to get the index here
+  since the cursor will be changed if the users get the history
+  command in history by key up and down events */
+  const startIdx = Math.max(0, historyModel.lines.length - N)
+  const endIdx = historyModel.lines.length
   const recent = historyModel.lines.slice(startIdx, endIdx)
 
   debug('argv', argv)

--- a/plugins/plugin-openwhisk/src/lib/cmds/activations/await.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/activations/await.ts
@@ -116,7 +116,8 @@ const findActivationId = (options, activationId?: string) => new Promise((resolv
       return repl.qexec(`wsk activation last`).then(poll).catch(reject)
     } else {
       // otherwise, use our local history to find the last activation id
-      const lastActivationCommand = historyModel.find(entry => entry.entityType === 'actions' && (entry.verb === 'invoke' || entry.verb === 'async'))
+      const lastActivationCommand = historyModel.find(entry => entry.response && entry.response.activationId)
+
       debug('lastActivationCommand', lastActivationCommand)
 
       if (lastActivationCommand) {


### PR DESCRIPTION
also removed entityType and verb in the history model 

and added some types to openwhisk-core

Fixes #1642 

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
