### PR TITLE
fix(packages/app): bad monospace font in webpack builds, on mac

### DIFF
--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -2901,7 +2901,7 @@ body {
     --color-scrollbar-track: transparent;
 
     --font-sans-serif: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-    --font-monospace: -apple-system,SFMono-Regular,"SF Mono",Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+    --font-monospace: SFMono-Regular,"SF Mono",Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
 
     --color-hover-primary-text: var(--color-cyan);
     --color-content-divider: var(--color-cyan);
@@ -3061,15 +3061,15 @@ body {
     padding-left: 0.75em;
 }
 
-@font-face { font-family: "SF Mono"; font-weight: 200; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Light.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 200; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-LightItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 400; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Regular.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 400; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-RegularItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 500; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Medium.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 500; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-MediumItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 600; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Semibold.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 600; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-SemiboldItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 700; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Bold.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 700; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-BoldItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 800; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Heavy.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 800; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-HeavyItalic.otf); }
+@font-face { font-family: "SF Mono"; font-weight: 200; font-style: normal; src: local("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Light.otf"),local("Menlo"),local("Monaco"),local("Consolas"),local("Liberation Mono"),local("Courier New"),local("monospace"); }
+@font-face { font-family: "SF Mono"; font-weight: 200; font-style: italic; src: local("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-LightItalic.otf"),local("Menlo"),local("Monaco"),local("Consolas"),local("Liberation Mono"),local("Courier New"),local("monospace"); }
+@font-face { font-family: "SF Mono"; font-weight: 400; font-style: normal; src: local("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Regular.otf"),local("Menlo"),local("Monaco"),local("Consolas"),local("Liberation Mono"),local("Courier New"),local("monospace"); }
+@font-face { font-family: "SF Mono"; font-weight: 400; font-style: italic; src: local("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-RegularItalic.otf"),local("Menlo"),local("Monaco"),local("Consolas"),local("Liberation Mono"),local("Courier New"),local("monospace"); }
+@font-face { font-family: "SF Mono"; font-weight: 500; font-style: normal; src: local("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Medium.otf"),local("Menlo"),local("Monaco"),local("Consolas"),local("Liberation Mono"),local("Courier New"),local("monospace"); }
+@font-face { font-family: "SF Mono"; font-weight: 500; font-style: italic; src: local("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-MediumItalic.otf"),local("Menlo"),local("Monaco"),local("Consolas"),local("Liberation Mono"),local("Courier New"),local("monospace"); }
+@font-face { font-family: "SF Mono"; font-weight: 600; font-style: normal; src: local("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Semibold.otf"),local("Menlo"),local("Monaco"),local("Consolas"),local("Liberation Mono"),local("Courier New"),local("monospace"); }
+@font-face { font-family: "SF Mono"; font-weight: 600; font-style: italic; src: local("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-SemiboldItalic.otf"),local("Menlo"),local("Monaco"),local("Consolas"),local("Liberation Mono"),local("Courier New"),local("monospace"); }
+@font-face { font-family: "SF Mono"; font-weight: 700; font-style: normal; src: local("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Bold.otf"),local("Menlo"),local("Monaco"),local("Consolas"),local("Liberation Mono"),local("Courier New"),local("monospace"); }
+@font-face { font-family: "SF Mono"; font-weight: 700; font-style: italic; src: local("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-BoldItalic.otf"),local("Menlo"),local("Monaco"),local("Consolas"),local("Liberation Mono"),local("Courier New"),local("monospace"); }
+@font-face { font-family: "SF Mono"; font-weight: 800; font-style: normal; src: local("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Heavy.otf"),local("Menlo"),local("Monaco"),local("Consolas"),local("Liberation Mono"),local("Courier New"),local("monospace"); }
+@font-face { font-family: "SF Mono"; font-weight: 800; font-style: italic; src: local("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-HeavyItalic.otf"),local("Menlo"),local("Monaco"),local("Consolas"),local("Liberation Mono"),local("Courier New"),local("monospace"); }


### PR DESCRIPTION
Fixes #1910

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
