### PR TITLE
fix: Remove plugin-openwhisk-debug from tsconfig

### DIFF
--- a/packages/kui-builder/tsconfig.json
+++ b/packages/kui-builder/tsconfig.json
@@ -31,7 +31,6 @@
       "@kui-shell/plugin-manager/*": ["plugins/plugin-manager/src/*"],
       "@kui-shell/plugin-openwhisk/tests/*": ["plugins/plugin-openwhisk/tests/*"],
       "@kui-shell/plugin-openwhisk/*": ["plugins/plugin-openwhisk/src/*"],
-      "@kui-shell/plugin-openwhisk-debug/*": ["plugins/plugin-openwhisk-debug/src/*"],
       "@kui-shell/plugin-proxy-support/*": ["plugins/plugin-proxy-support/src/*"],
       "@kui-shell/plugin-tutorials/*": ["plugins/plugin-tutorials/src/*"],
       "@kui-shell/plugin-wskflow/*": ["plugins/plugin-wskflow/src/*"],


### PR DESCRIPTION
#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
