### PR TITLE
fix: pty alt buffer flashes

### DIFF
--- a/packages/app/web/css/left-tab-stripe.css
+++ b/packages/app/web/css/left-tab-stripe.css
@@ -193,20 +193,20 @@ body.subwindow .repl .horizontal-landing-zone {
     padding-top: 0;
 }
 .repl-input, .repl-output {
-    padding: 0 0 0 1em;
+    padding: 0 0 0 0.375rem;
     transition: padding 150ms ease-in-out;
 }
 .repl-result > div, .repl:not(.sidecar-visible) .repl-result .result-table-outer {
-    padding-right: 1em;
+    padding-right: 0.375rem;
 }
 .repl-prompt-right-elements {
-    padding-right: 1em;
+    padding-right: 0.375rem;
 }
 .repl.sidecar-visible .repl-input, .repl.sidecar-visible .repl-output {
-    padding-left: 1em;
+    padding-left: 0.375rem;
 }
 .repl.sidecar-visible .repl-output {
-    padding-right: 1em;
+    padding-right: 0.375rem;
 }
 
 #help-button.left-tab-stripe-button {

--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -166,7 +166,7 @@ body.still-loading .repl {
     background: transparent;
 }
 .repl-block {
-    padding: 1em 0 0;
+    padding: 0.5em 0 0;
     display: flex;
     flex-direction: column;
 }

--- a/plugins/plugin-bash-like/web/css/xterm.css
+++ b/plugins/plugin-bash-like/web/css/xterm.css
@@ -45,9 +45,6 @@ tab.xterm-alt-buffer-mode .repl-inner .repl-block {
 tab.xterm-alt-buffer-mode .repl-inner .repl-block .repl-output {
     align-items: unset;
 }
-tab.xterm-alt-buffer-mode .repl {
-    background: var(--color-stripe-01);
-}
 tab.xterm-alt-buffer-mode .repl-block:not(.processing), tab.xterm-alt-buffer-mode .repl-input, tab.xterm-alt-buffer-mode .repl-result-spinner {
     display: none;
 }


### PR DESCRIPTION
this also tightens up the REPL a bit; this is partly driven by the flash avoidance fix.
to avoid setting the background of repl in alt buffer mode (which we were doing to avoid
having too much "white space" to the left of the alt buffer emacs or vi), it is helpful
to tighten up the UI a bit, so that we can avoid the whitespace altogether.

this also makes the REPL look a bit more REPL-like

Fixes #1664

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
