### PR TITLE
docs: one-liner command into install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ data.
 
 The fastest option is to install a prebuilt release.
 
-[Kui-MacOS.tar.bz2](https://macos-tarball.kui-shell.org) **|** [Kui-Linux.zip](https://linux-zip.kui-shell.org)
+```sh
+curl -sL https://raw.githubusercontent.com/IBM/kui/master/tools/install.sh | sh
+```
 
 Visit the [Kui Installation Guide](docs/installation.md)
-for installation details and alternative installation options.
+for details and alternative options.
 
 ## Contributing
 


### PR DESCRIPTION
The README now includes the one-liner command to use the multi-platform installation script.

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
