### PR TITLE
fix(packages/app): retry app launch in tests

### DIFF
--- a/packages/app/tests/lib/common.js
+++ b/packages/app/tests/lib/common.js
@@ -123,7 +123,7 @@ exports.before = (ctx, { fuzz, noApp = false, popup } = {}) => {
     }
 
     // start the app, if requested
-    const start = noApp ? x => x : () => {
+    const start = noApp ? () => Promise.resolve() : () => {
       return ctx.app.start() // this will launch electron
       // commenting out setTitle due to buggy spectron (?) "Cannot call function 'setTitle' on missing remote object 1"
         // .then(() => ctx.title && ctx.app.browserWindow.setTitle(ctx.title)) // set the window title to the current test

--- a/packages/app/tests/lib/ui.js
+++ b/packages/app/tests/lib/ui.js
@@ -198,7 +198,9 @@ exports.cli = {
 
   /** wait for the repl to be active */
   waitForRepl: async (app) => {
-    await app.client.waitForEnabled(selectors.CURRENT_PROMPT, timeout)
+    // if it takes more than 10 seconds to have an active prompt,
+    // treat that as a failure
+    await app.client.waitForEnabled(selectors.CURRENT_PROMPT, 10000)
     return app
   },
 


### PR DESCRIPTION
Fixes #1822

#### Please confirm that your PR fulfills these requirements
- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
