### PR TITLE
test: travis test webpack build with http and no compression 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,9 @@ env:
   global:
     - TRAVIS_KUBE_VERSION=1.12 # kubeadm-dind
     - TRAVIS_HELM_VERSION=2.13.0 # kubeadm-dind
-    - WEBPACK_CLIENT_URL="https://localhost:9080/"
+    - WEBPACK_CLIENT_URL="http://localhost:9080/"
+    - WEB_COMPRESS=none
+    - KUI_USE_HTTP=true
     - TEST_ORG=testorg
     - TEST_SPACE=testspace
     - LOCAL_OPENWHISK=true # allows e.g. openwhisk/src/test/openwhisk1/headless to avoid trying to host set <not-local>

--- a/packages/kui-builder/dist/webpack/Dockerfile.http
+++ b/packages/kui-builder/dist/webpack/Dockerfile.http
@@ -1,0 +1,2 @@
+FROM nginx
+COPY build /usr/share/nginx/html

--- a/packages/kui-builder/dist/webpack/bin/webpack-client.sh
+++ b/packages/kui-builder/dist/webpack/bin/webpack-client.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 echo 'Visit this url:'
-echo 'https://localhost:9080'
-
-docker run --rm -p 9080:443 kui-webpack
+if [ "$KUI_USE_HTTP" == true ]; then
+  echo 'http://localhost:9080'
+  docker run --rm -p 9080:80 kui-webpack
+else
+  echo 'https://localhost:9080'
+  docker run --rm -p 9080:443 kui-webpack
+fi

--- a/packages/kui-builder/dist/webpack/build-docker.sh
+++ b/packages/kui-builder/dist/webpack/build-docker.sh
@@ -30,13 +30,19 @@ BUILDDIR=${KUI_BUILDDIR-"$CLIENT_HOME"/dist/webpack}
 echo "build-docker CLIENT_HOME=$CLIENT_HOME"
 echo "build-docker BUILDDIR=$BUILDDIR"
 
-# create the self-signed certificate
-CLIENT_HOME="$CLIENT_HOME" npm run http-allocate-cert
-cp -a "$CLIENT_HOME"/.keys .
+if [ "$KUI_USE_HTTP" != true ]; then
+  # create the self-signed certificate
+  CLIENT_HOME="$CLIENT_HOME" npm run http-allocate-cert
+  cp -a "$CLIENT_HOME"/.keys .
+fi
 
 # this directory will contain the webpack bundles, CSS, images,
 # index.html, etc.
 cp -a "$BUILDDIR" build
 
 # finally, build the docker image
-docker build . -t kui-webpack
+if [ "$KUI_USE_HTTP" == true ]; then
+  docker build . -t kui-webpack -f Dockerfile.http
+else
+  docker build . -t kui-webpack
+fi

--- a/packages/kui-builder/dist/webpack/build.sh
+++ b/packages/kui-builder/dist/webpack/build.sh
@@ -134,7 +134,7 @@ function init {
 # install the webpackery bits
 function initWebpack {
     pushd "$STAGING_DIR" > /dev/null
-    cp -a "$BUILDER_HOME"/dist/webpack/{package.json,webpack.config.js,build-docker.sh,Dockerfile,bin,conf.d} .
+    cp -a "$BUILDER_HOME"/dist/webpack/{package.json,webpack.config.js,build-docker.sh,Dockerfile,Dockerfile.http,bin,conf.d} .
     npm install --no-package-lock
     popd > /dev/null
 }


### PR DESCRIPTION
Part of #1698 

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
