### PR TITLE
fix(packages/app): register capabilities before preloading plugins

### DIFF
--- a/plugins/plugin-k8s/src/preload.ts
+++ b/plugins/plugin-k8s/src/preload.ts
@@ -28,6 +28,18 @@ import { lastAppliedMode } from './lib/view/modes/last-applied'
 const debug = Debug('plugins/k8s/preload')
 
 /**
+ * This is the capabilities registraion
+ *
+ */
+export const registerCapabilities = async () => {
+  if (inBrowser()) {
+    debug('register capabilities for browser')
+    const { restoreAuth } = await import('./lib/model/auth')
+    restoreAuth()
+  }
+}
+
+/**
  * This is the module
  *
  */
@@ -36,10 +48,4 @@ export default async () => {
   registerSidecarMode(containersMode) // show containers of pods
   registerSidecarMode(conditionsMode) // show conditions of a variety of resource kinds
   registerSidecarMode(lastAppliedMode) // show a last applied configuration tab
-
-  if (inBrowser()) {
-    debug('preload for browser')
-    const { restoreAuth } = await import('./lib/model/auth')
-    restoreAuth()
-  }
 }

--- a/plugins/plugin-proxy-support/src/preload.ts
+++ b/plugins/plugin-proxy-support/src/preload.ts
@@ -20,6 +20,24 @@ import { inBrowser, assertHasProxy, assertLocalAccess } from '@kui-shell/core/co
 const debug = Debug('plugins/proxy-support/preload')
 
 /**
+ * This is the capabilities registraion
+ *
+ */
+export const registerCapabilities = async () => {
+  if (inBrowser()) {
+    const { config } = await import('@kui-shell/core/core/settings')
+    debug('config', config)
+
+    if (!config['disableProxy']) {
+      // notify the Capabilities manager that we have extended the
+      // capabilities of Kui
+      assertHasProxy()
+      assertLocalAccess()
+    }
+  }
+}
+
+/**
  * This is the module
  *
  */
@@ -34,11 +52,6 @@ export default async () => {
 
       debug('attempting to establish our proxy executor')
       setEvaluatorImpl(new ProxyEvaluator())
-
-      // notify the Capabilities manager that we have extended the
-      // capabilities of Kui
-      assertHasProxy()
-      assertLocalAccess()
     }
   }
 }


### PR DESCRIPTION
Fixes #1742

#### Please confirm that your PR fulfills these requirements
- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
