### PR TITLE
style(plugins/k8s): lint unused-vars

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,7 @@
         "plugins/plugin-core-support/**/*.ts",
         "plugins/plugin-editor/**/*.ts",
         "plugins/plugin-grid/**/*.ts",
+        "plugins/plugin-k8s/**/*.ts",
         "plugins/plugin-manager/**/*.ts",
         "plugins/plugin-openwhisk-debug/**/*.ts",
         "plugins/plugin-openwhisk-editor-extensions/**/*.ts",

--- a/plugins/plugin-k8s/src/lib/clients/kiali.ts
+++ b/plugins/plugin-k8s/src/lib/clients/kiali.ts
@@ -20,7 +20,7 @@ import * as needle from 'needle'
 import * as parseDuration from 'parse-duration'
 
 import Presentation from '@kui-shell/core/webapp/views/presentation'
-import { rexec as $, encodeComponent } from '@kui-shell/core/core/repl'
+import { rexec as $ } from '@kui-shell/core/core/repl'
 const debug = Debug('k8s/clients/kiali')
 
 export interface IKialiOptions {

--- a/plugins/plugin-k8s/src/lib/controller/contexts.ts
+++ b/plugins/plugin-k8s/src/lib/controller/contexts.ts
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-import * as Debug from 'debug'
 import { Row, Table } from '@kui-shell/core/webapp/models/table'
 import { CommandRegistrar } from '@kui-shell/core/models/command'
-const debug = Debug('k8s/controller/contexts')
 
 import repl = require('@kui-shell/core/core/repl')
 

--- a/plugins/plugin-k8s/src/lib/controller/describe.ts
+++ b/plugins/plugin-k8s/src/lib/controller/describe.ts
@@ -19,8 +19,6 @@ import * as Debug from 'debug'
 import { safeDump } from 'js-yaml'
 
 import { isPopup } from '@kui-shell/core/webapp/cli'
-import { prettyPrintTime } from '@kui-shell/core/webapp/util/time'
-import drilldown from '@kui-shell/core/webapp/picture-in-picture'
 import { rexec as $, qexec as $$ } from '@kui-shell/core/core/repl'
 import { ISidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
 
@@ -33,18 +31,6 @@ import { statusButton } from '../view/modes/status'
 import { deleteResourceButton } from '../view/modes/crud'
 import { apply as addRelevantModes } from '../view/modes/registrar'
 const debug = Debug('k8s/controller/describe')
-
-const usage = command => ({
-  title: command,
-  command,
-  strict: command,
-  onlyEnforceOptions: [ '-f' ],
-  noHelp: true, // kubectl and helm both provide their own -h output
-  docs: 'Show details of a specific resource or group of resources',
-  optional: [
-    { name: '-f', file: true, docs: 'Filename, directory, or URL to files to use to create the resource' }
-  ]
-})
 
 /** conditionally add a field, if it exists */
 function addField (label: string, value: any) {

--- a/plugins/plugin-k8s/src/lib/controller/kedit.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kedit.ts
@@ -19,13 +19,12 @@ import * as Debug from 'debug'
 import { basename, dirname, join } from 'path'
 
 import { inBrowser } from '@kui-shell/core/core/capabilities'
-import { CommandRegistrar, IEvaluatorArgs, ParsedOptions } from '@kui-shell/core/models/command'
-import { IExecOptions } from '@kui-shell/core/models/execOptions'
+import { CommandRegistrar, IEvaluatorArgs } from '@kui-shell/core/models/command'
 import { injectCSS } from '@kui-shell/core/webapp/util/inject'
 import expandHomeDir from '@kui-shell/core/util/home'
 import { findFile } from '@kui-shell/core/core/find-file'
 import { ITab } from '@kui-shell/core/webapp/cli'
-import { Row, Table } from '@kui-shell/core/webapp/models/table'
+import { Table } from '@kui-shell/core/webapp/models/table'
 import { IEntitySpec } from '@kui-shell/core/models/entity'
 
 import { FinalState } from '../model/states'
@@ -59,7 +58,7 @@ const usage = {
  * Show a customized view of a given yaml in the editor
  *
  */
-const showResource = async (yaml: IKubeResource, filepath: string, tab: ITab, parsedOptions: ParsedOptions, execOptions: IExecOptions) => {
+const showResource = async (yaml: IKubeResource, filepath: string, tab: ITab) => {
   debug('showing one resource', yaml)
 
   if (inBrowser()) {
@@ -175,7 +174,7 @@ const showAsTable = (yamls: any[], filepathAsGiven: string, parsedOptions): Tabl
  * kedit command handler
  *
  */
-const kedit = async ({ tab, execOptions, argv, argvNoOptions, parsedOptions }: IEvaluatorArgs) => {
+const kedit = async ({ tab, argvNoOptions, parsedOptions }: IEvaluatorArgs) => {
   const idx = argvNoOptions.indexOf('kedit') + 1
   const filepathAsGiven = argvNoOptions[idx]
   const resource = argvNoOptions[idx + 1]
@@ -199,7 +198,7 @@ const kedit = async ({ tab, execOptions, argv, argvNoOptions, parsedOptions }: I
     if (yamlIdx < 0) {
       throw new Error('Cannot find the specified resource')
     } else {
-      return showResource(yamls[yamlIdx], filepath, tab, parsedOptions, execOptions)
+      return showResource(yamls[yamlIdx], filepath, tab)
     }
   }
 }

--- a/plugins/plugin-k8s/src/lib/controller/kiali.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kiali.ts
@@ -19,7 +19,7 @@ import * as Debug from 'debug'
 import { exec } from 'child_process'
 
 import { CommandRegistrar, IEvaluatorArgs } from '@kui-shell/core/models/command'
-import { pexec, rexec as $, qexec as $$, encodeComponent } from '@kui-shell/core/core/repl'
+import { pexec, qexec as $$, encodeComponent } from '@kui-shell/core/core/repl'
 
 import * as client from '../clients/kiali'
 import { States, TrafficLight } from '../model/states'
@@ -30,7 +30,7 @@ import parseDuration = require('parse-duration')
  * Install Kiali
  *
  */
-const installKiali = async ({ parsedOptions }: IEvaluatorArgs) => {
+const installKiali = async () => {
   const tmp = '/tmp' // FIXME
 
   // const ns = 'default' // FIXME
@@ -39,7 +39,7 @@ const installKiali = async ({ parsedOptions }: IEvaluatorArgs) => {
   // await $(`kubectl create secret generic kiali -n "${ns}" --from-literal=username="${username}" --from-literal=passphrase="${passphrase}"`)
 
   await new Promise((resolve, reject) => {
-    exec('bash <(curl -L http://git.io/getLatestKialiKubernetes)', { cwd: tmp, shell: 'bash' }, (err, stdout, stderr) => {
+    exec('bash <(curl -L http://git.io/getLatestKialiKubernetes)', { cwd: tmp, shell: 'bash' }, (err, stdout) => {
       if (err) {
         console.error(err)
         reject(err)
@@ -55,7 +55,7 @@ const installKiali = async ({ parsedOptions }: IEvaluatorArgs) => {
  * Uninstall Kiali
  *
  */
-const uninstallKiali = async ({ parsedOptions }: IEvaluatorArgs) => {
+const uninstallKiali = async () => {
   return $$('kubectl delete all,secrets,sa,configmaps,deployments,ingresses,clusterroles,clusterrolebindings,virtualservices,destinationrules,customresourcedefinitions --selector=app=kiali -n istio-system')
 }
 
@@ -127,7 +127,7 @@ const getApps = async ({ parsedOptions }: IEvaluatorArgs) => {
         value: States.Pending,
         outerCSS: 'text-center',
         css: TrafficLight.Yellow,
-        watch: async (iter: number) => {
+        watch: async () => {
           const health = await client.appHealth(app.name, new client.Namespace(list.namespace.name), rateInterval)
           const { errorRatio, inboundErrorRatio, outboundErrorRatio } = health.requests
 
@@ -174,11 +174,6 @@ const getApps = async ({ parsedOptions }: IEvaluatorArgs) => {
  */
 const ingressFor = (appName: string): Promise<string> => {
   return $$(`istio ingress "${appName}"`)
-}
-
-type Handler = (arg: string) => any
-const sendFirstArgTo = (command: string, handler: Handler) => ({ argvNoOptions: args }) => {
-  return handler(args[args.indexOf(command) + 1])
 }
 
 /**

--- a/plugins/plugin-k8s/src/lib/controller/status.ts
+++ b/plugins/plugin-k8s/src/lib/controller/status.ts
@@ -26,7 +26,7 @@ import { Row, Table } from '@kui-shell/core/webapp/models/table'
 import { CodedError } from '@kui-shell/core/models/errors'
 
 import { withRetryOn404 } from '../util/retry'
-import { flatten, isDirectory, toOpenWhiskFQN } from '../util/util'
+import { flatten, isDirectory } from '../util/util'
 
 import { ICRDResource, IKubeResource } from '../model/resource'
 import { States, FinalState } from '../model/states'
@@ -308,7 +308,7 @@ const errorEntity = (execOptions: IExecOptions, base: IKubeResource, backupNames
 interface FinalStateOptions extends ParsedOptions {
   'final-state': FinalState
 }
-const getDirectReferences = (command: string) => async ({ execOptions, argv, argvNoOptions, parsedOptions }: IEvaluatorArgs) => {
+const getDirectReferences = (command: string) => async ({ execOptions, argvNoOptions, parsedOptions }: IEvaluatorArgs) => {
   const raw = Object.assign({}, execOptions, { raw: true })
 
   const idx = argvNoOptions.indexOf(command) + 1
@@ -483,7 +483,7 @@ const findControlledResources = async (args: IEvaluatorArgs, kubeEntities: IKube
   debug('findControlledResources', kubeEntities)
 
   const raw = Object.assign({}, args.execOptions, { raw: true })
-  const pods = removeDuplicateResources(flatten(await Promise.all(kubeEntities.map(({ kind, metadata: { labels, namespace, name } }) => {
+  const pods = removeDuplicateResources(flatten(await Promise.all(kubeEntities.map(({ kind, metadata: { labels, namespace } }) => {
     if (labels && labels.app && kind !== 'Pod') {
       const pods: Promise<IKubeResource[]> = repl.qexec(`kubectl get pods -n "${namespace || 'default'}" -l "app=${labels.app}" -o json`,
         undefined, undefined, raw)

--- a/plugins/plugin-k8s/src/lib/model/states.ts
+++ b/plugins/plugin-k8s/src/lib/model/states.ts
@@ -264,17 +264,17 @@ export const getStatus = async (desiredFinalState: FinalState, apiVersion: strin
  * Check the deployment status of an openwhisk entity
  *
  */
-const getOpenWhiskStatus = (type: string, fqn: string): Promise<IStatus> => repl.qexec(`wsk ${type} get "${fqn}"`)
-  .then(() => ({ state: States.Online }))
-  .catch(err => {
-    if (err.statusCode === 404) {
-      return {
-        state: States.Offline
-      }
-    } else {
-      throw err
-    }
-  })
+// const getOpenWhiskStatus = (type: string, fqn: string): Promise<IStatus> => repl.qexec(`wsk ${type} get "${fqn}"`)
+//   .then(() => ({ state: States.Online }))
+//   .catch(err => {
+//     if (err.statusCode === 404) {
+//       return {
+//         state: States.Offline
+//       }
+//     } else {
+//       throw err
+//     }
+//   })
 
 interface IWatch {
   apiVersion: string
@@ -376,8 +376,6 @@ export const watchStatus = async (watch: IWatch, finalStateStr: string | FinalSt
       (finalState === FinalState.OnlineLike && isOnlineLike(newState)) ||
       (finalState === FinalState.OfflineLike && isOfflineLike(newState))
     // || (!offlineOk && newState === States.Disparity);
-
-    const labels = watch.labels
 
     const getOpenWhiskResource = (exec: string) => repl[exec](`wsk ${type} get ${repl.encodeComponent(fqn)}`)
     const getKubernetesResource = `kubectl get ${kindForQuery(watch.apiVersion, kind)} ${repl.encodeComponent(name)} ${contextOption(context)} ${ns(namespace)} -o yaml`

--- a/plugins/plugin-k8s/src/lib/util/help.ts
+++ b/plugins/plugin-k8s/src/lib/util/help.ts
@@ -23,10 +23,9 @@ const debug = require('debug')('k8s/util/help')
  *
  * @param command e.g. helm versus kubectl
  * @param verb e.g. list versus get
- * @param entityType? e.g. crd
  *
  */
-export const renderHelp = (out: string, command: string, verb: string, exitCode: number, entityType?: string) => {
+export const renderHelp = (out: string, command: string, verb: string, exitCode: number) => {
   debug('renderHelp')
 
   // kube and helm help often have a `Use "this command" to do that operation`
@@ -40,7 +39,7 @@ export const renderHelp = (out: string, command: string, verb: string, exitCode:
 
   // form the detailedExample model from the use part we stripped out
   const detailedExampleFromUsePart = usePart && usePart.filter(x => x).map(line => {
-    const [ _, command, docs ] = line.split(/^Use "([^"]+)"\s+(.*)\s*$/)
+    const [ , command, docs ] = line.split(/^Use "([^"]+)"\s+(.*)\s*$/)
     return { command, docs }
   })
 
@@ -110,7 +109,7 @@ export const renderHelp = (out: string, command: string, verb: string, exitCode:
       .split(/^\s*(?:#\s+)/mg)
       .map(x => x.trim())
       .filter(x => x)
-      .map((group, idx, A) => {
+      .map((group) => {
         //
         // Explanation: compare `kubectl completion -h` to `kubectl get -h`
         // The former Examples section has a structure of (Summary, MultiLineDetail)
@@ -124,7 +123,7 @@ export const renderHelp = (out: string, command: string, verb: string, exitCode:
         //
         const match = group.match(/(.*)[\n\r]([\s\S]+)/)
         if (match && match.length === 3) {
-          const [_, firstPartFull, secondPartFull] = match
+          const [, firstPartFull, secondPartFull] = match
 
           const firstPart = removeSolitaryAndTrailingPeriod(firstPartFull)
           const secondPart = removeSolitaryAndTrailingPeriod(secondPartFull)

--- a/plugins/plugin-k8s/src/lib/util/log-parser.ts
+++ b/plugins/plugin-k8s/src/lib/util/log-parser.ts
@@ -204,7 +204,6 @@ const parseCloudLens = (raw: string, options: IOptions): any[] => {
  */
 const parseIstio = (raw: string): IZaprEntry[] => {
   let prevTimestamp: string
-  let idxOfPrevTimestamp: number
 
   return raw
     .split(/[\n\r]/)

--- a/plugins/plugin-k8s/src/lib/util/selectors.ts
+++ b/plugins/plugin-k8s/src/lib/util/selectors.ts
@@ -38,14 +38,3 @@ export const selectorToString = (selector: Selector): string => {
 
   return stringified
 }
-
-const valueToString = (value: Selector | string): string => {
-  if (typeof value === 'string') {
-    return value
-  } else {
-    return Object
-      .keys(value)
-      .map(key => `${key}=${value[key]}`)
-      .join(',')
-  }
-}

--- a/plugins/plugin-k8s/src/lib/view/form.ts
+++ b/plugins/plugin-k8s/src/lib/view/form.ts
@@ -40,28 +40,6 @@ interface IFormGroup {
 }
 
 /**
- * Traverse the given yaml
- *
- */
-const findParent = (yaml: Record<string, any>, path: string[]): Record<string, any> => {
-  debug('findParent', yaml, path)
-  if (!yaml || path.length === 1) {
-    throw new Error('Cannot find path')
-  } else {
-    const desiredKey = path[0]
-    for (let key in yaml) {
-      if (key === desiredKey) {
-        if (path.length === 2) {
-          return yaml[key]
-        } else {
-          return findParent(yaml[key], path.slice(1))
-        }
-      }
-    }
-  }
-}
-
-/**
  * Update the given path in the given yaml to have the given value
  *
  */

--- a/plugins/plugin-k8s/src/lib/view/formatEntity.ts
+++ b/plugins/plugin-k8s/src/lib/view/formatEntity.ts
@@ -16,8 +16,8 @@
 
 import eventBus from '@kui-shell/core/core/events'
 
-import { flatten, isDirectory, toOpenWhiskFQN } from '../util/util'
-import { State, States, FinalState, watchStatus, rendering as stateRendering } from '../model/states'
+import { toOpenWhiskFQN } from '../util/util'
+import { States, FinalState, watchStatus, rendering as stateRendering } from '../model/states'
 
 const debug = require('debug')('k8s/util/formatEntity')
 
@@ -60,7 +60,6 @@ export const formatEntity = (parsedOptions, context?: string) => kubeEntity => {
 
   // see if anyone else changes the expected final state
   const watch = { apiVersion, kind, name, namespace, type, fqn, context, labels }
-  let conflictingFinalStates = false
   const eventType = '/kubectl/state/expect'
   const listener = ({ watch: other, finalState: otherFinalState }) => {
     if (watch.kind === other.kind &&
@@ -69,7 +68,6 @@ export const formatEntity = (parsedOptions, context?: string) => kubeEntity => {
         finalState !== otherFinalState) {
       debug('conflicting final states', watch, finalState, otherFinalState)
 
-      conflictingFinalStates = true
       eventBus.removeListener(eventType, listener)
     }
   }

--- a/plugins/plugin-k8s/src/lib/view/formatTable.ts
+++ b/plugins/plugin-k8s/src/lib/view/formatTable.ts
@@ -129,18 +129,6 @@ const cssForValue = {
 }
 
 /**
- * If the given resource name is of the form <kind>/<name>, then
- * return kind, otherwise return undefined
- *
- */
-const resourceNameWithKindPattern = /^([^/]+)\/[^/]+$/
-const kindFromResourceName = fqn => {
-  const match = fqn.match(resourceNameWithKindPattern)
-  const kind = match && match.length === 2 && match[1]
-  return kind.charAt(kind.length - 1) === 's' ? kind : `${kind}s`
-}
-
-/**
  * Split the given string at the given split indices
  *
  */

--- a/plugins/plugin-k8s/src/lib/view/helm-status.ts
+++ b/plugins/plugin-k8s/src/lib/view/helm-status.ts
@@ -45,7 +45,8 @@ export const format = async (command: string, verb: string, entityType: string, 
   const namespaceFromHelmStatusOutput = namespaceMatch[1]
   debug('namespace', namespaceFromHelmStatusOutput)
 
-  const namespaceFor = (entityType: string) => {
+  // const namespaceFor = (entityType: string) => {
+  const namespaceFor = () => {
     // i think the commented out bit was for some buggy controllers
     /* if (/ConfigMap(s?)|cm/i.test(entityType)) {
       return 'default'
@@ -82,7 +83,7 @@ export const format = async (command: string, verb: string, entityType: string, 
         table: formatTable(command,
           verb,
           entityType,
-          Object.assign({}, options, { namespace: namespaceFor(entityType) }),
+          Object.assign({}, options, { namespace: namespaceFor() }),
           preprocessTable([A.slice(1).join('\n')])[0])
       }
     })

--- a/plugins/plugin-k8s/src/lib/view/modes/conditions.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/conditions.ts
@@ -17,8 +17,6 @@
 import * as Debug from 'debug'
 
 import { ITab } from '@kui-shell/core/webapp/cli'
-import { formatMultiListResult } from '@kui-shell/core/webapp/views/table'
-import { ISidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
 import { Row, Table } from '@kui-shell/core/webapp/models/table'
 
 import { IResource, IKubeResource } from '../../model/resource'

--- a/plugins/plugin-k8s/src/lib/view/modes/containers.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/containers.ts
@@ -17,9 +17,7 @@
 import * as Debug from 'debug'
 import { ITab } from '@kui-shell/core/webapp/cli'
 import drilldown from '@kui-shell/core/webapp/picture-in-picture'
-import { formatMultiListResult } from '@kui-shell/core/webapp/views/table'
-import { Row, Table } from '@kui-shell/core/webapp/models/table'
-import { ISidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
+import { Row } from '@kui-shell/core/webapp/models/table'
 
 import { IResource, IKubeResource } from '../../model/resource'
 
@@ -69,20 +67,6 @@ export const containersButton = (command: string, resource: IResource, overrides
     parameters: { command, resource }
   }
 }, overrides || {})
-
-/**
- * Format a timestamp field from the status.containers model; these might be null
- *
- */
-const formatTimestamp = (timestamp: string): string => {
-  debug('formatTimestamp', timestamp)
-
-  if (!timestamp) {
-    return ''
-  } else {
-    return new Date(timestamp).toLocaleString()
-  }
-}
 
 /**
  * Render the tabular containers view
@@ -161,7 +145,7 @@ const bodyModel = (tab: ITab, resource: IResource): Row[] => {
         tag: 'badge',
         outerCSS: 'capitalize',
         css: stateKey === 'running' ? TrafficLight.Green : stateKey === 'terminated' ? TrafficLight.Red : TrafficLight.Yellow,
-        watch: async (idx: number) => {
+        watch: async () => {
           // { value, done = false, css, onclick, others = [], unchanged = false, outerCSS }
           const pod = await repl.qexec(`kubectl get pod ${podName} -n ${ns} -o json`, undefined, undefined, { raw: true })
 

--- a/plugins/plugin-k8s/src/lib/view/modes/last-applied.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/last-applied.ts
@@ -18,13 +18,8 @@ import * as Debug from 'debug'
 
 import { safeDump } from 'js-yaml'
 
-import { qexec as $$ } from '@kui-shell/core/core/repl'
 import { ITab } from '@kui-shell/core/webapp/cli'
-import drilldown from '@kui-shell/core/webapp/picture-in-picture'
-import { formatMultiListResult } from '@kui-shell/core/webapp/views/table'
-import { ISidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
 import { ICustomSpec } from '@kui-shell/core/webapp/views/sidecar'
-import { Table } from '@kui-shell/core/webapp/models/table'
 
 import { IResource, IKubeResource } from '../../model/resource'
 

--- a/plugins/plugin-k8s/src/lib/view/modes/pods.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/pods.ts
@@ -18,15 +18,11 @@ import * as Debug from 'debug'
 
 import { qexec as $$ } from '@kui-shell/core/core/repl'
 import { ITab } from '@kui-shell/core/webapp/cli'
-import drilldown from '@kui-shell/core/webapp/picture-in-picture'
-import { formatMultiListResult } from '@kui-shell/core/webapp/views/table'
-import { ISidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
 import { Table } from '@kui-shell/core/webapp/models/table'
 
 import { selectorToString } from '../../util/selectors'
 
 import { IResource, IKubeResource } from '../../model/resource'
-import { TrafficLight } from '../../model/states'
 
 import insertView from '../insert-view'
 import { formatTable } from '../formatMultiTable'

--- a/plugins/plugin-k8s/src/lib/view/redact.ts
+++ b/plugins/plugin-k8s/src/lib/view/redact.ts
@@ -71,7 +71,8 @@ const redactWithPattern = (str: string, pattern: RegExp): string => {
  * Redact the given YAML
  *
  */
-export const redactYAML = (str: string, options?): string => {
+// export const redactYAML = (str: string, options?): string => {
+export const redactYAML = (str: string): string => {
   return patterns.reduce(redactWithPattern, str)
 }
 
@@ -79,7 +80,8 @@ export const redactYAML = (str: string, options?): string => {
  * Redact the given JSON
  *
  */
-export const redactJSON = (obj: any, options?): any => {
+// export const redactJSON = (obj: any, options?): any => {
+export const redactJSON = (obj: any): any => {
   // FIXME
   return obj
 }

--- a/plugins/plugin-k8s/src/preload.ts
+++ b/plugins/plugin-k8s/src/preload.ts
@@ -17,7 +17,6 @@
 import * as Debug from 'debug'
 
 import { inBrowser } from '@kui-shell/core/core/capabilities'
-import { CommandRegistrar } from '@kui-shell/core/models/command'
 
 import { podMode } from './lib/view/modes/pods'
 import { conditionsMode } from './lib/view/modes/conditions'
@@ -31,7 +30,7 @@ const debug = Debug('plugins/k8s/preload')
  * This is the module
  *
  */
-export default async (commandTree: CommandRegistrar) => {
+export default async () => {
   registerSidecarMode(podMode) // show pods of deployments
   registerSidecarMode(containersMode) // show containers of pods
   registerSidecarMode(conditionsMode) // show conditions of a variety of resource kinds

--- a/plugins/plugin-k8s/src/test/k8s/contexts.ts
+++ b/plugins/plugin-k8s/src/test/k8s/contexts.ts
@@ -20,7 +20,7 @@ import { safeDump, safeLoad as parseYAML } from 'js-yaml'
 
 import expandHomeDir from '@kui-shell/core/util/home'
 import * as common from '@kui-shell/core/tests/lib/common'
-import { cli, expectYAMLSubset, expectSubset, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
+import { cli, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
 import { createNS, waitTillNone } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
 import path = require('path')
 import assert = require('assert')

--- a/plugins/plugin-k8s/src/test/k8s1/apply-pod.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/apply-pod.ts
@@ -18,9 +18,6 @@ import * as common from '@kui-shell/core/tests/lib/common'
 import { cli, selectors, sidecar, getValueFromMonaco, expectYAML } from '@kui-shell/core/tests/lib/ui'
 import { defaultModeForGet, createNS, allocateNS, deleteNS } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
 
-import { dirname } from 'path'
-const ROOT = dirname(require.resolve('@kui-shell/plugin-k8s/tests/package.json'))
-
 const synonyms = ['kubectl', 'k']
 const dashFs = ['-f', '--filename']
 

--- a/plugins/plugin-k8s/src/test/k8s1/config-map.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/config-map.ts
@@ -18,8 +18,6 @@ import * as common from '@kui-shell/core/tests/lib/common'
 import { expectYAMLSubset, cli, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
 import { defaultModeForGet, createNS, allocateNS, deleteNS, waitTillNone } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
 
-import assert = require('assert')
-
 const synonyms = ['kubectl']
 
 describe('electron configmap', function (this: common.ISuite) {

--- a/plugins/plugin-k8s/src/test/k8s1/describe.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/describe.ts
@@ -15,7 +15,7 @@
  */
 
 import * as common from '@kui-shell/core/tests/lib/common'
-import { cli, expectYAMLSubset, expectSubset, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
+import { cli, expectYAMLSubset, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
 import { defaultModeForGet, createNS, allocateNS, deleteNS } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
 
 const synonyms = ['kubectl']

--- a/plugins/plugin-k8s/src/test/k8s1/get-namespaces-with-watch.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/get-namespaces-with-watch.ts
@@ -15,7 +15,7 @@
  */
 
 import * as common from '@kui-shell/core/tests/lib/common'
-import { cli, expectSubset, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
+import { cli, selectors } from '@kui-shell/core/tests/lib/ui'
 import { createNS as create } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
 /** name of the namespace */
 const nsName: string = create()
@@ -108,7 +108,7 @@ const watchNS = function (this: common.ISuite, kubectl: string) {
       await this.app.client.waitForExist(selector2ButOffline)
 
       // create again
-      const selector4 = await waitForOnline(await cli.do(`${kubectl} create ns ${nsName}`, this.app))
+      await waitForOnline(await cli.do(`${kubectl} create ns ${nsName}`, this.app))
 
       // the "online" badge from the watch had better now exist again after the create
       // (i.e. we had better actually be watching!)

--- a/plugins/plugin-k8s/src/test/k8s1/helm.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/helm.ts
@@ -15,10 +15,9 @@
  */
 
 import * as common from '@kui-shell/core/tests/lib/common'
-import { cli, selectors } from '@kui-shell/core/tests/lib/ui'
+import { cli } from '@kui-shell/core/tests/lib/ui'
 import * as assert from 'assert'
-import * as Debug from 'debug'
-const debug = Debug('plugins/apache-composer/cmd/app-invoke')
+
 describe('helm commands', function (this: common.ISuite) {
   before(common.before(this))
   after(common.after(this))

--- a/plugins/plugin-k8s/src/test/k8s1/kedit.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/kedit.ts
@@ -21,7 +21,7 @@ import { Application } from 'spectron'
 
 import { readFileSync } from 'fs'
 import { dirname, join } from 'path'
-import { safeLoad, safeLoadAll, safeDump } from 'js-yaml'
+import { safeLoad, safeDump } from 'js-yaml'
 
 const ROOT = dirname(require.resolve('@kui-shell/plugin-k8s/tests/package.json'))
 
@@ -71,8 +71,6 @@ const save = (app: Application) => async (): Promise<void> => {
 }
 /** for some reason, monaco inserts a trailing view-line even for one-line files :( */
 const verifyYAML = (expected: object) => async (app: Application): Promise<void> => {
-  const selector = `${selectors.SIDECAR} .monaco-editor .view-lines`
-
   await app.client.waitUntil(async () => {
     const ok: boolean = await getValue(app)
       .then(expectYAML(expected, false, false)) // false: not a subset; false: do not throw, instead return boolean
@@ -98,7 +96,7 @@ describe('electron kedit', function (this: common.ISuite) {
     return this.app
   }
 
-  const switchToEdit = switchTo('edit')
+  switchTo('edit')
   const switchToRaw = (cmd: string) => async () => {
     if (cmd !== 'edit') {
       await switchTo('raw')()

--- a/plugins/plugin-k8s/src/test/k8s1/namespace.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/namespace.ts
@@ -15,7 +15,7 @@
  */
 
 import * as common from '@kui-shell/core/tests/lib/common'
-import { cli, expectYAMLSubset, expectSubset, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
+import { cli, expectYAMLSubset, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
 import { defaultModeForGet, createNS, waitTillNone } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
 
 const ns1: string = createNS()
@@ -81,28 +81,6 @@ describe('electron namespace', function (this: common.ISuite) {
           .then(sidecar.expectMode(defaultModeForGet))
           .then(expectEditorText)
           .catch(common.oops(this))
-      })
-    }
-
-    /** kubectl get namespace */
-    const listIt = (name: string) => {
-      it(`should list that namespace ${name} via ${kubectl}`, async () => {
-        try {
-          const selector = await cli.do(`${kubectl} get namespace`, this.app)
-            .then(cli.expectOKWithCustom({ selector: selectors.BY_NAME(name) }))
-
-          // wait for the badge to become green
-          await this.app.client.waitForExist(`${selector} badge.green-background`)
-
-          // now click on the table row
-          this.app.client.click(`${selector} .clickable`)
-          await sidecar.expectOpen(this.app)
-            .then(sidecar.expectMode(defaultModeForGet))
-            .then(sidecar.expectShowing(name))
-            .then(expectEditorText)
-        } catch (err) {
-          common.oops(this)(err)
-        }
       })
     }
 

--- a/plugins/plugin-k8s/src/test/k8s1/status.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/status.ts
@@ -15,7 +15,6 @@
  */
 
 import * as common from '@kui-shell/core/tests/lib/common'
-import { cli, selectors } from '@kui-shell/core/tests/lib/ui'
 import { createNS, waitTillNone } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
 import { kubectl, cli as kui, CLI } from '@kui-shell/core/tests/lib/headless'
 

--- a/plugins/plugin-k8s/src/test/k8s2/get-pod.ts
+++ b/plugins/plugin-k8s/src/test/k8s2/get-pod.ts
@@ -15,7 +15,7 @@
  */
 
 import * as common from '@kui-shell/core/tests/lib/common'
-import { cli, expectSubset, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
+import { cli, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
 import { defaultModeForGet, createNS, allocateNS, deleteNS } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
 
 import assert = require('assert')
@@ -51,25 +51,6 @@ describe('electron get pod', function (this: common.ISuite) {
 
       // check that the ready check mark is green
       await this.app.client.waitForExist(`${table} .entity[data-name="nginx"] [data-key="ready"].green-text .fa-check-circle`)
-    }
-
-    /**
-     * Interact with the Raw tab
-     *
-     */
-    const testRawTab = async () => {
-      this.app.client.click(selectors.SIDECAR_MODE_BUTTON('raw'))
-
-      // expect to see some familiar bits of a pod in the editor under the raw tab
-      return this.app.client.getText(`${selectors.SIDECAR} .monaco-editor .view-lines`)
-        .then(expectSubset({
-          apiVersion: 'v1',
-          kind: 'Pod',
-          metadata: {
-            name: 'nginx',
-            namespace: ns
-          }
-        }))
     }
 
     const ns: string = createNS()

--- a/plugins/plugin-k8s/src/test/k8s2/get-pods-with-watch.ts
+++ b/plugins/plugin-k8s/src/test/k8s2/get-pods-with-watch.ts
@@ -15,7 +15,7 @@
  */
 
 import * as common from '@kui-shell/core/tests/lib/common'
-import { cli, expectSubset, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
+import { cli, selectors } from '@kui-shell/core/tests/lib/ui'
 import { createNS, allocateNS, deleteNS } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
 
 /** name of the pod */
@@ -142,7 +142,7 @@ const watchPods = function (this: common.ISuite, kubectl: string, ns: string) {
       await this.app.client.waitForExist(selector2ButOffline)
 
       // create again
-      const selector4 = await waitForOnline(await cli.do(`${kubectl} create -f ${url} -n ${ns}`, this.app))
+      await waitForOnline(await cli.do(`${kubectl} create -f ${url} -n ${ns}`, this.app))
 
       // the "online" badge from the watch had better now exist again after the create
       // (i.e. we had better actually be watching!)

--- a/plugins/plugin-k8s/src/test/k8s2/helm-repo-add-and-search.ts
+++ b/plugins/plugin-k8s/src/test/k8s2/helm-repo-add-and-search.ts
@@ -15,10 +15,7 @@
  */
 
 import * as common from '@kui-shell/core/tests/lib/common'
-import { cli, expectSubset, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
-import { defaultModeForGet, createNS, allocateNS, deleteNS } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
-
-import assert = require('assert')
+import { cli } from '@kui-shell/core/tests/lib/ui'
 
 const synonyms = ['helm']
 


### PR DESCRIPTION
This one wasn't easy at all. I tried to keep commented things like we did in other PRs but I had to drop a lot of things. If I drop too many stuff we still use I can start a new one, but I need your review before :smile:.

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
