### PR TITLE
fix(packages/app): register capabilities before preloading plugins

### DIFF
--- a/packages/app/src/models/plugin.ts
+++ b/packages/app/src/models/plugin.ts
@@ -22,3 +22,5 @@ export type KuiPlugin = any
 export type PluginRegistration = (commandTree: CommandRegistrar, options?) => Promise<any>
 
 export type PreloadRegistration = (commandTree: CommandRegistrar, options?) => Promise<void>
+
+export type CapabilityRegistration = () => Promise<void>

--- a/plugins/plugin-k8s/src/preload.ts
+++ b/plugins/plugin-k8s/src/preload.ts
@@ -18,6 +18,7 @@ import * as Debug from 'debug'
 
 import { inBrowser } from '@kui-shell/core/core/capabilities'
 import registerSidecarMode from '@kui-shell/core/webapp/views/modes/registrar'
+import { CapabilityRegistration } from '@kui-shell/core/models/plugin'
 
 import { podMode } from './lib/view/modes/pods'
 import { conditionsMode } from './lib/view/modes/conditions'
@@ -28,6 +29,18 @@ import registerTabCompletion from './lib/tab-completion'
 const debug = Debug('plugins/k8s/preload')
 
 /**
+ * This is the capabilities registraion
+ *
+ */
+export const registerCapability: CapabilityRegistration = async () => {
+  if (inBrowser()) {
+    debug('register capabilities for browser')
+    const { restoreAuth } = await import('./lib/model/auth')
+    restoreAuth()
+  }
+}
+
+/**
  * This is the module
  *
  */
@@ -36,12 +49,5 @@ export default async () => {
   registerSidecarMode(containersMode) // show containers of pods
   registerSidecarMode(conditionsMode) // show conditions of a variety of resource kinds
   registerSidecarMode(lastAppliedMode) // show a last applied configuration tab
-
-  if (inBrowser()) {
-    debug('preload for browser')
-    const { restoreAuth } = await import('./lib/model/auth')
-    restoreAuth()
-  }
-
   registerTabCompletion()
 }

--- a/plugins/plugin-proxy-support/src/preload.ts
+++ b/plugins/plugin-proxy-support/src/preload.ts
@@ -17,7 +17,26 @@
 import * as Debug from 'debug'
 
 import { inBrowser, assertHasProxy, assertLocalAccess } from '@kui-shell/core/core/capabilities'
+import { CapabilityRegistration } from '@kui-shell/core/models/plugin'
 const debug = Debug('plugins/proxy-support/preload')
+
+/**
+ * This is the capabilities registraion
+ *
+ */
+export const registerCapability: CapabilityRegistration = async () => {
+  if (inBrowser()) {
+    const { config } = await import('@kui-shell/core/core/settings')
+    debug('config', config)
+
+    if (!config['disableProxy']) {
+      // notify the Capabilities manager that we have extended the
+      // capabilities of Kui
+      assertHasProxy()
+      assertLocalAccess()
+    }
+  }
+}
 
 /**
  * This is the module
@@ -34,11 +53,6 @@ export default async () => {
 
       debug('attempting to establish our proxy executor')
       setEvaluatorImpl(new ProxyEvaluator())
-
-      // notify the Capabilities manager that we have extended the
-      // capabilities of Kui
-      assertHasProxy()
-      assertLocalAccess()
     }
   }
 }


### PR DESCRIPTION
Fixes #1724

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
