### PR TITLE
chore(packages/kui-builder): electron 5.0.3

### DIFF
--- a/packages/kui-builder/package.json
+++ b/packages/kui-builder/package.json
@@ -40,7 +40,7 @@
     "@types/webdriverio": "4.13.1",
     "colors": "1.3.3",
     "debug": "4.1.1",
-    "electron": "5.0.2",
+    "electron": "5.0.3",
     "fs-extra": "8.0.1",
     "spectron": "5.0.0",
     "terser": "3.17.0",


### PR DESCRIPTION
Fixes #1670

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
