### PR TITLE
fix(plugins/plugin-editor): editor text selection versus light theme

### DIFF
--- a/plugins/plugin-editor/web/css/dark.css
+++ b/plugins/plugin-editor/web/css/dark.css
@@ -11,8 +11,6 @@ body[kui-theme-style="dark"] .monaco-editor .lines-content .cigr {
 }
 
 body[kui-theme-style="dark"] .monaco-editor .selected-text {
-    transition: background 300ms ease-in-out;
-    background: var(--color-selection-background);
     opacity: 0.3; /* i don't know why the selection outside of monaco is different, despite using the same CSS styling */
 }
 

--- a/plugins/plugin-editor/web/css/editor.css
+++ b/plugins/plugin-editor/web/css/editor.css
@@ -142,3 +142,8 @@ tab.sidecar-full-screen #sidecar .wskflow-container.visible {
     bottom: -1em;
     color: var(--color-support-01);
 }
+
+body[kui-theme-style] .monaco-editor .selected-text {
+    transition: background 300ms ease-in-out;
+    background: var(--color-selection-background);
+}


### PR DESCRIPTION
Fixes #1888

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
