### PR TITLE
style(plugins/openwhisk): lint unused-vars

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,7 @@
         "plugins/plugin-editor/**/*.ts",
         "plugins/plugin-grid/**/*.ts",
         "plugins/plugin-manager/**/*.ts",
+        "plugins/plugin-openwhisk/**/*.ts",
         "plugins/plugin-openwhisk-debug/**/*.ts",
         "plugins/plugin-openwhisk-editor-extensions/**/*.ts",
         "plugins/plugin-proxy-support/**/*.ts",

--- a/plugins/plugin-openwhisk/src/lib/cmds/actions/_html.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/actions/_html.ts
@@ -27,7 +27,7 @@ import repl = require('@kui-shell/core/core/repl')
  * Deploy a linked asset
  *
  */
-const link = (dir, file, name) => new Promise((resolve, reject) => {
+const link = (dir, file) => new Promise((resolve, reject) => {
   const filepath = pathResolve(dir, file)
   lstat(filepath, (err, stats) => {
     if (stats) {
@@ -87,11 +87,11 @@ export const deployHTMLViaOpenWhisk = location => new Promise((resolve, reject) 
           onopentag: (name, attribs) => {
             if (name === 'script' && attribs.src) {
               const webbed = webbify(attribs.src)
-              Ps.push(link(dir, attribs.src, webbed))
+              Ps.push(link(dir, attribs.src))
               attribs.src = webbed
             } else if (name === 'link' && attribs.href) {
               const webbed = webbify(attribs.href)
-              Ps.push(link(dir, attribs.href, webbed))
+              Ps.push(link(dir, attribs.href))
               attribs.href = webbed
             }
 

--- a/plugins/plugin-openwhisk/src/lib/cmds/actions/invoke.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/actions/invoke.ts
@@ -37,7 +37,7 @@ import repl = require('@kui-shell/core/core/repl')
  * Make a documentation struct
  *
  */
-const docs = (syn: string) => ({
+const docs = () => ({
   usage: actions.available.find(({ command }) => command === 'invoke')
 })
 
@@ -133,7 +133,7 @@ export default async (commandTree: CommandRegistrar) => {
   const asyncInvoke = doAsync(rawHandler) //             ... and for async
 
   synonyms('actions').map(syn => {
-    const invokeOpts = docs(syn)
+    const invokeOpts = docs()
     const asyncOpts = {
       usage: Object.assign({}, invokeOpts.usage, {
         command: 'async',

--- a/plugins/plugin-openwhisk/src/lib/cmds/actions/let.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/actions/let.ts
@@ -214,7 +214,7 @@ const makeZipActionFromZipFile = (wsk, name: string, location: string, options, 
   try {
     debug('makeZipActionFromZipFile', name, location, options)
 
-    lstat(location, (err, stats) => {
+    lstat(location, (err) => {
       if (err) {
         console.error(err)
         reject(new Error(`I think you asked to create a zip action, but the specified zip file does not exist: ${location}`))

--- a/plugins/plugin-openwhisk/src/lib/cmds/activations/await.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/activations/await.ts
@@ -88,7 +88,7 @@ const fetch = activationId => new Promise((resolve, reject) => {
  * Check to see whether the given activation has completed
  *
  */
-const poll = activation => new Promise((resolve, reject) => {
+const poll = activation => new Promise((resolve) => {
   const iter = () => {
     if (activation.end || activation.response.status) {
       // then the activation has finished!

--- a/plugins/plugin-openwhisk/src/lib/cmds/activations/list.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/activations/list.ts
@@ -23,8 +23,6 @@ import { activations as usage } from '../openwhisk-usage'
 import { renderActivationListView } from '../../views/cli/activations/list'
 const debug = Debug('plugins/openwhisk/activations/list')
 
-import repl = require('@kui-shell/core/core/repl')
-
 interface IOptions {
   docs: boolean
   limit: number

--- a/plugins/plugin-openwhisk/src/lib/cmds/beautify.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/beautify.ts
@@ -15,7 +15,6 @@
  */
 
 import { isHeadless } from '@kui-shell/core/core/capabilities'
-import * as cli from '@kui-shell/core/webapp/cli'
 import { getSidecar } from '@kui-shell/core/webapp/views/sidecar'
 import { CommandRegistrar } from '@kui-shell/core/models/command'
 
@@ -30,7 +29,7 @@ declare var hljs
  *
  */
 export default async (commandTree: CommandRegistrar) => {
-  synonyms('actions').forEach(syn => commandTree.listen(`/wsk/${syn}/beautify`, ({ block, nextBlock, execOptions, tab }) => {
+  synonyms('actions').forEach(syn => commandTree.listen(`/wsk/${syn}/beautify`, ({ execOptions, tab }) => {
     if (isHeadless()) {
       throw new Error('beautify not supported in headless mode')
     }

--- a/plugins/plugin-openwhisk/src/lib/cmds/context.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/context.ts
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-import * as Debug from 'debug'
-
 import { current } from '../models/namespace'
 import { CommandRegistrar } from '@kui-shell/core/models/command'
-const debug = Debug('plugins/openwhisk/cmds/namespace/current')
-import repl = require('@kui-shell/core/core/repl')
 
 export default (commandTree: CommandRegistrar) => {
   // register namespace.current command

--- a/plugins/plugin-openwhisk/src/lib/cmds/list-all.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/list-all.ts
@@ -41,7 +41,7 @@ const types = [ 'actions', 'packages', 'triggers', 'rules' ]
 const list = type => repl.qexec(`wsk ${type} list`, undefined, undefined, { showHeader: true })
 
 /** the command handler */
-const doList = cmd => () => Promise.all(types.map(list)).then(L => {
+const doList = () => () => Promise.all(types.map(list)).then(L => {
   return L.map(_ => _[0] || []).filter(x => x.length > 0)
 })
 
@@ -50,5 +50,5 @@ const doList = cmd => () => Promise.all(types.map(list)).then(L => {
  *
  */
 export default (commandTree) => {
-  commandTree.listen(`/wsk/list`, doList('list'), docs('list'))
+  commandTree.listen(`/wsk/list`, doList(), docs('list'))
 }

--- a/plugins/plugin-openwhisk/src/lib/cmds/load-test.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/load-test.ts
@@ -37,7 +37,7 @@ const usage = (verb: string) => `Usage: ${verb} <action> [--numIters|-n N] [--nu
 
 const costFns = {
   duration: {
-    cost: (duration: string, memory: string) => duration, // nothing fancy, duration alone is our measure
+    cost: (duration: string) => duration, // nothing fancy, duration alone is our measure
     pretty: prettyPrintDuration, // use the pretty-ms module to render durations
 
     summary: D => D.N === 0 ? `No such recent activity of ${D.name}` : `The <strong>average</strong> duration of <strong>${D.N}</strong> ${D.N === 1 ? 'activation' : 'activations'} ${D.name ? 'of ' + D.name : ''} was <strong>${prettyPrintDuration(D.totalCost / D.N)}</strong>.`
@@ -195,7 +195,7 @@ const loadtest = (verb: string) => ({ argv: argvWithOptions, argvNoOptions: argv
     numErrors?: number
   }
 
-  return new Promise<ITally>((resolve, reject) => {
+  return new Promise<ITally>((resolve) => {
     // tally of results
     const tally: ITally = {
       durations: {

--- a/plugins/plugin-openwhisk/src/lib/cmds/mv.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/mv.ts
@@ -48,7 +48,7 @@ const usage = (type: string, command: string) => ({
  * This is the core logic
  *
  */
-const mv = (type: string) => (op: string) => ({ argvNoOptions: argv, parsedOptions: options }: IEvaluatorArgs) => {
+const mv = (type: string) => (op: string) => ({ argvNoOptions: argv }: IEvaluatorArgs) => {
   const idx = argv.indexOf(op) + 1
   const oldName = argv[idx]
   const newName = argv[idx + 1]

--- a/plugins/plugin-openwhisk/src/lib/cmds/rules/every.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/rules/every.ts
@@ -63,7 +63,7 @@ const doEvery = async ({ argv }) => {
  * Register the command
  *
  */
-export default (commandTree, require) => {
+export default (commandTree) => {
   // install the routes
   commandTree.listen('/wsk/every', doEvery, { docs: 'Execute an OpenWhisk action periodically; e.g. "every 5 sec do foo"' })
   // commandTree.listen('/wsk/never', doEvery, { docs: 'Remove a periodic execution; e.g. "never 5 sec do foo"' })

--- a/plugins/plugin-openwhisk/src/lib/cmds/wipe.ts
+++ b/plugins/plugin-openwhisk/src/lib/cmds/wipe.ts
@@ -16,7 +16,7 @@
 
 import * as Debug from 'debug'
 
-import { inBrowser, isHeadless } from '@kui-shell/core/core/capabilities'
+import { isHeadless } from '@kui-shell/core/core/capabilities'
 import { hide as hideSidecar } from '@kui-shell/core/webapp/views/sidecar'
 import { CommandRegistrar, IEvaluatorArgs } from '@kui-shell/core/models/command'
 const debug = Debug('plugins/openwhisk/cmds/wipe')

--- a/plugins/plugin-openwhisk/src/lib/views/cli/activations/entity.ts
+++ b/plugins/plugin-openwhisk/src/lib/views/cli/activations/entity.ts
@@ -19,7 +19,7 @@ import * as Debug from 'debug'
 import { ok, ITab } from '@kui-shell/core/webapp/cli'
 import { showEntity } from '@kui-shell/core/webapp/views/sidecar'
 import { pexec } from '@kui-shell/core/core/repl'
-import { Entity, IEntitySpec } from '@kui-shell/core/models/entity'
+import { IEntitySpec } from '@kui-shell/core/models/entity'
 
 import { current as currentNamespace } from '../../../models/namespace'
 import { IActivation, isAsyncActivationSpec } from '../../../models/openwhisk-entity'

--- a/plugins/plugin-openwhisk/src/lib/views/cli/activations/list.ts
+++ b/plugins/plugin-openwhisk/src/lib/views/cli/activations/list.ts
@@ -575,7 +575,7 @@ const _render = args => {
  * A handler intended to be passed to cli.registerListView
  *
  */
-export const renderActivationListView = (tab: ITab, activations: Object[], container: Element, parsedOptions, execOptions) => {
+export const renderActivationListView = (tab: ITab, activations: Object[], container: Element, parsedOptions) => {
   debug('rendering activation list view', activations)
 
   const subset = Object.assign({}, parsedOptions)

--- a/plugins/plugin-openwhisk/src/lib/views/sidecar/activations.ts
+++ b/plugins/plugin-openwhisk/src/lib/views/sidecar/activations.ts
@@ -23,7 +23,7 @@ import * as repl from '@kui-shell/core/core/repl'
 import { element, removeAllDomChildren } from '@kui-shell/core/webapp/util/dom'
 import { linkify, getSidecar, renderField, showCustom } from '@kui-shell/core/webapp/views/sidecar'
 import { prettyPrintTime } from '@kui-shell/core/webapp/util/time'
-import { IShowOptions, DefaultShowOptions } from '@kui-shell/core/webapp/views/show-options'
+import { IShowOptions } from '@kui-shell/core/webapp/views/show-options'
 import { ITab } from '@kui-shell/core/webapp/cli'
 
 import { isActivationId } from '../../models/activation'

--- a/plugins/plugin-openwhisk/src/lib/views/sidecar/entity.ts
+++ b/plugins/plugin-openwhisk/src/lib/views/sidecar/entity.ts
@@ -18,12 +18,10 @@ import * as Debug from 'debug'
 
 import * as cli from '@kui-shell/core/webapp/cli'
 import * as repl from '@kui-shell/core/core/repl'
-import eventBus from '@kui-shell/core/core/events'
 
-import { addModeButtons } from '@kui-shell/core/webapp/bottom-stripe'
 import { element, removeAllDomChildren } from '@kui-shell/core/webapp/util/dom'
 import { formatOneListResult } from '@kui-shell/core/webapp/views/table'
-import { addBadge, addNameToSidecarHeader, addVersionBadge, beautify, clearBadges, getSidecar, linkify, renderField } from '@kui-shell/core/webapp/views/sidecar'
+import { addBadge, beautify, getSidecar, renderField } from '@kui-shell/core/webapp/views/sidecar'
 import sidecarSelector from '@kui-shell/core/webapp/views/sidecar-selector'
 import { IShowOptions, DefaultShowOptions } from '@kui-shell/core/webapp/views/show-options'
 
@@ -213,7 +211,7 @@ export const showEntity = async (tab: cli.ITab, entity, sidecar: Element, option
         // form a fake AST, so we can use the wskflow visualization
         // wskflw now use the IR, so we have to fake a IR instead of a AST
         // const key = idx => `action_${idx}`
-        Promise.all(entity.exec.components.map((actionName, idx, A) => repl.qexec(`wsk action get "${actionName}"`)
+        Promise.all(entity.exec.components.map((actionName) => repl.qexec(`wsk action get "${actionName}"`)
           .then(action => {
             const anonymousCode = isAnonymousLet(action)
             if (anonymousCode) {

--- a/plugins/plugin-openwhisk/src/plugin.ts
+++ b/plugins/plugin-openwhisk/src/plugin.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as Debug from 'debug'
-
 import { CommandRegistrar } from '@kui-shell/core/models/command'
 
 import cp from './lib/cmds/copy'
@@ -42,7 +40,6 @@ import core from './lib/cmds/openwhisk-core'
 import activationList from './lib/cmds/activations/list'
 
 import registerViews from './views'
-const debug = Debug('plugins/openwhisk/loader')
 
 export default async (commandTree: CommandRegistrar) => {
   const wsk = await core(commandTree)
@@ -72,7 +69,7 @@ export default async (commandTree: CommandRegistrar) => {
 
   // rule extension
   await on(commandTree)
-  await every(commandTree, wsk)
+  await every(commandTree)
 
   // views
   await modes(commandTree, wsk)

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/action-drilldown-from-activation.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/action-drilldown-from-activation.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const actionName = `foo-${new Date().getTime()}`
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/action-list-click.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/action-list-click.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const actionName = 'foo'
 const actionName2 = 'foo2'
@@ -45,7 +45,7 @@ describe('create action list it then click to show it again', function (this: co
 
     // click on the row entity, and expect sidecar to show it
     .then(N => this.app.client.click(`${ui.selectors.OUTPUT_N(N)} .entity[data-name="${actionName}"] .entity-name.clickable`))
-    .then(_ => this.app)
+    .then(() => this.app)
     .then(sidecar.expectOpen)
     .then(sidecar.expectShowing(actionName))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/action-update.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/action-update.ts
@@ -20,7 +20,7 @@ import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/open
 
 import { dirname } from 'path'
 const { localIt } = common
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 const actionName = 'foo'

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/activation-get-last.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/activation-get-last.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 const actionName1 = `foo1-${new Date().getTime()}`

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/activation-result.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/activation-result.ts
@@ -23,7 +23,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/all-numeric-uuids.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/all-numeric-uuids.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli } = ui
 
 // see https://github.com/ibm-functions/shell/issues/284
 describe('Confirm proper handling of all-numeric uuids', function (this: common.ISuite) {

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/basic-stuff.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/basic-stuff.ts
@@ -19,17 +19,14 @@
  *
  */
 
-import * as assert from 'assert'
-
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, sidecar } = ui
-const { localDescribe } = common
+const { cli } = ui
 const { validateNamespace, expectedNamespace } = ui
 
 const API_HOST = process.env.API_HOST
-const APP_TITLE = process.env.APP_TITLE || 'Kui Shell'
+// const APP_TITLE = process.env.APP_TITLE || 'Kui Shell'
 // const CLI_PLACEHOLDER = process.env.CLI_PLACEHOLDER || 'enter your command'
 
 const selectors = {

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/bottom-stripe-action.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/bottom-stripe-action.ts
@@ -28,7 +28,7 @@ import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/open
 // so we can compare the content of code mode
 import { readFileSync } from 'fs'
 import * as path from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 
 const actionName = 'foo'
@@ -59,7 +59,7 @@ localDescribe('Sidecar bottom stripe interactions for actions', function (this: 
       await this.app.client.click(ui.selectors.SIDECAR_MODE_BUTTON('annotations'))
       return sidecar.expectOpen(this.app)
         .then(sidecar.expectShowing(name))
-        .then(app => this.app.client.getText(`${ui.selectors.SIDECAR_CONTENT} .action-source`))
+        .then(() => this.app.client.getText(`${ui.selectors.SIDECAR_CONTENT} .action-source`))
         .then(ui.expectSubset(expectedAnnotations))
         .catch(common.oops(this))
     })
@@ -69,7 +69,7 @@ localDescribe('Sidecar bottom stripe interactions for actions', function (this: 
       await this.app.client.click(ui.selectors.SIDECAR_MODE_BUTTON('code'))
       return sidecar.expectOpen(this.app)
         .then(sidecar.expectShowing(name))
-        .then(app => this.app.client.getText(`${ui.selectors.SIDECAR_CONTENT} .action-source`))
+        .then(() => this.app.client.getText(`${ui.selectors.SIDECAR_CONTENT} .action-source`))
         .then(code => assert.strictEqual(code.replace(/\s+/g, ''), expectedSrc.replace(/\s+/g, '')))
         .catch(common.oops(this))
     })

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/bottom-stripe-activation.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/bottom-stripe-activation.ts
@@ -25,7 +25,7 @@ import * as assert from 'assert'
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const actionName = 'foo'
 
@@ -40,7 +40,7 @@ describe('Sidecar bottom stripe interactions for activations', function (this: c
       await this.app.client.click(ui.selectors.SIDECAR_MODE_BUTTON('logs'))
       return sidecar.expectOpen(this.app)
         .then(sidecar.expectShowing(name))
-        .then(app => this.app.client.getText(`${ui.selectors.SIDECAR_CONTENT} .activation-result`))
+        .then(() => this.app.client.getText(`${ui.selectors.SIDECAR_CONTENT} .activation-result`))
         .then(actualLogs => {
           if (actualLogs.replace(/\s+/g, '').indexOf(expectedLogs.replace(/\s+/g, '')) < 0) {
             console.error(actualLogs.replace(/\s+/g, '') + ' != ' + expectedLogs.replace(/\s+/g, ''))
@@ -57,7 +57,7 @@ describe('Sidecar bottom stripe interactions for activations', function (this: c
       await this.app.client.click(ui.selectors.SIDECAR_MODE_BUTTON('annotations'))
       return sidecar.expectOpen(this.app)
         .then(sidecar.expectShowing(name))
-        .then(app => this.app.client.getText(`${ui.selectors.SIDECAR_CONTENT} .activation-result`))
+        .then(() => this.app.client.getText(`${ui.selectors.SIDECAR_CONTENT} .activation-result`))
         .then(ui.expectSubset(subsetOfAnnotations))
         .catch(common.oops(this))
     })
@@ -67,7 +67,7 @@ describe('Sidecar bottom stripe interactions for activations', function (this: c
       await this.app.client.click(ui.selectors.SIDECAR_MODE_BUTTON('result'))
       return sidecar.expectOpen(this.app)
         .then(sidecar.expectShowing(name))
-        .then(app => this.app.client.getText(`${ui.selectors.SIDECAR_CONTENT} .activation-result`))
+        .then(() => this.app.client.getText(`${ui.selectors.SIDECAR_CONTENT} .activation-result`))
         .then(ui.expectStruct(expectedResult))
         .catch(common.oops(this))
     })
@@ -77,7 +77,7 @@ describe('Sidecar bottom stripe interactions for activations', function (this: c
       await this.app.client.click(ui.selectors.SIDECAR_MODE_BUTTON('raw'))
       return sidecar.expectOpen(this.app)
         .then(sidecar.expectShowing(name))
-        .then(app => this.app.client.getText(`${ui.selectors.SIDECAR_CONTENT} .activation-result`))
+        .then(() => this.app.client.getText(`${ui.selectors.SIDECAR_CONTENT} .activation-result`))
         .then(ui.expectSubset({ name, namespace: ui.expectedNamespace() })) // parts of the raw annotation record
         .catch(common.oops(this))
     })

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/command-not-found-suggestions.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/command-not-found-suggestions.ts
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert'
-
 import * as common from '@kui-shell/core/tests/lib/common'
-import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { expectSuggestionsFor } from '@kui-shell/core/test/core/command-not-found-suggestions'
-const { cli, selectors, sidecar } = ui
 
 describe('Suggestions for command not found', function (this: common.ISuite) {
   before(openwhisk.before(this))

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/copy-action.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/copy-action.ts
@@ -19,14 +19,12 @@
  *    this test also covers toggling the sidecar
  */
 
-import * as assert from 'assert'
-
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-add-parameter/action.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-add-parameter/action.ts
@@ -26,7 +26,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-add-parameter/annotate.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-add-parameter/annotate.ts
@@ -26,7 +26,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-add-parameter/package.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-add-parameter/package.ts
@@ -20,7 +20,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-add-parameter/trigger.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-add-parameter/trigger.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const triggerName = 'ppp'
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-add-parameter/with-quotes.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-add-parameter/with-quotes.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-delete-then-list/action-with-explicit-entity-type.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-delete-then-list/action-with-explicit-entity-type.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-delete-then-list/action-with-implicit-entity-type.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-delete-then-list/action-with-implicit-entity-type.ts
@@ -23,7 +23,7 @@ import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-delete-then-list/sequence.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-delete-then-list/sequence.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-invoke/create-invoke-list.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-invoke/create-invoke-list.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-invoke/create-package-action-then-invoke.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-invoke/create-package-action-then-invoke.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-invoke/synchronous-invoke.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-invoke/synchronous-invoke.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-list/action-with-implicit-entity-type.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-list/action-with-implicit-entity-type.ts
@@ -23,7 +23,7 @@ import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 import { dirname } from 'path'
-const { cli, keys, selectors, sidecar } = ui
+const { cli, keys, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-list/create-two-actions.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-list/create-two-actions.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-list/sequence-with-spaces.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-list/sequence-with-spaces.ts
@@ -23,7 +23,7 @@ import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-list/sequence.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-list/sequence.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-list/with-explicit-entity-type.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/create-then-list/with-explicit-entity-type.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/headless.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/headless.ts
@@ -15,10 +15,9 @@
  */
 
 import * as assert from 'assert'
-import { exec } from 'child_process'
 
 // for now, use require, to support headless from bx tests
-import { HookFunction, Context, Suite } from 'mocha'
+import { Suite } from 'mocha'
 import { Application } from 'spectron'
 
 import * as common from '@kui-shell/core/tests/lib/common'
@@ -28,14 +27,11 @@ import { cli } from '@kui-shell/core/tests/lib/headless'
 
 import { dirname, join } from 'path'
 
-const debug = require('debug')('test.openwhisk1.headless')
 interface ISuite extends Suite {
   app: Application
 }
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
-
-const kui = process.env.KUI || join(process.env.TEST_ROOT, '../../bin/kui')
 
 export const { version: expectedVersion } = require('@kui-shell/settings/package.json')
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/help.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/help.ts
@@ -20,11 +20,9 @@
  */
 
 import * as common from '@kui-shell/core/tests/lib/common'
-import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { doHelp, header, header2 } from '@kui-shell/plugin-core-support/test/core-support/help'
-const { cli, selectors, sidecar } = ui
 
 /* the header for action help */
 const actionHelpHeader = header2('OpenWhisk', 'Action Operations')

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/host.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/host.ts
@@ -19,12 +19,10 @@
  *    this test also covers toggling the sidecar
  */
 
-import * as assert from 'assert'
-
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli } = ui
 
 describe('host tests', function (this: common.ISuite) {
   before(openwhisk.before(this))

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/list/entities.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/list/entities.ts
@@ -22,7 +22,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli } = ui
 
 describe('List entities with a clean slate', function (this: common.ISuite) {
   before(openwhisk.before(this))

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/list/namespace.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/list/namespace.ts
@@ -22,7 +22,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli } = ui
 
 describe('Namespaces list', function (this: common.ISuite) {
   before(openwhisk.before(this))

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/package-bind.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/package-bind.ts
@@ -19,12 +19,10 @@
  *
  */
 
-import * as assert from 'assert'
-
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 describe('wsk package bind tests', function (this: common.ISuite) {
   before(openwhisk.before(this))

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/package-list.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/package-list.ts
@@ -19,8 +19,6 @@
  *
  */
 
-import * as assert from 'assert'
-
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/quiet-invoke.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/quiet-invoke.ts
@@ -19,14 +19,12 @@
  *    this test also covers toggling the sidecar
  */
 
-import * as assert from 'assert'
-
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/quote-parsing.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/quote-parsing.ts
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert'
-
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 describe('parameter parsing with quotes', function (this: common.ISuite) {
   before(openwhisk.before(this))

--- a/plugins/plugin-openwhisk/src/test/openwhisk1/trigger-fire.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk1/trigger-fire.ts
@@ -19,12 +19,10 @@
  *
  */
 
-import * as assert from 'assert'
-
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 describe('wsk trigger fire tests', function (this: common.ISuite) {
   before(openwhisk.before(this))

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/apis.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/apis.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { rp } = common
 
 describe('Create api gateway', function (this: common.ISuite) {

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/at-file-params.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/at-file-params.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const paramsFileContent = require('@kui-shell/plugin-openwhisk/tests/data/openwhisk/params.json')
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/auth.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/auth.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 describe('auth tests', function (this: common.ISuite) {

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/await.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/await.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 const actionName = 'long'

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/click-on-action-part-of-activation.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/click-on-action-part-of-activation.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 describe('Click on action part of activation sidecar', function (this: common.ISuite) {

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/copy.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/copy.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const actionName1 = 'foo1'
 const actionName1b = 'foo1b'

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/edit-new.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/edit-new.ts
@@ -22,7 +22,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 describe('create new actions in editor', function (this: common.ISuite) {
   before(openwhisk.before(this))

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/edit.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/edit.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 describe('edit actions', function (this: common.ISuite) {

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/history.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/history.ts
@@ -19,7 +19,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 describe('History', function (this: common.ISuite) {

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/jar.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/jar.ts
@@ -21,7 +21,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 const actionName1 = 'foo1'

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/load-test.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/load-test.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli } = ui
 
 const actionName = 'foo'
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/rename.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/rename.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const actionName1 = 'foo1'
 const actionName1b = 'foo1b'

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/rm-with-wildcards.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/rm-with-wildcards.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const subset = ['foo', 'foo2']
 const actions = subset.concat(['goo'])

--- a/plugins/plugin-openwhisk/src/test/openwhisk2/rm.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk2/rm.ts
@@ -19,7 +19,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 const actionName = 'foo'

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/ctrl-c.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/ctrl-c.ts
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert'
-
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const delay = 3000
 const actionName = 'foo'

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/lcd.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/lcd.ts
@@ -19,7 +19,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname, normalize } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/limits-via-let.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/limits-via-let.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/limits.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/limits.ts
@@ -24,7 +24,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/list-all-v2.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/list-all-v2.ts
@@ -22,7 +22,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const actionName = 'foo'
 const packageName = 'ppp'

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/list-all.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/list-all.ts
@@ -22,7 +22,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const actionName = 'foo'
 const packageName = 'ppp'

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/local.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/local.ts
@@ -24,7 +24,7 @@ import * as assert from 'assert'
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 
 localDescribe('local plugin', function (this: common.ISuite) {

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/on.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/on.ts
@@ -19,7 +19,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { expectRule } from '@kui-shell/plugin-apache-composer/tests/lib/composer-viz-util'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const actionName = 'foo'
 const actionName2 = 'foo2'

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/paste.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/paste.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const actionName = 'foo'
 const actionName2 = 'foo2'

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/popup.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/popup.ts
@@ -15,7 +15,7 @@
  */
 
 import * as common from '@kui-shell/core/tests/lib/common'
-import { cli, selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
+import { selectors, sidecar } from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 import { readFileSync } from 'fs'
 import { dirname, join } from 'path'

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/roots-with-error.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/roots-with-error.ts
@@ -21,7 +21,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/run.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/run.ts
@@ -22,7 +22,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname, join } from 'path'
-const { cli, normalizeHTML, selectors, sidecar } = ui
+const { cli, normalizeHTML } = ui
 const { rp, localDescribe } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/seq-let.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/seq-let.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const seqName = 'seq'
 const seqName2 = 'seq2'

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/tab-completion.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/tab-completion.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert'
 import { Application } from 'spectron'
 
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, keys, selectors, sidecar } = ui
+const { cli, keys, sidecar } = ui
 
 /** execute the given async task n times */
 const doTimes = (n: number, task: () => Promise<void>) => {
@@ -62,7 +61,7 @@ describe('Tab completion openwhisk', function (this: common.ISuite) {
     })
     .catch(common.oops(this))
 
-  const tabbyWithOptions = (app: Application, partial: string, expected?: string[], full?: string, { click = undefined, nTabs = undefined, expectOK = true, iter = 0, expectedPromptAfterTab = undefined } = {}) => {
+  const tabbyWithOptions = (app: Application, partial: string, expected?: string[], full?: string, { click = undefined, nTabs = undefined, expectOK = true, expectedPromptAfterTab = undefined } = {}) => {
     return app.client.waitForExist(ui.selectors.CURRENT_PROMPT_BLOCK)
       .then(() => app.client.getAttribute(ui.selectors.CURRENT_PROMPT_BLOCK, 'data-input-count'))
       .then(count => parseInt(count, 10))
@@ -124,20 +123,6 @@ describe('Tab completion openwhisk', function (this: common.ISuite) {
         return common.oops(this)(err)
       })
   }
-
-  const tabbyWithOptionsThenCancel = (app: Application, partial: string, expected: string[]) => app.client.waitForExist(ui.selectors.CURRENT_PROMPT_BLOCK)
-    .then(() => app.client.getAttribute(ui.selectors.CURRENT_PROMPT_BLOCK, 'data-input-count'))
-    .then(count => parseInt(count, 10))
-    .then(count => app.client.setValue(ui.selectors.CURRENT_PROMPT, partial)
-      .then(() => waitForValue(app, ui.selectors.PROMPT_N(count), partial))
-      .then(() => app.client.setValue(ui.selectors.CURRENT_PROMPT, `${partial}${keys.TAB}`))
-      .then(() => app.client.waitForVisible(`${ui.selectors.PROMPT_BLOCK_N(count)} .tab-completion-temporary .clickable`))
-      .then(() => app.client.getText(`${ui.selectors.PROMPT_BLOCK_N(count)} .tab-completion-temporary .clickable`))
-      .then(ui.expectArray(expected))
-      .then(() => app.client.keys('ffffff')) // type something random
-      .then(() => app.client.waitForVisible(`${ui.selectors.PROMPT_BLOCK_N(count)} .tab-completion-temporary`, 20000, true))) // wait for non-existence of the temporary
-    .then(() => this.app.client.keys(ui.ctrlC)) // clear the line
-    .catch(common.oops(this))
 
   it('should create an action foo', () => cli.do('let foo = x=>x', this.app)
     .then(cli.expectOK)

--- a/plugins/plugin-openwhisk/src/test/openwhisk3/z-activation-list-drilldowns.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk3/z-activation-list-drilldowns.ts
@@ -22,7 +22,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, keys, selectors, sidecar } = ui
+const { cli, keys, sidecar } = ui
 
 describe('List activations, then drill down to summary views', function (this: common.ISuite) {
   before(openwhisk.before(this))

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/blackbox-action-shell-script.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/blackbox-action-shell-script.ts
@@ -22,7 +22,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 const flip = 'flip'

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/blackbox-action.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/blackbox-action.ts
@@ -21,7 +21,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 describe('blackbox actions', function (this: common.ISuite) {

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/invoke-dash-r.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/invoke-dash-r.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const actionName = 'foo'
 const actionName2 = 'foo2'

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/invoke-implicit.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/invoke-implicit.ts
@@ -19,7 +19,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 import paramsJson = require('@kui-shell/plugin-openwhisk/tests/data/openwhisk/params.json')

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/invoke-non-existent-action.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/invoke-non-existent-action.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const actionName = 'foo'
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/let-anonymous.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/let-anonymous.ts
@@ -17,7 +17,7 @@
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 
 const actionName1 = 'foo1'
 const actionName2 = 'foo2'

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/let-base64.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/let-base64.ts
@@ -21,7 +21,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 const file = `${ROOT}/data/openwhisk/not-really-png.png`

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/let-remote.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/let-remote.ts
@@ -22,7 +22,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, normalizeHTML, selectors, sidecar } = ui
+const { cli, normalizeHTML, sidecar } = ui
 const { rp } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/let-webjs.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/let-webjs.ts
@@ -21,8 +21,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
-const { rp } = common
+const { cli } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 const HTML_WITH_JS_INPUT = `${ROOT}/data/openwhisk/hello-with-script.html`

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/let-with-dots.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/let-with-dots.ts
@@ -19,7 +19,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 const fileWithSpaces = `${ROOT}/data/openwhisk/dir with spaces/foo.js`

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/let-with-spaces.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/let-with-spaces.ts
@@ -19,7 +19,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 const fileWithSpaces = `${ROOT}/data/openwhisk/dir with spaces/foo.js`

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/let.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/let.ts
@@ -22,7 +22,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { rp } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/pagination.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/pagination.ts
@@ -19,7 +19,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 const actionName = `paginator-test-${new Date().getTime()}`

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/webbify.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/webbify.ts
@@ -21,7 +21,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const { rp } = common
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/wipe.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/wipe.ts
@@ -19,7 +19,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname } from 'path'
-const { cli, keys, selectors, sidecar } = ui
+const { cli, keys } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 describe('wipe command', function (this: common.ISuite) {

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/zip.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/zip.ts
@@ -22,7 +22,7 @@ import * as ui from '@kui-shell/core/tests/lib/ui'
 import * as openwhisk from '@kui-shell/plugin-openwhisk/tests/lib/openwhisk/openwhisk'
 
 import { dirname, join } from 'path'
-const { cli, selectors, sidecar } = ui
+const { cli, sidecar } = ui
 const ROOT = dirname(require.resolve('@kui-shell/plugin-openwhisk/tests/package.json'))
 
 const actionName1 = 'foo1'
@@ -34,7 +34,7 @@ const actionName18 = 'foo18'
 
 const rimraf = filepath => {
   if (fs.existsSync(filepath)) {
-    fs.readdirSync(filepath).forEach((file, index) => {
+    fs.readdirSync(filepath).forEach((file) => {
       const curPath = join(filepath, file)
       if (fs.lstatSync(curPath).isDirectory()) {
         rimraf(curPath)

--- a/plugins/plugin-openwhisk/src/views.ts
+++ b/plugins/plugin-openwhisk/src/views.ts
@@ -15,8 +15,8 @@
  */
 
 import { isHeadless } from '@kui-shell/core/core/capabilities'
-import { ITab, ViewHandler, registerListView, registerEntityView as registerCLIEntityView } from '@kui-shell/core/webapp/cli'
-import { ISidecarViewHandler, registerEntityView as registerSidecarEntityView } from '@kui-shell/core/webapp/views/sidecar'
+import { ITab, ViewHandler, registerEntityView as registerCLIEntityView } from '@kui-shell/core/webapp/cli'
+import { registerEntityView as registerSidecarEntityView } from '@kui-shell/core/webapp/views/sidecar'
 import { IShowOptions } from '@kui-shell/core/webapp/views/show-options'
 import { Entity } from '@kui-shell/core/models/entity'
 


### PR DESCRIPTION
#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
