### PR TITLE
fix(packages/proxy): proxy build fails for non-bluemix and non-kubernetes users

### DIFF
--- a/packages/proxy/build.sh
+++ b/packages/proxy/build.sh
@@ -39,8 +39,9 @@ function init {
 function initProxy {
     pushd "$STAGING_DIR" > /dev/null
     cp -a "$PROXY_HOME"/{package.json,build-docker.sh,Dockerfile,.dockerignore,app} .
-    if [ -d ~/.kube ]; then cp -a ~/.kube .; fi
-    if [ -d ~/.bluemix/plugins/container-service/clusters ]; then mkdir -p .bluemix/plugins/container-service && cp -a ~/.bluemix/plugins/container-service/clusters .bluemix/plugins/container-service; fi
+    # mkdir .kube and .bluemix if they don't exist, see issue: https://github.com/IBM/kui/issues/1647
+    if [ -d ~/.kube ]; then cp -a ~/.kube .; else mkdir .kube; fi
+    if [ -d ~/.bluemix/plugins/container-service/clusters ]; then mkdir -p .bluemix/plugins/container-service && cp -a ~/.bluemix/plugins/container-service/clusters .bluemix/plugins/container-service; else mkdir .bluemix; fi
     npm install --no-package-lock
     popd > /dev/null
 }


### PR DESCRIPTION


Fixes #1647

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
