### PR TITLE
feat: port k status table into new watcher and add watchable multi-table

### DIFF
--- a/packages/app/src/models/entity.ts
+++ b/packages/app/src/models/entity.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Table } from '../webapp/models/table'
+import { Table, MultiTable } from '../webapp/models/table'
 import { CustomSpec } from '../webapp/views/sidecar'
 import { SidecarMode } from '../webapp/bottom-stripe'
 
@@ -112,3 +112,4 @@ export type Entity =
   | boolean
   | any[] // eslint-disable-line @typescript-eslint/no-explicit-any
   | Table
+  | MultiTable

--- a/packages/app/src/webapp/cli.ts
+++ b/packages/app/src/webapp/cli.ts
@@ -37,6 +37,7 @@ import {
 } from '../models/execOptions'
 import * as historyModel from '../models/history'
 import { CodedError, isCodedError } from '../models/errors'
+import { Table, isTable, MultiTable, isMultiTable } from './models/table'
 
 import { element, removeAllDomChildren } from './util/dom'
 import { prettyPrintTime } from './util/time'
@@ -48,7 +49,7 @@ import {
   formatMultiListResult,
   formatTable
 } from './views/table'
-import { Table, isTable, isMultiTable } from './models/table'
+
 import {
   Formattable,
   getSidecar,
@@ -538,7 +539,7 @@ const printTable = async (
  * Stream output to the given block
  *
  */
-export type Streamable = SimpleEntity | Table | Table[] | CustomSpec
+export type Streamable = SimpleEntity | Table | MultiTable | CustomSpec
 export const streamTo = (tab: Tab, block: Element) => {
   const resultDom = block.querySelector('.repl-result') as HTMLElement
   // so we can scroll this into view as streaming output arrives
@@ -567,8 +568,8 @@ export const streamTo = (tab: Tab, block: Element) => {
     } else if (isHTML(response)) {
       previousLine = response
       pre.appendChild(previousLine)
-    } else if (Array.isArray(response)) {
-      response.forEach(async _ => printTable(tab, _, resultDom))
+    } else if (isMultiTable(response)) {
+      response.tables.forEach(async _ => printTable(tab, _, resultDom))
       const br = document.createElement('br')
       resultDom.appendChild(br)
     } else if (isTable(response)) {
@@ -1066,7 +1067,10 @@ export const printResults = (
 
           return !customContainer || customContainer.children.length === 0
         }
-      } else if (registeredEntityViews[response.type]) {
+      } else if (
+        isEntitySpec(response) &&
+        registeredEntityViews[response.type]
+      ) {
         // there is a registered entity view handler for this response
         if (
           await registeredEntityViews[response.type](
@@ -1082,7 +1086,7 @@ export const printResults = (
 
         // we rendered the content?
         return resultDom.children.length === 0
-      } else if (response.verb === 'delete') {
+      } else if (isEntitySpec(response) && response.verb === 'delete') {
         if (echo) {
           // we want the 'ok:' part to appear even in popup mode
           if (response.type) {
@@ -1147,16 +1151,19 @@ export const printResults = (
       'result-vertical'
     )
 
-    if (response[0].flexWrap) {
+    const tables = response.tables
+
+    if (tables[0].flexWrap) {
       ;(resultDom.parentNode as HTMLElement).classList.add(
         'result-as-multi-table-flex-wrap'
       )
     }
+
     // multi-table output; false means that the renderer hasn't placed
     // anything in the DOM; it's up to us here
-    promise = Promise.all(
-      response.map(table => formatTable(tab, table, resultDom as HTMLElement))
-    ).then(() => false)
+    promise = Promise.resolve(formatTable(tab, response, resultDom)).then(
+      () => false
+    )
   } else if (Array.isArray(response) && Array.isArray(response[0])) {
     /**
      * multi-table output; false means that the renderer hasn't placed

--- a/packages/app/src/webapp/models/basicModels.ts
+++ b/packages/app/src/webapp/models/basicModels.ts
@@ -10,3 +10,7 @@ export interface Watchable {
   watchInterval?: number
   watchLimit?: number
 }
+
+export function isWatchable(model: any): model is Watchable {
+  return model && model.refreshCommand
+}

--- a/packages/app/src/webapp/models/table.ts
+++ b/packages/app/src/webapp/models/table.ts
@@ -18,6 +18,7 @@
 
 import { Watchable } from './basicModels'
 import { sortBody } from '../views/table'
+import { Entity } from '@kui-shell/core/models/entity'
 
 export class Row {
   attributes?: Cell[]
@@ -25,12 +26,11 @@ export class Row {
   type?: string
   packageName?: string
   prettyType?: string
-  watch?: any // eslint-disable-line @typescript-eslint/no-explicit-any
   fontawesome?: string
   fontawesomeCSS?: string
   setSelected?: () => void
   setUnselected?: () => void
-  nameCss?: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  nameCss?: string
   key?: string
   prettyName?: string
   fullName?: string
@@ -44,6 +44,7 @@ export class Row {
   onclick?: any // eslint-disable-line @typescript-eslint/no-explicit-any
   css?: string
   outerCSS?: string
+  done?: boolean
 
   constructor(row: Row) {
     Object.assign(this, row)
@@ -110,40 +111,35 @@ export class Table {
 
 export interface WatchableTable extends Table, Watchable {}
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isTable(model: any): model is Table {
+export function isTable(model: Entity): model is Table {
   return (
     model !== undefined &&
     (model instanceof Table || (model as Table).body !== undefined)
   )
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isMultiTable(model: any): model is Table[] {
+export interface MultiTable {
+  tables: Table[]
+}
+
+export function isMultiTable(model: Entity): model is MultiTable {
   return (
     model !== undefined &&
-    Array.isArray(model) &&
-    model.length > 0 &&
-    model.filter(m => !isTable(m)).length === 0
+    (model as MultiTable).tables !== undefined &&
+    Array.isArray((model as MultiTable).tables) &&
+    (model as MultiTable).tables.length > 1 &&
+    (model as MultiTable).tables.filter(table => !isTable(table)).length === 0
   )
 }
 
-export function isWatchableTable(
-  model: Table | WatchableTable
-): model is WatchableTable {
-  return (
-    model &&
-    isTable(model) &&
-    (model as Watchable).refreshCommand &&
-    (model as Watchable).watchByDefault !== undefined
-  )
-}
+export type WatchableMultiTable = MultiTable & Watchable
 
-export function formatWatchableTable(model: Table | Table[], watch: Watchable) {
-  if (isTable(model)) {
+export function formatWatchableTable(
+  model: Table | MultiTable,
+  watch: Watchable
+) {
+  if (isTable(model) || isMultiTable(model)) {
     return Object.assign(model, watch)
-  } else if (isMultiTable(model)) {
-    model.forEach(table => Object.assign(table, watch))
   } else {
     // TODO: we might need to consider the variance of model, throw error for now
     throw new Error(

--- a/packages/app/src/webapp/views/diffTable.ts
+++ b/packages/app/src/webapp/views/diffTable.ts
@@ -62,10 +62,10 @@ export const applyDiffTable = (
           status.className = 'cell-inner red-background'
           status.innerText = 'Offline'
         }
-        const badge = rows[rowDeletion.deleteIndex].querySelector(
-          '.badge-width'
+        const pulse = rows[rowDeletion.deleteIndex].querySelector(
+          '.repeating-pulse'
         ) as HTMLElement
-        if (badge) badge.classList.remove('repeating-pulse')
+        if (pulse) pulse.classList.remove('repeating-pulse')
       })
   }
 

--- a/packages/app/src/webapp/views/table.ts
+++ b/packages/app/src/webapp/views/table.ts
@@ -21,22 +21,34 @@ import { pexec, qexec } from '../../core/repl'
 import drilldown from '../picture-in-picture'
 import {
   Table,
+  MultiTable,
   Row,
   Cell,
   Icon,
   TableStyle,
   WatchableTable,
   diffTableRows,
-  isWatchableTable,
+  isMultiTable,
   isTable
 } from '../models/table'
+import { isWatchable } from '../models/basicModels'
 import { applyDiffTable } from '../views/diffTable'
 import { theme } from '@kui-shell/core/core/settings'
+import { _split as split, Split } from '@kui-shell/core/core/repl'
+import minimist = require('yargs-parser')
 
 const debug = Debug('webapp/views/table')
 
 interface TableFormatOptions {
   usePip?: boolean
+}
+
+/** groups of States that mark desired final outcomes */
+// NOTE: This is a copy from kubectl plguin, and we should port models/states in kubectl plugin to the core
+enum FinalState {
+  NotPendingLike,
+  OnlineLike,
+  OfflineLike
 }
 
 // sort the body of table
@@ -71,6 +83,131 @@ const prepareTable = (tab: Tab, response: Table | WatchableTable): Row[] => {
   // sort the list, then format each element, then add the results to the resultDom
   // (don't sort lists of activations. i wish there were a better way to do this)
   return [header].concat(noSort ? body : sortBody(body)).filter(x => x)
+}
+
+const registerWatcher = (
+  tab: Tab,
+  watchLimit: number = 100000,
+  command: string,
+  resultDom: HTMLElement,
+  tableViewInfo: TableViewInfo | TableViewInfo[]
+) => {
+  // the current watch interval; used for clear/reset/stop
+  let interval: NodeJS.Timeout // eslint-disable-line prefer-const
+
+  const stopWatching = () => {
+    debug('stopWatching')
+    clearInterval(interval)
+  }
+
+  const processRefreshResponse = (response: Table | MultiTable) => {
+    let reachedFinalState = false
+
+    if (isTable(response)) {
+      if (!response.body.some(row => !row.done)) {
+        // stop watching if all resources have reached to the finial state
+        reachedFinalState = true
+      }
+
+      return { table: prepareTable(tab, response), reachedFinalState }
+    } else if (isMultiTable(response)) {
+      let allDone = true // allDone is used to indicate if all resources have reached to the final state
+
+      const newRowModels = response.tables.map(table => {
+        if (table.body.some(row => !row.done)) {
+          allDone = false
+        }
+
+        return prepareTable(tab, table)
+      })
+
+      return { tables: newRowModels, reachedFinalState: allDone }
+    } else {
+      console.error('refresh result is not a table', response)
+      throw new Error('refresh result is not a table')
+    }
+  }
+
+  const refreshTable = async () => {
+    debug(`refresh with ${command}`)
+    let processedTableRow: Row[] = []
+    let processedMultiTableRow: Row[][] = []
+
+    try {
+      const response = await qexec(command)
+
+      const processedResponse = processRefreshResponse(response)
+
+      processedTableRow = processedResponse.table
+      processedMultiTableRow = processedResponse.tables
+
+      // stop watching if all resources in the table reached to the finial state
+      if (processedResponse.reachedFinalState) {
+        stopWatching()
+      }
+    } catch (err) {
+      if (err.code === 404) {
+        // parse the refresh command
+        const { A: argv } = split(command, true, true) as Split
+        const options = minimist(argv)
+
+        if (
+          options['final-state'] &&
+          FinalState[options['finalState']] === 'OfflineLike'
+        ) {
+          debug(
+            'resource not found after status check, but that is ok because that is what we wanted'
+          )
+          stopWatching()
+        }
+      } else {
+        while (resultDom.firstChild) {
+          resultDom.removeChild(resultDom.firstChild)
+        }
+        stopWatching()
+        throw err
+      }
+    }
+
+    const applyRefreshResult = (
+      newRowModel: Row[],
+      tableViewInfo: TableViewInfo
+    ) => {
+      const diffs = diffTableRows(tableViewInfo.rowsModel, newRowModel)
+      applyDiffTable(
+        diffs,
+        tab,
+        tableViewInfo.renderedTable,
+        tableViewInfo.renderedRows,
+        tableViewInfo.rowsModel
+      )
+    }
+
+    if (Array.isArray(tableViewInfo)) {
+      processedMultiTableRow.forEach((newRowModel, index) => {
+        applyRefreshResult(newRowModel, tableViewInfo[index])
+      })
+    } else {
+      applyRefreshResult(processedTableRow, tableViewInfo)
+    }
+  }
+
+  const watchIt = () => {
+    if (--watchLimit < 0) {
+      debug('watchLimit exceeded')
+      stopWatching()
+    } else {
+      try {
+        Promise.resolve(refreshTable()) // or refreshTables
+      } catch (err) {
+        console.error('Error refreshing table', err)
+        stopWatching()
+      }
+    }
+  }
+
+  // establish the initial watch interval
+  interval = setInterval(watchIt, 1000 + ~~(1000 * Math.random()))
 }
 
 /**
@@ -607,155 +744,122 @@ function setStyle(tableDom: HTMLElement, table: Table) {
   }
 }
 
+// This helps multi-table view handler to use the the processed data from single-table view handler
+interface TableViewInfo {
+  renderedRows: HTMLElement[]
+  rowsModel: Row[]
+  renderedTable: HTMLElement
+  tableModel: Table | WatchableTable
+}
+
 export const formatTable = (
   tab: Tab,
-  table: Table | WatchableTable,
+  response: Table | MultiTable,
   resultDom: HTMLElement,
   options: TableFormatOptions = {}
-): void => {
-  const tableDom = document.createElement('div')
-  tableDom.classList.add('result-table')
+) => {
+  const format = (table: Table) => {
+    const tableDom = document.createElement('div')
+    tableDom.classList.add('result-table')
 
-  let container: HTMLElement
-  if (table.title) {
-    const tableOuterWrapper = document.createElement('div')
-    const tableOuter = document.createElement('div')
-    const titleOuter = document.createElement('div')
-    const titleInner = document.createElement('div')
+    let container: HTMLElement
+    if (table.title) {
+      const tableOuterWrapper = document.createElement('div')
+      const tableOuter = document.createElement('div')
+      const titleOuter = document.createElement('div')
+      const titleInner = document.createElement('div')
 
-    tableOuterWrapper.classList.add('result-table-outer-wrapper')
-    tableOuter.appendChild(titleOuter)
-    titleOuter.appendChild(titleInner)
-    tableOuterWrapper.appendChild(tableOuter)
-    resultDom.appendChild(tableOuterWrapper)
+      tableOuterWrapper.classList.add('result-table-outer-wrapper')
+      tableOuter.appendChild(titleOuter)
+      titleOuter.appendChild(titleInner)
+      tableOuterWrapper.appendChild(tableOuter)
+      resultDom.appendChild(tableOuterWrapper)
 
-    if (table.flexWrap) {
-      const tableScroll = document.createElement('div')
-      tableScroll.classList.add('scrollable')
-      tableScroll.classList.add('scrollable-auto')
-      tableScroll.setAttribute(
-        'data-table-max-rows',
-        typeof table.flexWrap === 'number' ? table.flexWrap.toString() : '8'
-      )
-      tableScroll.appendChild(tableDom)
-      tableOuter.appendChild(tableScroll)
+      if (table.flexWrap) {
+        const tableScroll = document.createElement('div')
+        tableScroll.classList.add('scrollable')
+        tableScroll.classList.add('scrollable-auto')
+        tableScroll.setAttribute(
+          'data-table-max-rows',
+          typeof table.flexWrap === 'number' ? table.flexWrap.toString() : '8'
+        )
+        tableScroll.appendChild(tableDom)
+        tableOuter.appendChild(tableScroll)
+      } else {
+        tableOuter.appendChild(tableDom)
+      }
+
+      tableOuter.classList.add('result-table-outer')
+      titleOuter.classList.add('result-table-title-outer')
+      titleInner.classList.add('result-table-title')
+      titleInner.innerText = table.title
+
+      if (table.tableCSS) {
+        tableOuterWrapper.classList.add(table.tableCSS)
+      }
+
+      if (table.fontawesome) {
+        const awesomeWrapper = document.createElement('div')
+        const awesome = document.createElement('i')
+        awesomeWrapper.appendChild(awesome)
+        titleOuter.appendChild(awesomeWrapper)
+
+        awesome.className = table.fontawesome
+
+        if (table.fontawesomeCSS) {
+          awesomeWrapper.classList.add(table.fontawesomeCSS)
+          delete table.fontawesomeCSS
+        }
+
+        if (table.fontawesomeBalloon) {
+          awesomeWrapper.setAttribute('data-balloon', table.fontawesomeBalloon)
+          awesomeWrapper.setAttribute('data-balloon-pos', 'left')
+          delete table.fontawesomeBalloon
+        }
+
+        // otherwise, the header row renderer will pick this up
+        delete table.fontawesome
+      }
+
+      container = tableOuterWrapper
     } else {
-      tableOuter.appendChild(tableDom)
+      resultDom.appendChild(tableDom)
+      container = tableDom
     }
 
-    tableOuter.classList.add('result-table-outer')
-    titleOuter.classList.add('result-table-title-outer')
-    titleInner.classList.add('result-table-title')
-    titleInner.innerText = table.title
+    container.classList.add('big-top-pad')
 
-    if (table.tableCSS) {
-      tableOuterWrapper.classList.add(table.tableCSS)
+    const prepareRows = prepareTable(tab, table)
+    const rows = prepareRows.map(formatOneRowResult(tab, options))
+    rows.map(row => tableDom.appendChild(row))
+
+    setStyle(tableDom, table)
+
+    const rowSelection = tableDom.querySelector('.selected-row')
+    if (rowSelection) {
+      tableDom.classList.add('has-row-selection')
     }
 
-    if (table.fontawesome) {
-      const awesomeWrapper = document.createElement('div')
-      const awesome = document.createElement('i')
-      awesomeWrapper.appendChild(awesome)
-      titleOuter.appendChild(awesomeWrapper)
-
-      awesome.className = table.fontawesome
-
-      if (table.fontawesomeCSS) {
-        awesomeWrapper.classList.add(table.fontawesomeCSS)
-        delete table.fontawesomeCSS
-      }
-
-      if (table.fontawesomeBalloon) {
-        awesomeWrapper.setAttribute('data-balloon', table.fontawesomeBalloon)
-        awesomeWrapper.setAttribute('data-balloon-pos', 'left')
-        delete table.fontawesomeBalloon
-      }
-
-      // otherwise, the header row renderer will pick this up
-      delete table.fontawesome
+    return {
+      renderedRows: rows,
+      renderedTable: tableDom,
+      rowsModel: prepareRows,
+      tableModel: table
     }
-
-    container = tableOuterWrapper
-  } else {
-    resultDom.appendChild(tableDom)
-    container = tableDom
   }
 
-  container.classList.add('big-top-pad')
+  const tableViewInfo = isMultiTable(response)
+    ? response.tables.map(table => format(table))
+    : format(response)
 
-  const prepareRows = prepareTable(tab, table)
-  const rows = prepareRows.map(formatOneRowResult(tab, options))
-  rows.map(row => tableDom.appendChild(row))
-
-  setStyle(tableDom, table)
-
-  const rowSelection = tableDom.querySelector('.selected-row')
-  if (rowSelection) {
-    tableDom.classList.add('has-row-selection')
-  }
-
-  if (isWatchableTable(table)) {
-    if (table.watchByDefault) {
-      // TODO: register a button?
-      // we'll ping the watcher at most watchLimit times
-      let count = table.watchLimit ? table.watchLimit : 100000
-
-      // the current watch interval; used for clear/reset/stop
-      let interval: NodeJS.Timeout // eslint-disable-line prefer-const
-
-      const stopWatching = () => {
-        debug('stopWatching')
-        clearInterval(interval)
-      }
-
-      const refreshTable = async () => {
-        debug(`refresh with ${table.refreshCommand}`)
-
-        let newPrepareRows: Row[]
-
-        try {
-          const response = await qexec(table.refreshCommand)
-          if (isTable(response)) {
-            newPrepareRows = prepareTable(tab, response)
-          } else {
-            console.error('refresh result is not a table', response)
-            rows.map(row => tableDom.removeChild(row))
-          }
-        } catch (err) {
-          if (err.code === 404) {
-            newPrepareRows = []
-          } else {
-            while (resultDom.firstChild) {
-              resultDom.removeChild(resultDom.firstChild)
-            }
-            stopWatching()
-            throw err
-          }
-        }
-
-        const diffs = diffTableRows(prepareRows, newPrepareRows)
-        // debug('diff table rows', diffs)
-        applyDiffTable(diffs, tab, tableDom, rows, prepareRows)
-      }
-
-      const watchIt = () => {
-        if (--count < 0) {
-          debug('watchLimit exceeded')
-          stopWatching()
-          return
-        }
-
-        try {
-          Promise.resolve(refreshTable())
-        } catch (err) {
-          console.error('Error refreshing table', err)
-          clearInterval(interval)
-        }
-      }
-
-      // establish the initial watch interval
-      interval = setInterval(watchIt, 1000 + ~~(1000 * Math.random()))
-    }
+  if (isWatchable(response) && response.watchByDefault) {
+    registerWatcher(
+      tab,
+      response.watchLimit,
+      response.refreshCommand,
+      resultDom,
+      tableViewInfo
+    )
   }
 }
 

--- a/plugins/plugin-k8s/src/lib/controller/contexts.ts
+++ b/plugins/plugin-k8s/src/lib/controller/contexts.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { Row, Table } from '@kui-shell/core/webapp/models/table'
+import {
+  Row,
+  Table,
+  MultiTable,
+  isMultiTable
+} from '@kui-shell/core/webapp/models/table'
 import { CommandRegistrar } from '@kui-shell/core/models/command'
 
 import repl = require('@kui-shell/core/core/repl')
@@ -83,9 +88,11 @@ const listContexts = opts =>
       undefined,
       opts.execOptions
     )
-    .then((contexts: Table | Table[]) =>
-      Array.isArray(contexts)
-        ? contexts.map(context => addClickHandlers(context, opts.execOptions))
+    .then((contexts: Table | MultiTable) =>
+      isMultiTable(contexts)
+        ? contexts.tables.map(context =>
+            addClickHandlers(context, opts.execOptions)
+          )
         : addClickHandlers(contexts, opts.execOptions)
     )
 

--- a/plugins/plugin-k8s/src/lib/controller/kedit.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kedit.ts
@@ -185,11 +185,11 @@ const showResource = async (yaml: KubeResource, filepath: string, tab: Tab) => {
  * Render the resources as a REPL table
  *
  */
-const showAsTable = (
+const showAsTable = async (
   yamls: any[], // eslint-disable-line @typescript-eslint/no-explicit-any
   filepathAsGiven: string,
   parsedOptions
-): Table => {
+): Promise<Table> => {
   debug('showing as table', yamls)
 
   const ourOptions = {
@@ -206,8 +206,10 @@ const showAsTable = (
     }
   }
 
-  return new Table({
-    body: yamls.map(formatEntity(Object.assign({}, parsedOptions, ourOptions)))
+  return Promise.all(
+    yamls.map(formatEntity(Object.assign({}, parsedOptions, ourOptions)))
+  ).then(formattedEntities => {
+    return new Table({ body: formattedEntities })
   })
 }
 

--- a/plugins/plugin-k8s/src/lib/view/formatMultiTable.ts
+++ b/plugins/plugin-k8s/src/lib/view/formatMultiTable.ts
@@ -22,6 +22,7 @@ import { Tab } from '@kui-shell/core/webapp/cli'
 import { formatTable as format } from '@kui-shell/core/webapp/views/table'
 import {
   Table,
+  MultiTable,
   isTable,
   isMultiTable
 } from '@kui-shell/core/webapp/models/table'
@@ -85,7 +86,7 @@ const updateTableForPip = (tab: Tab, viewName: string, execOptions) => (
  */
 export const formatTable = (
   tab: Tab,
-  model: Table | Table[],
+  model: Table | MultiTable,
   { usePip = false, viewName = 'previous view', execOptions = {} } = {}
 ): HTMLElement => {
   debug('formatTable model', model)
@@ -98,7 +99,7 @@ export const formatTable = (
     // e.g. establish an attribute [k8s-table="Containers"]
     resultDomOuter.setAttribute(
       attr,
-      isTable(model) ? model.title : model.map(m => m.title).join(' ')
+      isTable(model) ? model.title : model.tables.map(m => m.title).join(' ')
     )
 
     // modify onclick links to use the "picture in picture" drilldown module
@@ -107,7 +108,7 @@ export const formatTable = (
       if (isTable(model)) {
         updateTableForPip(tab, viewName, execOptions)(model)
       } else {
-        model.forEach(updateTableForPip(tab, viewName, execOptions))
+        model.tables.forEach(updateTableForPip(tab, viewName, execOptions))
       }
     }
 
@@ -126,7 +127,7 @@ export const formatTable = (
       format(tab, model, resultDom)
     } else {
       resultDom.classList.add('result-as-multi-table')
-      model.forEach(m => format(tab, m, resultDom))
+      model.tables.forEach(m => format(tab, m, resultDom))
     }
   }
 

--- a/plugins/plugin-k8s/src/lib/view/helm-status.ts
+++ b/plugins/plugin-k8s/src/lib/view/helm-status.ts
@@ -116,7 +116,12 @@ export const format = async (
       }
     })
   if (headerString) await stdout(headerString)
-  await stdout(resourcesOut)
+
+  await stdout(
+    Array.isArray(resourcesOut) ? { tables: resourcesOut } : resourcesOut
+  )
+
   if (notesString) await stdout(notesString)
+
   return true
 }


### PR DESCRIPTION
Fixes #1853
Fixes #1764

About this PR:

Current Problem: The k status command uses the old watch mechanism, which doesn't work in proxy+webpack mode. Since we use k status table to create k8s resource, this issue blocks us from enabling our proxy+webpack test for k8s layers.

Solution: I ported the k status table into new watchable table, and implemented a watchable multi-table. 

Implementation Details: 
1. I changed the behavior of k status command. It used to return Table(s) with initial status - Pending and relied on cell watching mechanism (located at views/table/addCellToRow) to call the watch function and update the cell attribute. In my PR, k status command will no longer return a table with placeholder Pending status. Instead, it will wait for resource fetcher and return the real Table from fetcher. I found that there's a retryWith404 in controller/status, which will retry the getter for the case of resource creation. Due to this, I think my removal of the Pending placeholder won't cause regression. 
2. I introduced a k status --watch command, which is basically a k status table with a watcher (refreshCommand: k status). 
2. I added a temporary mechanism to stop watching resource if all the resources in Table have reached to a final state. This is the capability that the existing k status table has. 


#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
