### PR TITLE
fix(packages/app): ascii-to-usage versus git commit

### DIFF
--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -2434,6 +2434,7 @@ sidecar.minimized [data-balloon]:before, sidecar.minimized [data-balloon]:after 
 .usage-error-wrapper .marked-content p {
     /* marked markdown renderer paragraphs */
     margin: 0.25em 0;
+    white-space: pre-wrap;
 }
 .usage-error-wrapper .hideable {
     margin: 2em 0;


### PR DESCRIPTION
Fixes #1668

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
