### PR TITLE
fix(plugins/plugin-k8s): kubectl get fails if STATUS column has empty…

### DIFF
--- a/plugins/plugin-k8s/src/lib/view/formatTable.ts
+++ b/plugins/plugin-k8s/src/lib/view/formatTable.ts
@@ -183,7 +183,7 @@ export const preprocessTable = (raw: string[]) => {
 
 /** normalize the status badge by capitalization */
 const capitalize = (str: string): string => {
-  return str[0].toUpperCase() + str.slice(1).toLowerCase()
+  return !str ? 'Unknown' : str[0].toUpperCase() + str.slice(1).toLowerCase()
 }
 
 export const formatTable = (command: string, verb: string, entityTypeFromCommandLine: string, options, preTable: Pair[][]): Table => {

--- a/plugins/plugin-k8s/src/test/k8s2/empty-status-cell.ts
+++ b/plugins/plugin-k8s/src/test/k8s2/empty-status-cell.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { dirname, join } from 'path'
+
+import { before as commonBefore, after as commonAfter, localDescribe, ISuite, oops } from '@kui-shell/core/tests/lib/common'
+import { cli } from '@kui-shell/core/tests/lib/ui'
+
+const ROOT = dirname(require.resolve('@kui-shell/plugin-k8s/tests/package.json'))
+const input = join(ROOT, 'data/k8s/empty-status-cell.txt')
+
+localDescribe('k8s table with empty status cell', function (this: ISuite) {
+  before(commonBefore(this))
+  after(commonAfter(this))
+
+  it('should format a table with an empty status cell', () => cli.do(`kdebug "${input}"`, this.app)
+    .then(cli.expectOKWith('reviews-v3-rollout'))
+    .catch(oops(this)))
+})

--- a/plugins/plugin-k8s/tests/data/k8s/empty-status-cell.txt
+++ b/plugins/plugin-k8s/tests/data/k8s/empty-status-cell.txt
@@ -1,0 +1,2 @@
+NAME                 COMPLETED   STATUS   BASELINE     PERCENTAGE   CANDIDATE    PERCENTAGE
+reviews-v3-rollout   True                 reviews-v2   0            reviews-v3   100


### PR DESCRIPTION
… cells

Fixes #1787

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
