### PR TITLE
fix(packages/app): don't show application icon by default for webpack…

### DIFF
--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -75,29 +75,8 @@ body .page > .header {
     padding: 0.75ex 0;
 }
 .application-icon {
-    transition: transform .8s ease-in-out, opacity 0s linear;
-    background-position: 50% 50%;
-    background-repeat: no-repeat;
-    background-size: contain;
-}
-body.still-loading .application-icon {
-    animation: pulse 1000ms infinite alternate-reverse;
-}
-.application-icon:hover {
-    opacity: 1;
-    filter: hue-rotate(-20deg) brightness(0.925);
-    cursor: pointer;
-}
-body:not(.not-electron) .application-icon {
+    /* hide the application by default; custom clients can override this */
     display: none;
-}
-.application-icon {
-    width: 3.75em;
-    height: 3.75em;
-    margin: 1em auto;
-    -webkit-app-region: no-drag;
-    transition: all 650ms ease-in-out;
-    opacity: 0.75;
 }
 .header .application-name {
     font-size: 1.125rem;
@@ -2002,16 +1981,6 @@ body.os-darwin:not(.fullscreen) .header {
     padding-left: 5em;
 }
 
-body.sidecar-is-minimized .application-icon {
-    /* scoot the icon to be flush right when the sidecar is minimized, so
-   that the icon will be horizontally centered on the vertical stripe
-   that represents the minimized sidecar */
-    right: 0;
-}
-body.subwindow.still-loading .application-icon {
-    transition: all 150ms ease-in-out;
-    transition-delay: 1750ms;
-}
 body.subwindow .header {
     margin: 0;
 }


### PR DESCRIPTION
… clients

custom clients can always override this, but we should hide it by default, because the current default webpack client doesn't have space for an application icon

Fixes #1719

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
