### PR TITLE
fix(plugins/plugin-k8s): k8s tab completion test regression

### DIFF
--- a/plugins/plugin-k8s/src/test/k8s1/tab-completion.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/tab-completion.ts
@@ -52,7 +52,7 @@ describe('Tab completion for kubectl get', function (this: ISuite) {
 
     it(`should tab complete namespaces not unique`, () => {
       return tabbyWithOptions(this.app,
-        `k get pods -n ${commonPrefix.charAt(0)}`,
+        `k get pods -n ${commonPrefix}`,
         [ns, ns2],
         `k get pods -n ${ns}`,
         {


### PR DESCRIPTION
Fixes #1756

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
