### PR TITLE
fix(plugins/plugin-k8s): kui still searches in bashrc if KUBECONFIG=<…

### DIFF
--- a/plugins/plugin-k8s/src/lib/util/discovery/kubeconfig.ts
+++ b/plugins/plugin-k8s/src/lib/util/discovery/kubeconfig.ts
@@ -57,7 +57,7 @@ const maybeKUBECONFIG = (file: string): string | void => {
  *
  */
 const fillInKUBECONFIG = (env) => {
-  if (!env.KUBECONFIG) {
+  if (env.KUBECONFIG === undefined) { // see https://github.com/IBM/kui/issues/1789
     debug('attempting to find KUBECONFIG env var')
     const kubeconfig = maybeKUBECONFIG('.bash_profile') ||
       maybeKUBECONFIG('.profile') ||


### PR DESCRIPTION
…emptystring>

Fixes #1789

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
