### PR TITLE
fix(plugins/plugin-k8s): eliminated unnecessary error message for finding KUBECONFIG in local file system

### DIFF
--- a/plugins/plugin-k8s/src/lib/util/discovery/kubeconfig.ts
+++ b/plugins/plugin-k8s/src/lib/util/discovery/kubeconfig.ts
@@ -40,7 +40,7 @@ const fillInPATH = (env: Record<string, any>) => {
 // indicates failure (on macOS, the length seems to be 0?)
 const maybeKUBECONFIG = (file: string): string | void => {
   try {
-    const maybe = execSync(`echo $(. ~/${file} && echo $KUBECONFIG)`)
+    const maybe = execSync(`if [ -f ~/${file} ]; then echo $(. ~/${file} && echo $KUBECONFIG); fi`)
     debug('maybe? KUBECONFIG from %s', file, maybe)
     if (maybe.length > 1) {
       const kubeconfig = maybe.toString().trim()


### PR DESCRIPTION
Fixes #1936

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
