### PR TITLE
fix(packages/proxy): override execOptions.tab in proxy executor

### DIFF
--- a/packages/app/src/core/repl.ts
+++ b/packages/app/src/core/repl.ts
@@ -317,7 +317,7 @@ class InProcessExecutor implements IExecutor {
     // debug(`repl::exec ${new Date()}`)
     debug('exec', commandUntrimmed)
     const tab = execOptions.tab || cli.getCurrentTab()
-    debug('tab', cli.getTabIndex(tab))
+    debug('tab', tab)
 
     if (!isHeadless()) {
       const storage = JSON.parse(sessionStore().getItem(key)) || {}

--- a/plugins/plugin-proxy-support/src/lib/proxy-executor.ts
+++ b/plugins/plugin-proxy-support/src/lib/proxy-executor.ts
@@ -59,6 +59,7 @@ class ProxyEvaluator implements IReplEval {
         execOptions: Object.assign({}, execOptions, {
           isProxied: true,
           credentials: getValidCredentials(),
+          tab: undefined, // override execOptions.tab here since the DOM doesn't serialize, see issue: https://github.com/IBM/kui/issues/1649
           rawResponse: true // we will post-process the response
         })
       }


### PR DESCRIPTION
Fixes #1649

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
