### PR TITLE
fix(packages/app): Table Watcher should check if it reaches the final state before registering watcher

### DIFF
--- a/packages/app/src/main/tray.ts
+++ b/packages/app/src/main/tray.ts
@@ -31,7 +31,7 @@ import { Quittable } from './main-models'
  *
  */
 export default ({ Tray, Menu }, app: Quittable, createWindow: Function) => {
-  const screen = require('electron').screen
+  const screen = require('electron').remote.screen
   const screenSize = screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).workArea
   const dimensions = { width: 800, height: 600 }
 


### PR DESCRIPTION
Also improved the test by replacing the deprecated electron.screen with electron.remote.screen

Fixes #1932

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
