### PR TITLE
fix(packages/kui-builder): ANSI black in new dark theme is not visible

### DIFF
--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/tomorrow-night.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/tomorrow-night.css
@@ -20,6 +20,7 @@ body[kui-theme="tomorrow-night"] {
     --color-base0E: #b294bb; /* MAGENTA: Keywords, Storage, Selector, Markup Italic, Diff Changed */
     --color-base0F: #a3685a; /* BROWN: Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?> */
 
+    --color-black: var(--color-base05); /* e.g. husky's "No partially staged files found" */
     --color-light-red: hsla(0, 80%, 75%, 50%);
     --color-light-green: hsla(66, 69%, 57%, 50%);
     --color-light-yellow: hsl(40, 81%, 70%);


### PR DESCRIPTION
Fixes #2011

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
