### PR TITLE
fix(packages/app): inconsistent inactive tab borders

### DIFF
--- a/packages/app/web/css/top-tab-stripe.css
+++ b/packages/app/web/css/top-tab-stripe.css
@@ -256,8 +256,8 @@ body.os-darwin .left-tab-stripe {
     /* make not-selected tabs a bit more visible */
     color: var(--color-base02);
 
-    border-left: 1px inset transparent;
-    border-right: 1px inset transparent;
+    border-left: 1px solid transparent;
+    border-right: 1px solid transparent;
     transition: color 150ms ease-in-out;
 }
 body[kui-theme-style="dark"] .left-tab-stripe-button:not(.left-tab-stripe-button-selected) .left-tab-stripe-button-label {
@@ -287,7 +287,7 @@ body[kui-theme-style="dark"] .left-tab-stripe-button:not(.left-tab-stripe-button
 
 .left-tab-stripe-button-label {
     flex: 1;
-    padding: 0.375em 1.25em 0.375em 1em;
+    padding: 0.5em 1.25em 0.5em 1em;
     font-weight: 500;
     direction: unset;
     max-width: 25em;


### PR DESCRIPTION
Fixes #1773

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
