### PR TITLE
fix: kubectl logs versus webpack+proxy

### DIFF
--- a/packages/app/src/models/execOptions.ts
+++ b/packages/app/src/models/execOptions.ts
@@ -73,11 +73,31 @@ export interface ExecOptions {
   entity?: any // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
+export interface LanguageBearing extends ExecOptions {
+  /** navigator.language */
+  language: string
+}
+
+export function hasLanguage(execOptions: ExecOptions): execOptions is LanguageBearing {
+  return (execOptions as LanguageBearing).language !== undefined
+}
+
+export function withLanguage(execOptions: ExecOptions): LanguageBearing {
+  if (hasLanguage(execOptions)) {
+    return execOptions
+  } else {
+    return Object.assign({}, execOptions, { language: typeof navigator !== 'undefined' && navigator.language })
+  }
+}
+
 export class DefaultExecOptions implements ExecOptions {
   readonly type: ExecType
 
+  readonly language: string
+
   constructor(type: ExecType = ExecType.TopLevel) {
     this.type = type
+    this.language = typeof navigator !== 'undefined' && navigator.language
   }
 }
 

--- a/packages/app/src/util/mimic-dom.ts
+++ b/packages/app/src/util/mimic-dom.ts
@@ -36,7 +36,15 @@ import Store from '../main/store'
   } */
 
 class ClassList {
-  private classList: string[] = []
+  readonly classList: string[] = []
+
+  get length(): number {
+    return this.classList.length
+  }
+
+  forEach(fn: (str: string) => void) {
+    this.classList.forEach(fn)
+  }
 
   add(_: string) {
     return this.classList.push(_)
@@ -142,7 +150,7 @@ export class ElementMimic {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static isFakeDom(dom: any): dom is ElementMimic {
-    return (dom as ElementMimic)._isFakeDom
+    return dom && (dom as ElementMimic)._isFakeDom
   }
 }
 

--- a/packages/app/src/webapp/util/time.ts
+++ b/packages/app/src/webapp/util/time.ts
@@ -16,6 +16,8 @@
 
 import * as prettyPrintDuration from 'pretty-ms'
 
+import { DefaultExecOptions, LanguageBearing } from '@kui-shell/core/models/execOptions'
+
 function isDate(object: Date | string | number): object is Date {
   return object && typeof object !== 'string' && typeof object !== 'number' && 'getMonth' in object
 }
@@ -34,7 +36,8 @@ const span = (text: string): HTMLElement => {
 export const prettyPrintTime = (
   timestamp: Date | string | number,
   fmt = 'long',
-  previousTimestamp?: Date | string | number
+  previousTimestamp?: Date | string | number,
+  execOptions: LanguageBearing = new DefaultExecOptions()
 ) => {
   // compare now to then, to see if we need to show a year, etc.
   const now = new Date()
@@ -90,7 +93,7 @@ export const prettyPrintTime = (
         return sameDay()
       } else {
         return span(
-          then.toLocaleString(navigator.language, {
+          then.toLocaleString(execOptions.language, {
             weekday: fmt,
             month: fmt,
             day: 'numeric',
@@ -103,7 +106,7 @@ export const prettyPrintTime = (
     }
   } else if (now.getFullYear() === then.getFullYear()) {
     return span(
-      then.toLocaleString(navigator.language, {
+      then.toLocaleString(execOptions.language, {
         weekday: fmt,
         month: fmt,
         day: 'numeric',

--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -1747,7 +1747,7 @@ sidecar .activation-result .log-line .log-field > div > div:first-child code {
   color: var(--color-text-02);
 }
 .log-lines .log-line .log-field.log-date.hljs-attribute {
-  color: var(--color-base0A);
+  color: var(--color-base0C);
 }
 .log-lines .log-line .log-message {
   white-space: pre-wrap;

--- a/plugins/plugin-k8s/src/lib/controller/kubectl.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kubectl.ts
@@ -594,7 +594,7 @@ const executeLocally = (command: string) => (opts: EvaluatorArgs) =>
           output === 'json'
             ? JSON.parse(out)
             : verb === 'logs'
-            ? formatLogs(out)
+            ? formatLogs(out, execOptions)
             : output === 'yaml'
             ? redactYAML(out)
             : redactJSON(out)


### PR DESCRIPTION
this introduces the passing through of navigator.language to the proxy

Fixes #1684

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
