### PR TITLE
feat: extend tab completion extension API to support completion of op…

### DIFF
--- a/packages/app/src/models/command.ts
+++ b/packages/app/src/models/command.ts
@@ -88,19 +88,68 @@ export interface ParsedOptions {
 }
 
 /**
- * Evaluator args
+ * This information represents a command line, but split out in
+ * various useful ways.
  *
  */
-export interface EvaluatorArgs {
-  tab: Tab
-  block: HTMLElement | boolean
-  nextBlock: HTMLElement
-  parsedOptions: ParsedOptions
+export interface CommandLine {
+  /**
+   * the raw command string, as given by the user
+   */
   command: string
+
+  /** the result of a whitespace split applied to the `command` string
+   * that pays attention to backslash escaping and quotations
+   */
   argv: string[]
+
+  /**
+   * the residual of `argv` without `parsedOptions`
+   */
   argvNoOptions: string[]
+
+  /**
+   * the dash options parsed out in a way that pays attention to n-ary
+   * options such as `--option key value`
+   */
+  parsedOptions: ParsedOptions
+}
+
+/**
+ * The full set of data passed to a command handler
+ *
+ */
+export interface EvaluatorArgs extends CommandLine {
+  /**
+   * The tab context in which the command was initiated
+   */
+  tab: Tab
+
+  /**
+   * Optional command channel options that one command can use to
+   * influence the execution of another.
+   */
   execOptions: ExecOptions
+
+  /**
+   * Commands can use this to stream output to the UI, rather than
+   * using the normal request-response interaction between the REPL
+   * and the command.
+   */
   createOutputStream: () => WritableStream
+
+  /**
+   * EXPERT MODE: The REPL block in which this command was initiated
+   * (rarely used, but useful for more complex UI extensions)
+   */
+  block: HTMLElement | boolean
+
+  /**
+   * EXPERT MODE: The REPL block that will house the *subsequent*
+   * command execution (rarely used, but useful for more complex UI
+   * extensions)
+   */
+  nextBlock: HTMLElement
 }
 
 // TODO

--- a/plugins/plugin-bash-like/src/lib/tab-completion/git.ts
+++ b/plugins/plugin-bash-like/src/lib/tab-completion/git.ts
@@ -16,14 +16,17 @@
 
 import { exec } from 'child_process'
 
-import { ParsedOptions } from '@kui-shell/core/models/execOptions'
-import { registerEnumerator } from '@kui-shell/plugin-core-support/lib/tab-completion'
+import { CommandLine } from '@kui-shell/core/models/command'
+import { registerEnumerator, TabCompletionSpec } from '@kui-shell/plugin-core-support/lib/tab-completion'
 
 /**
  * Tab completion handler for git branch names
  *
  */
-async function completeGitBranches (command: string, args: string[], options: ParsedOptions, toBeCompleted: string): Promise<string[]> {
+async function completeGitBranches (commandLine: CommandLine, spec: TabCompletionSpec): Promise<string[]> {
+  const { argvNoOptions: args } = commandLine
+  const { toBeCompleted } = spec
+
   if (args[0] === 'git' &&
       (args[1] === 'checkout' ||
           args[1] === 'branch')

--- a/plugins/plugin-k8s/tests/lib/k8s/utils.d.ts
+++ b/plugins/plugin-k8s/tests/lib/k8s/utils.d.ts
@@ -28,8 +28,10 @@ declare var defaultModeForGet: string
 /**
  * Allocate a new unique namespace name
  *
+ * @param prefix the (optional) prefix of the generated namespace name
+ *
  */
-declare function createNS (): string
+declare function createNS (prefix?: string): string
 
 /**
  * Install a mocha test to allocate the given namespace `ns`

--- a/plugins/plugin-k8s/tests/lib/k8s/utils.js
+++ b/plugins/plugin-k8s/tests/lib/k8s/utils.js
@@ -23,7 +23,7 @@ const { cli, selectors } = ui
 // the default tab we expect to see on "get"
 exports.defaultModeForGet = 'summary'
 
-exports.createNS = () => uuid()
+exports.createNS = (prefix = '') => `${prefix}${uuid()}`
 
 exports.allocateNS = (ctx, ns, theCli = cli) => {
   it(`should create a namespace ${ns} `, () => {


### PR DESCRIPTION
…tional args

use this to add -n namespace enumeration to kube tab completer

Fixes #1748

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
