### PR TITLE
chore: Kui is not automatically open after installation

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -77,8 +77,6 @@ case $OS in
  
     echo ""
     echo "|----- You can find \"Kui\" in your \"$BIN_DIR\" folder :) -----|"
- 
-    open -a Kui
     ;;
   *)
     echo "Not supported platform :("


### PR DESCRIPTION
#### Description of what you did:

When the installation scripts finish the installation process at macOS, the application is not automatically open. That is not the default process of an application installation, in any case, we should ask users before doing operations in their name.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
