### PR TITLE
fix(plugins/plugin-k8s): k8s resource states with Ready:True should b…

### DIFF
--- a/plugins/plugin-k8s/src/lib/model/states.ts
+++ b/plugins/plugin-k8s/src/lib/model/states.ts
@@ -205,7 +205,11 @@ const getStatusOfDeployment = (kubeEntity: KubeResource, desiredFinalState: Fina
   } else {
     const readyCondition = kubeEntity.status &&
       kubeEntity.status.conditions &&
-      kubeEntity.status.conditions.find(({ reason }) => reason === 'MinimumReplicasAvailable')
+      kubeEntity.status.conditions.find(({ reason, type, status }) => {
+        return reason === 'MinimumReplicasAvailable' ||
+          type === 'Ready' || status === 'True'
+      })
+
     if (readyCondition) {
       return {
         state: desireIsOffline ? States.Pending : States.Online,


### PR DESCRIPTION
…e designated as Online

Fixes #1775

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
