### PR TITLE
fix: remove regex lookbehind for webpack in firefox

### DIFF
--- a/packages/app/src/webapp/util/ascii-to-table.ts
+++ b/packages/app/src/webapp/util/ascii-to-table.ts
@@ -124,9 +124,6 @@ const capitalize = (str: string): string => {
 const kubelike = /kubectl|oc/
 const isKubeLike = (command: string): boolean => kubelike.test(command)
 
-/** split word by camel case */
-const camelCaseSplit = (str: string) => !str ? [] : str.split(/(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/)
-
 /**
  * Turn an IPair[][], i.e. a table of key-value pairs into a Table,
  * i.e. kui Table model. IPair is defined below, it is internal just
@@ -239,7 +236,7 @@ export const formatTable = (command: string, verb: string, entityType: string, o
   const body = hasHeader ? allRows.slice(1) : allRows
 
   return {
-    title: camelCaseSplit(entityType).join(' '),
+    title: entityType,
     header,
     body,
     noSort: true

--- a/plugins/plugin-k8s/src/lib/view/formatTable.ts
+++ b/plugins/plugin-k8s/src/lib/view/formatTable.ts
@@ -186,9 +186,6 @@ const capitalize = (str: string): string => {
   return !str ? 'Unknown' : str[0].toUpperCase() + str.slice(1).toLowerCase()
 }
 
-/** split word by camel case */
-const camelCaseSplit = (str: string) => !str ? [] : str.split(/(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/)
-
 export const formatTable = (command: string, verb: string, entityTypeFromCommandLine: string, options, preTable: Pair[][]): Table => {
   debug('formatTable', preTable)
   // for helm status, table clicks should dispatch to kubectl;
@@ -295,6 +292,6 @@ export const formatTable = (command: string, verb: string, entityTypeFromCommand
     header: rows[0],
     body: rows.slice(1),
     noSort: true,
-    title: camelCaseSplit(entityTypeFromRows || entityTypeFromCommandLine).join(' ')
+    title: entityTypeFromRows || entityTypeFromCommandLine
   }
 }


### PR DESCRIPTION
Fixes #1801

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
