### PR TITLE
chore(packages/webpack): remove dependence on webpack-visualizer-plugin

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -48,8 +48,7 @@
     "to-string-loader": "1.1.5",
     "webpack": "4.35.0",
     "webpack-cli": "3.3.5",
-    "webpack-dev-server": "3.7.2",
-    "webpack-visualizer-plugin": "0.1.11"
+    "webpack-dev-server": "3.7.2"
   },
   "kui": {
     "headless": false,

--- a/packages/webpack/webpack.config.js
+++ b/packages/webpack/webpack.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 IBM Corporation
+ * Copyright 2018-19 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,6 @@ if (isMonorepo) {
 } else {
   console.log('external client mode')
 }
-
-// const Visualizer = require('webpack-visualizer-plugin')
 
 /** point webpack to the root directory */
 const stageDir = process.env.KUI_STAGE || process.env.KUI_MONO_HOME || process.cwd()
@@ -99,9 +97,6 @@ if (CompressionPlugin) {
 const optimization = {
   usedExports: true
 }
-
-// for debugging, webpack stats plugin
-/* plugins.push(new Visualizer({ filename: './webpack-stats.html' })) */
 
 // the Kui builder plugin
 plugins.push({


### PR DESCRIPTION
Fixes #2065

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
