### PR TITLE
feat(packages/proxy): allow builders to choose kubectl verison for proxy

### DIFF
--- a/packages/proxy/Dockerfile
+++ b/packages/proxy/Dockerfile
@@ -29,17 +29,18 @@ WORKDIR /kui-proxy/kui
 ###########
 # Note: Latest version of kubectl may be found at:
 # https://aur.archlinux.org/packages/kubectl-bin/
-ENV KUBE_LATEST_VERSION="v1.13.2"
+ARG KUBE_VERSION
+ENV KUBE_VERSION=$KUBE_VERSION
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
 
 # we will download a gamut of helm clients and place them here
 # see plugins/plugin-k8s/src/lib/util/discovery/helm-client.ts
-ENV KUI_HELM_CLIENTS_DIR=/usr/local/bin
-ENV HELM_LATEST_VERSION="${KUI_HELM_CLIENTS_DIR}"/helm-2.12
+#ENV KUI_HELM_CLIENTS_DIR=/usr/local/bin
+#ENV HELM_LATEST_VERSION="${KUI_HELM_CLIENTS_DIR}"/helm-2.12
 
 RUN apk add --no-cache ca-certificates bash git \
-    && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
+    && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
     && wget -q https://storage.googleapis.com/kubernetes-helm/helm-v2.9.0-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm-2.9 \
     && chmod +x /usr/local/bin/helm-2.9 \
@@ -48,7 +49,11 @@ RUN apk add --no-cache ca-certificates bash git \
     && wget -q https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm-2.11 \
     && chmod +x /usr/local/bin/helm-2.11 \
     && wget -q https://storage.googleapis.com/kubernetes-helm/helm-v2.12.2-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm-2.12 \
-    && chmod +x /usr/local/bin/helm-2.12
+    && chmod +x /usr/local/bin/helm-2.12 \
+    && wget -q https://storage.googleapis.com/kubernetes-helm/helm-v2.13.1-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm-2.13 \
+    && chmod +x /usr/local/bin/helm-2.13 \
+    && wget -q https://storage.googleapis.com/kubernetes-helm/helm-v2.14.1-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm-2.14 \
+    && chmod +x /usr/local/bin/helm-2.14
 ###########
 
 COPY . /kui-proxy

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -31,9 +31,12 @@ will be refined in the near future.
 
 ## Building the Proxy
 
-The proxy is built into a docker image via:
+The proxy is built into a docker image via the following commands. You
+may choose to override the default version of kubectl via the
+`KUBE_VERSION` environment variable.
 
 ```bash
+export KUBE_VERSON=v1.13.2
 npm install
 ./build.sh
 ```

--- a/packages/proxy/build-docker.sh
+++ b/packages/proxy/build-docker.sh
@@ -19,8 +19,11 @@
 set -e
 set -o pipefail
 
+# accepted environment variables
+KUBE_VERSION=${KUBE_VERSION-v1.13.2}
+
 if [ "$KUI_USE_HTTP" == "true" ]; then
-  docker build . -t kui-proxy -f Dockerfile.http
+  docker build . -t kui-proxy -f Dockerfile.http --build-arg KUBE_VERSION=$KUBE_VERSION
 else
-  docker build . -t kui-proxy
+  docker build . -t kui-proxy --build-arg KUBE_VERSION=$KUBE_VERSION
 fi


### PR DESCRIPTION
this also downloads newer helm verisons

Fixes #1806

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
