### PR TITLE
fix(packages/kui-builder): update plugin-sample with prepack mechanism

### DIFF
--- a/packages/kui-builder/examples/plugin-sample/package.json
+++ b/packages/kui-builder/examples/plugin-sample/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "plugin.js",
   "scripts": {
-    "prepublishOnly": "rm -rf dist && mkdir dist && tar -C ../../build/plugins/$(basename `pwd`)/src --exclude test --exclude node_modules -cf - . | tar -C dist -xf - && find dist -type l -exec rm {} \\; && cp -a dist/* .",
+    "prepack": "rm -rf dist && mkdir dist && tar -C ../../build/plugins/$(basename `pwd`)/src --exclude node_modules -cf - . | tar -C dist -xf - && find dist -type l -exec rm {} \\; && cp -a dist/* .",
     "postpack": "for i in dist/*; do if [ -d $i ]; then for j in $i/*; do rm -rf ./`basename $i`/`basename $j`; done; else rm -rf ./`basename $i`; fi; done && rm -rf dist"
   }
 }


### PR DESCRIPTION
Fixes #1712

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
