### PR TITLE
feat(plugins/plugin-operator-framework): olm drilldowns should use fu…

### DIFF
--- a/plugins/plugin-operator-framework/src/controller/olm.ts
+++ b/plugins/plugin-operator-framework/src/controller/olm.ts
@@ -71,7 +71,7 @@ export default async (commandTree: CommandRegistrar) => {
     await remember(parsedOptions)
 
     const namespace = parsedOptions.n || parsedOptions.namespace
-    const getSources = `oc get opsrc ${namespace ? `-n ${namespace}` : '--all-namespaces'} -o=custom-columns=NAME:.metadata.name,PACKAGES:.status.packages ${parsedOptions.config ? `--config ${parsedOptions.config}` : ''}`
+    const getSources = `oc get OperatorSources ${namespace ? `-n ${namespace}` : '--all-namespaces'} -o=custom-columns=NAME:.metadata.name,PACKAGES:.status.packages ${parsedOptions.config ? `--config ${parsedOptions.config}` : ''}`
 
     return $(getSources, block, undefined, execOptions)
   }, {
@@ -83,7 +83,7 @@ export default async (commandTree: CommandRegistrar) => {
     await remember(parsedOptions)
 
     const namespace = parsedOptions.n || parsedOptions.namespace
-    const getSources = `oc get csvs -n ${namespace || 'default'} ${parsedOptions.config ? `--config ${parsedOptions.config}` : ''} -o=custom-columns=NAME:.metadata.name,DISPLAY:.spec.displayName,VERSION:.spec.version,STATUS:.status.phase`
+    const getSources = `oc get ClusterServiceVersions -n ${namespace || 'default'} ${parsedOptions.config ? `--config ${parsedOptions.config}` : ''} -o=custom-columns=NAME:.metadata.name,DISPLAY:.spec.displayName,VERSION:.spec.version,STATUS:.status.phase`
 
     return $(getSources, block, undefined, execOptions)
   }, {

--- a/plugins/plugin-operator-framework/src/view/modes/crds.ts
+++ b/plugins/plugin-operator-framework/src/view/modes/crds.ts
@@ -113,7 +113,7 @@ function toTable (resource: CRDBearer): Table {
       ]
     },
     body: resource.spec.customresourcedefinitions.owned.map(spec => ({
-      name: spec.displayName,
+      name: spec.name,
       outerCSS: outerCSSForKey.NAME,
       css: cssForKey.NAME,
       attributes: [


### PR DESCRIPTION
…ll resource kind string

Fixes #1796

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
