### PR TITLE
fix(packages/app): first column with sidecar open can be scrunched

### DIFF
--- a/packages/app/src/models/entity.ts
+++ b/packages/app/src/models/entity.ts
@@ -68,6 +68,9 @@ export interface MetadataBearing {
     namespace?: string
     creationTimestamp?: string
   }
+  spec?: {
+    displayName?: string
+  }
 }
 export function isMetadataBearing (spec: EntitySpec): spec is MetadataBearing {
   const meta = spec as MetadataBearing

--- a/packages/app/src/webapp/views/sidecar.ts
+++ b/packages/app/src/webapp/views/sidecar.ts
@@ -440,11 +440,13 @@ export const showCustom = async (tab: Tab, custom: CustomSpec, options?: ExecOpt
           const { edit } = await import('@kui-shell/plugin-editor/lib/cmds/edit')
           debug('successfully loaded editor', custom)
 
+          const metadataBearer = isMetadataBearingByReference(custom) ? custom.resource : custom
+
           const entity /*: IEditorEntity */ = {
             type: custom.prettyType,
             name: custom.name,
-            kind: custom.kind,
-            metadata: custom.metadata,
+            kind: metadataBearer.kind,
+            metadata: metadataBearer.metadata,
             persister: () => true,
             annotations: [],
             exec: {
@@ -510,6 +512,7 @@ export const showCustom = async (tab: Tab, custom: CustomSpec, options?: ExecOpt
  *
  */
 export const addSidecarHeaderIconText = (viewName: string, sidecar: HTMLElement) => {
+  debug('addSidecarHeaderIconText', viewName)
   const iconDom = element('.sidecar-header-icon', sidecar)
 
   if (viewName) {
@@ -582,16 +585,17 @@ export const addNameToSidecarHeader = async (sidecar: Sidecar, name: string | El
 
   // maybe entity.content is a metadat-bearing entity that we can
   // mine for identifying characteristics
-  const metadataBearer = (isMetadataBearing(entity) && entity) ||
-    (isMetadataBearingByReference(entity) && entity.resource)
+  const metadataBearer = isMetadataBearingByReference(entity) ? entity.resource
+    : isMetadataBearing(entity) && entity
   if (metadataBearer) {
-    if (!name) {
-      name = metadataBearer.metadata.name
+    const maybeName = metadataBearer.spec && (metadataBearer.spec.displayName || metadataBearer.metadata.name)
+    if (maybeName) {
+      name = maybeName
     }
     if (!packageName) {
       packageName = metadataBearer.metadata.namespace || ''
     }
-    if (!viewName) {
+    if (metadataBearer.kind) {
       viewName = metadataBearer.kind
     }
 

--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -530,10 +530,11 @@ body/*:not(.sidecar-full-screen)*/ repl.sidecar-visible .repl-selection, body/*.
     white-space: nowrap;
     text-overflow: ellipsis;
 }
-.repl.sidecar-visible .result-table .entity-name-group:not(.entity-name-group-narrow) {
+.repl.sidecar-visible .result-table .entity-name-group:first-child:not(.entity-name-group-narrow) {
     /* extra magic to get text ellipsis working; this needs width: 100% on enclosing tables */
     width: 100%;
     max-width: 0; /* important! 0 not 0% */
+    min-width: 5em;
 }
 .result-table .entity-name-group-narrow {
     max-width: 16em;

--- a/plugins/plugin-editor/src/lib/open.ts
+++ b/plugins/plugin-editor/src/lib/open.ts
@@ -134,7 +134,7 @@ export const openEditor = async (tab: Tab, name: string, options, execOptions) =
       // stash this so that the implicit entity model works
       sidecar.entity = entity
 
-      addSidecarHeaderIconText(entity.type || entity.kind, sidecar)
+      addSidecarHeaderIconText(entity.kind || entity.type, sidecar)
 
       // isModified display
       const subtext = sidecar.querySelector('.sidecar-header-secondary-content .custom-header-content')

--- a/plugins/plugin-k8s/src/test/k8s1/tab-completion.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/tab-completion.ts
@@ -35,8 +35,8 @@ describe('Tab completion for kubectl get', function (this: ISuite) {
     // namespace names
     const commonPrefix = 'foo-'
     const uniquePrefix = 'blammmmmo-' // something prefix-distinct from the first two
-    const ns: string = createNS(commonPrefix)
-    const ns2: string = createNS(commonPrefix)
+    const ns: string = createNS(`${commonPrefix}aaaa-`)
+    const ns2: string = createNS(`${commonPrefix}bbbb-`) // we want ns to be lexicographically < ns2
     const ns3: string = createNS(uniquePrefix)
 
     allocateNS(this, ns)


### PR DESCRIPTION
due to some CSS bugs... this PR also generalized the handling of resource metadata a bit

Fixes #1694

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
