### PR TITLE
chore: remove fontawesome from k8s

### DIFF
--- a/packages/app/src/webapp/views/table.ts
+++ b/packages/app/src/webapp/views/table.ts
@@ -313,7 +313,13 @@ export const formatOneRowResult = (tab: Tab, options: RowFormatOptions = {}) => 
       const icon = document.createElement('i')
       entityNameClickable.appendChild(icon)
       icon.classList.add('cell-inner')
-      icon.className = entity.fontawesome
+
+      if (/fa-network/.test(entity.fontawesome)) {
+        icon.innerHTML =
+          '<svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true"><path d="M26 14a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2v4.1a5 5 0 0 0-3.9 3.9H14v-2a2 2 0 0 0-2-2h-2v-4.1a5 5 0 1 0-2 0V18H6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2v-2h4.1a5 5 0 1 0 5.9-5.9V14zM6 9a3 3 0 1 1 3 3 3 3 0 0 1-3-3zm6 17H6v-6h6zm14-3a3 3 0 1 1-3-3 3 3 0 0 1 3 3zM20 6h6v6h-6z"></path></svg>'
+      } else {
+        icon.className = entity.fontawesome
+      }
     }
   } else if (typeof name === 'string') {
     entityNameClickable.title = name

--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -252,6 +252,9 @@ body:not(.subwindow) repl.sidecar-visible .repl-block,
   text-transform: capitalize;
   letter-spacing: 0.32px;
 }
+.header-cell svg path {
+  fill: var(--color-text-against-dark-bg);
+}
 .result-table:not([kui-table-style="Light"]) .header-cell .cell-inner {
   padding: 0 0.6875em;
 }
@@ -588,6 +591,9 @@ tab:not(.sidecar-full-screen) sidecar .fifty-fifty {
 .row-selection-context .selected-entity svg path {
   transition: fill 300ms ease-in-out;
 }
+.row-selection-context.selected-row .selected-entity svg path {
+  fill: var(--color-name) !important;
+}
 .row-selection-context:not(.selected-row) .selected-entity svg path {
   fill: var(--color-text-02) !important;
 }
@@ -638,7 +644,9 @@ tab:not(.sidecar-full-screen) sidecar .fifty-fifty {
   white-space: nowrap;
   text-overflow: ellipsis;
 }
-.repl.sidecar-visible .result-table .entity-name-group:first-child:not(.entity-name-group-narrow):not(.not-a-name) {
+.repl.sidecar-visible
+  .result-table
+  .entity-name-group:first-child:not(.entity-name-group-narrow):not(.entity-name-group-extra-narrow):not(.not-a-name) {
   /* extra magic to get text ellipsis working; this needs width: 100% on enclosing tables */
   width: 100%;
   max-width: 0; /* important! 0 not 0% */

--- a/plugins/plugin-k8s/src/lib/controller/status.ts
+++ b/plugins/plugin-k8s/src/lib/controller/status.ts
@@ -36,10 +36,6 @@ const debug = Debug('k8s/controller/status')
 debug('loading')
 import repl = require('@kui-shell/core/core/repl')
 
-/** icon to indicate "is a cluster" */
-const fontawesome = 'fas fa-network-wired'
-const fontawesomeCSS = 'selected-entity'
-
 const strings = {
   allContexts: 'Resources Across All Contexts',
   currentContext: 'This is your current context',
@@ -89,8 +85,6 @@ const usage = (command: string) => ({
 interface HeaderRow {
   title?: string
   context?: boolean
-  fontawesome?: string
-  fontawesomeCSS?: string
   balloon?: string
   tableCSS?: string
 }
@@ -127,7 +121,6 @@ const headerRow = (opts: HeaderRow, kind?: string): Row => {
     outerCSS: 'header-cell',
     // flexWrap: 10,
     title: opts.title && basename(opts.title).replace(/\.yaml$/, ''),
-    fontawesomeBalloon: opts.balloon,
     attributes
   })
 }
@@ -292,8 +285,6 @@ const getStatusForKnownContexts = (execOptions: ExecOptions, parsedOptions: Pars
               return [
                 headerRow({
                   title: name,
-                  fontawesome,
-                  fontawesomeCSS,
                   balloon,
                   tableCSS
                 })
@@ -317,8 +308,6 @@ const getStatusForKnownContexts = (execOptions: ExecOptions, parsedOptions: Pars
         title: parsedOptions.all ? strings.allContexts : await currentContext,
         context: true,
         tableCSS: 'selected-row',
-        fontawesome,
-        fontawesomeCSS,
         balloon: strings.currentContext
       })
       return [header].concat(resources)
@@ -610,18 +599,13 @@ const statusTable = entities => {
     const header: Row = {
       name: headerRow.name,
       attributes: headerRow.attributes,
-      outerCSS: headerRow.outerCSS,
-      fontawesome: headerRow.fontawesome,
-      fontawesomeCSS: headerRow.fontawesomeCSS
+      outerCSS: headerRow.outerCSS
     }
 
     return new Table({
       title: headerRow.title,
       noSort: headerRow.noSort,
       tableCSS: headerRow.tableCSS,
-      fontawesome,
-      fontawesomeCSS,
-      fontawesomeBalloon: headerRow.fontawesomeBalloon,
       header,
       body: entitiesRows
     })

--- a/plugins/plugin-k8s/src/lib/view/formatTable.ts
+++ b/plugins/plugin-k8s/src/lib/view/formatTable.ts
@@ -282,7 +282,7 @@ export const formatTable = (
       return {
         key: rows[0].key,
         name: nameForDisplay,
-        fontawesome: idx !== 0 && rows[0].key === 'CURRENT' && 'fas fa-network-wired',
+        fontawesome: idx !== 0 && rows[0].key === 'CURRENT' && 'fas fa-check',
         onclick: nameColumnIdx === 0 && onclick, // if the first column isn't the NAME column, no onclick; see onclick below
         css: firstColumnCSS,
         rowCSS,


### PR DESCRIPTION
1) the contexts table is ported to radiotable
2) remove odd use of fa-network from k status

Fixes #2089

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
