### PR TITLE
style: remove @typescript-eslint/no-object-literal-type-assertion rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,6 @@
       }
     }],
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-object-literal-type-assertion": "off",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-var-requires": "off"
   },

--- a/packages/app/src/core/repl.ts
+++ b/packages/app/src/core/repl.ts
@@ -448,7 +448,7 @@ class InProcessExecutor implements Executor {
         const commandFlags: YargsParserFlags = (evaluator.options && evaluator.options.flags) ||
           (evaluator.options && evaluator.options.synonymFor &&
            evaluator.options.synonymFor.options && evaluator.options.synonymFor.options.flags) ||
-          ({} as YargsParserFlags)
+          ({} as YargsParserFlags) // eslint-disable-line @typescript-eslint/no-object-literal-type-assertion
         const optional = builtInOptions.concat((evaluator.options && evaluator.options.usage && evaluator.options.usage.optional) || [])
         const optionalBooleans = optional && optional.filter(({ boolean }) => boolean).map(_ => unflag(_.name))
 


### PR DESCRIPTION
Continue with #1343.

I'm going to add them here: #1759.