### PR TITLE
fix(plugins/plugin-k8s): sidecar's yaml tab for namespace resource has wrong packageName

### DIFF
--- a/plugins/plugin-k8s/src/lib/controller/kubectl.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kubectl.ts
@@ -353,8 +353,6 @@ const executeLocally = (command: string) => (opts: EvaluatorArgs) =>
     // what we want to display for the entity kind
     const entityTypeForDisplay = abbreviations[entityTypeWithoutTrailingSuffix] || entityTypeWithoutTrailingSuffix
 
-    const cmdlineForDisplay = argv.slice(1).join(' ')
-
     // replace @seed/yo.yaml with full path
     const argvWithFileReplacements: string[] = await Promise.all(
       rawArgv.slice(1).map(
@@ -670,7 +668,7 @@ const executeLocally = (command: string) => (opts: EvaluatorArgs) =>
           type: 'custom',
           isEntity: true,
           name: entity || verb,
-          packageName: (yaml && yaml.metadata && yaml.metadata.namespace) || cmdlineForDisplay,
+          packageName: (yaml && yaml.metadata && yaml.metadata.namespace) || '',
           namespace: options.namespace || options.n,
           duration,
           version,


### PR DESCRIPTION
Fixes #2045

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
