### PR TITLE
fix(packages/app): watchable table: stop checking resource deletion by error message

### DIFF
--- a/packages/app/src/webapp/views/table.ts
+++ b/packages/app/src/webapp/views/table.ts
@@ -138,10 +138,13 @@ export const formatTable = (tab: Tab, table: Table | WatchableTable, resultDom: 
             rows.map(row => tableDom.removeChild(row))
           }
         } catch (err) {
-          if (err.code === 404 && err.message.includes('No resources')) {
+          if (err.code === 404) {
             newPrepareRows = []
           } else {
-            rows.map(row => tableDom.removeChild(row))
+            while (resultDom.firstChild) {
+              resultDom.removeChild(resultDom.firstChild)
+            }
+            stopWatching()
             throw err
           }
         }


### PR DESCRIPTION
Fixes #1779

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
