### PR TITLE
chore: bump version dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "lerna": "3.14.1"
+    "lerna": "3.15.0"
   },
   "husky": {
     "hooks": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -49,7 +49,7 @@
     "pretty-ms": "5.0.0",
     "properties-parser": "0.3.1",
     "tmp": "0.1.0",
-    "yargs-parser": "13.1.0"
+    "yargs-parser": "13.1.1"
   },
   "devDependencies": {
     "request-promise": "4.2.4"

--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -500,6 +500,10 @@ body/*:not(.sidecar-full-screen)*/ repl.sidecar-visible .repl-selection, body/*.
 .entity:first-child .entity-attributes > span {
     border-top: none;
 }
+.result-table[kui-table-style="Light"] .entity-attributes > span {
+    padding-top: 0;
+    padding-bottom: 0;
+}
 .entity-attributes > span {
     display: table-cell;
     vertical-align: middle;

--- a/packages/kui-builder/package.json
+++ b/packages/kui-builder/package.json
@@ -35,17 +35,17 @@
     "@types/mkdirp-promise": "5.0.0",
     "@types/mocha": "5.2.7",
     "@types/needle": "2.0.4",
-    "@types/node": "12.0.4",
-    "@types/swagger-schema-official": "2.0.16",
+    "@types/node": "12.0.8",
+    "@types/swagger-schema-official": "2.0.17",
     "@types/webdriverio": "4.13.1",
     "@types/yargs-parser": "^13.0.0",
     "colors": "1.3.3",
     "debug": "4.1.1",
-    "electron": "5.0.3",
+    "electron": "5.0.4",
     "fs-extra": "8.0.1",
-    "spectron": "5.0.0",
+    "spectron": "6.0.0",
     "terser": "3.17.0",
-    "typescript": "3.5.1"
+    "typescript": "3.5.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "1.10.2",
@@ -56,8 +56,8 @@
     "eslint-plugin-node": "9.1.0",
     "eslint-plugin-promise": "4.1.1",
     "eslint-plugin-standard": "4.0.0",
-    "husky": "2.4.0",
-    "lint-staged": "8.2.0"
+    "husky": "2.4.1",
+    "lint-staged": "8.2.1"
   },
   "kui": {
     "exclude": {

--- a/plugins/plugin-bash-like/package.json
+++ b/plugins/plugin-bash-like/package.json
@@ -27,12 +27,12 @@
   "dependencies": {
     "asciidoctor.js": "1.5.9",
     "debug": "4.1.1",
-    "diff2html": "2.9.0",
+    "diff2html": "2.10.0",
     "marked": "0.6.2",
     "node-pty": "0.8.1",
     "shelljs": "0.8.3",
     "strip-ansi": "^5.2.0",
-    "ws": "7.0.0",
+    "ws": "7.0.1",
     "xterm": "3.13.0"
   },
   "devDependencies": {


### PR DESCRIPTION
including electron 5.0.4

Fixes #1798

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
