### PR TITLE
test(plugins/plugin-core-support): tab-completion-util should not be symlinked into source tree

### DIFF
--- a/packages/kui-builder/tsconfig.json
+++ b/packages/kui-builder/tsconfig.json
@@ -22,6 +22,7 @@
       "@kui-shell/plugin-apache-composer/tests/*": ["plugins/plugin-apache-composer/tests/*"],
       "@kui-shell/plugin-apache-composer/*": ["plugins/plugin-apache-composer/src/*"],
       "@kui-shell/plugin-bash-like/*": ["plugins/plugin-base-like/src/*"],
+      "@kui-shell/plugin-core-support/tests/*": ["plugins/plugin-core-support/tests/*"],
       "@kui-shell/plugin-core-support/*": ["plugins/plugin-core-support/src/*"],
       "@kui-shell/plugin-editor/*": ["plugins/plugin-editor/src/*"],
       "@kui-shell/plugin-grid/*": ["plugins/plugin-grid/src/*"],

--- a/plugins/plugin-bash-like/src/test/bash-like/git-tab-completion.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/git-tab-completion.ts
@@ -21,7 +21,7 @@ import { dir as createTemporaryDirectory } from 'tmp'
 
 import * as common from '@kui-shell/core/tests/lib/common'
 import * as ui from '@kui-shell/core/tests/lib/ui'
-import { tabby, tabbyWithOptions } from '@kui-shell/plugin-core-support/tests/lib/tab-completion-util'
+import { tabby, tabbyWithOptions } from '@kui-shell/plugin-core-support/tests/lib/core-support/tab-completion-util'
 
 const { cli } = ui
 

--- a/plugins/plugin-core-support/src/test/core-support/tab-completion.ts
+++ b/plugins/plugin-core-support/src/test/core-support/tab-completion.ts
@@ -16,7 +16,7 @@
 
 import { ISuite, before as commonBefore, after as commonAfter, localIt, remoteIt } from '@kui-shell/core/tests/lib/common'
 
-import { tabby, tabbyWithOptions, tabbyWithOptionsThenCancel, touch } from '@kui-shell/plugin-core-support/tests/lib/tab-completion-util'
+import { tabby, tabbyWithOptions, tabbyWithOptionsThenCancel, touch } from '@kui-shell/plugin-core-support/tests/lib/core-support/tab-completion-util'
 import { dirSync as tmpDirSync } from 'tmp'
 import { dirname, join } from 'path'
 const ROOT = dirname(require.resolve('@kui-shell/core/tests/package.json'))

--- a/plugins/plugin-core-support/tests/lib/core-support/tab-completion-util.d.ts
+++ b/plugins/plugin-core-support/tests/lib/core-support/tab-completion-util.d.ts
@@ -1,0 +1,12 @@
+/** touch the given filepath */
+export declare const touch: (filepath: string) => void;
+/** execute the given async task n times */
+export declare const doTimes: (n: any, task: any) => any;
+export declare const tabby: (app: any, partial: any, full: any, expectOK?: boolean) => any;
+export declare const tabbyWithOptions: (app: any, partial: any, expected?: any, full?: any, { click, nTabs, expectOK, expectedPromptAfterTab }?: {
+    click?: any;
+    nTabs?: any;
+    expectOK?: boolean;
+    expectedPromptAfterTab?: any;
+}) => any;
+export declare const tabbyWithOptionsThenCancel: (app: any, partial: any, expected: any) => any;

--- a/plugins/plugin-core-support/tests/lib/core-support/tab-completion-util.js
+++ b/plugins/plugin-core-support/tests/lib/core-support/tab-completion-util.js
@@ -14,27 +14,28 @@
  * limitations under the License.
  */
 
-import * as common from '@kui-shell/core/tests/lib/common'
-import * as ui from '@kui-shell/core/tests/lib/ui'
+const common = require('@kui-shell/core/tests/lib/common')
+const ui = require('@kui-shell/core/tests/lib/ui')
+const fs = require('fs')
 
-import { openSync, closeSync } from 'fs'
+const { openSync, closeSync } = fs
 const { cli, keys } = ui
 
 /** touch the given filepath */
-export const touch = (filepath: string) => {
+exports.touch = (filepath) => {
   closeSync(openSync(filepath, 'w'))
 }
 
 /** execute the given async task n times */
-export const doTimes = (n, task) => {
+exports.doTimes = (n, task) => {
   if (n > 0) {
-    return task().then(() => doTimes(n - 1, task))
+    return task().then(() => exports.doTimes(n - 1, task))
   } else {
     return Promise.resolve()
   }
 }
 
-export const tabby = (app, partial, full, expectOK = true) => app.client.waitForExist(ui.selectors.CURRENT_PROMPT_BLOCK)
+exports.tabby = (app, partial, full, expectOK = true) => app.client.waitForExist(ui.selectors.CURRENT_PROMPT_BLOCK)
   .then(() => app.client.getAttribute(ui.selectors.CURRENT_PROMPT_BLOCK, 'data-input-count'))
   .then(count => parseInt(count, 10))
   .then(count => app.client.setValue(ui.selectors.CURRENT_PROMPT, partial)
@@ -52,7 +53,7 @@ export const tabby = (app, partial, full, expectOK = true) => app.client.waitFor
   })
   .catch(common.oops(app))
 
-export const tabbyWithOptions = (app, partial, expected?, full?, { click = undefined, nTabs = undefined, expectOK = true, expectedPromptAfterTab = undefined } = {}) => {
+exports.tabbyWithOptions = (app, partial, expected, full, { click = undefined, nTabs = undefined, expectOK = true, expectedPromptAfterTab = undefined } = {}) => {
   return app.client.waitForExist(ui.selectors.CURRENT_PROMPT_BLOCK)
     .then(() => app.client.getAttribute(ui.selectors.CURRENT_PROMPT_BLOCK, 'data-input-count'))
     .then(count => parseInt(count, 10))
@@ -94,7 +95,7 @@ export const tabbyWithOptions = (app, partial, expected?, full?, { click = undef
         } else {
           // otherwise hit tab a number of times, to cycle to the desired entry
           // console.error('tabbing', nTabs)
-          return doTimes(nTabs, () => app.client.keys('Tab'))
+          return exports.doTimes(nTabs, () => app.client.keys('Tab'))
             .then(() => app.client.keys('Enter'))
         }
       })
@@ -112,7 +113,7 @@ export const tabbyWithOptions = (app, partial, expected?, full?, { click = undef
       .then(() => common.oops(app)(err)))
 }
 
-export const tabbyWithOptionsThenCancel = (app, partial, expected) => app.client.waitForExist(ui.selectors.CURRENT_PROMPT_BLOCK)
+exports.tabbyWithOptionsThenCancel = (app, partial, expected) => app.client.waitForExist(ui.selectors.CURRENT_PROMPT_BLOCK)
   .then(() => app.client.getAttribute(ui.selectors.CURRENT_PROMPT_BLOCK, 'data-input-count'))
   .then(count => parseInt(count, 10))
   .then(count => app.client.setValue(ui.selectors.CURRENT_PROMPT, partial)

--- a/plugins/plugin-k8s/src/test/k8s1/tab-completion.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/tab-completion.ts
@@ -16,7 +16,7 @@
 
 import { ISuite, before as commonBefore, after as commonAfter, oops } from '@kui-shell/core/tests/lib/common'
 import { cli, selectors } from '@kui-shell/core/tests/lib/ui'
-import { tabby, tabbyWithOptions } from '@kui-shell/plugin-core-support/tests/lib/tab-completion-util'
+import { tabby, tabbyWithOptions } from '@kui-shell/plugin-core-support/tests/lib/core-support/tab-completion-util'
 import { dirname } from 'path'
 import { createNS, allocateNS, deleteNS } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
 


### PR DESCRIPTION
Fixes #1785

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
