### PR TITLE
fix: avoid install on blue for npm release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ after_success: ./tools/travis/publishers/cos.sh
 jobs:
   include:
     - stage: npm release
+      env: ""
       node_js: "8"
       script: 
         - echo "NPM Deploying Started ..."


### PR DESCRIPTION
Add env field to npm release stage
#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
