### PR TITLE
fix(packages/proxy): leaking subprocesses on websocket channel death

### DIFF
--- a/packages/proxy/app/routes/exec.js
+++ b/packages/proxy/app/routes/exec.js
@@ -83,7 +83,11 @@ function main(cmdline, execOptions, server, port, host, existingSession) {
       })
 
       const channel = new StdioChannelWebsocketSide(wss)
-      await channel.init(child, cookie)
+      await channel.init(child, process.env.KUI_HEARTBEAT_INTERVAL || 30000)
+
+      channel.once('closed', (exitCode /* : number */) => {
+        debug('channel closed')
+      })
 
       channel.once('open', () => {
         debug('channel open')

--- a/plugins/plugin-bash-like/package.json
+++ b/plugins/plugin-bash-like/package.json
@@ -36,6 +36,7 @@
     "xterm": "3.13.0"
   },
   "devDependencies": {
+    "@types/cookie": "^0.3.3",
     "@types/marked": "0.6.5",
     "@types/shelljs": "0.8.5"
   },

--- a/plugins/plugin-bash-like/src/pty/stdio-channel.ts
+++ b/plugins/plugin-bash-like/src/pty/stdio-channel.ts
@@ -21,11 +21,16 @@ import { ChildProcess } from 'child_process'
 import { ExitHandler, onConnection } from './server'
 import { Channel, ReadyState } from './channel'
 
-const debugE = Debug('plugins/bash-like/pty/stdio-channel-kui-stderr')
+const debugE = Debug('plugins/bash-like/pty/stdio-channel-proxy-stderr')
 const debugW = Debug('plugins/bash-like/pty/stdio-channel-proxy')
 const debugK = Debug('plugins/bash-like/pty/stdio-channel-kui')
 
 const MARKER = '\n'
+
+function heartbeat() {
+  debugW('heartbeat')
+  this.isAlive = true
+}
 
 /**
  * stdin/stdout channel
@@ -43,8 +48,12 @@ export class StdioChannelWebsocketSide extends EventEmitter implements Channel {
     this.wss = wss
   }
 
-  public async init(child: ChildProcess) {
+  public async init(child: ChildProcess, pollInterval = 30000) {
     debugW('StdioChannelWebsocketSide.init')
+
+    this.wss.on('error', (err: Error) => {
+      debugW('websocket error', err)
+    })
 
     this.wss.on('connection', (ws: Channel) => {
       debugW('got connection')
@@ -55,10 +64,36 @@ export class StdioChannelWebsocketSide extends EventEmitter implements Channel {
         debugW('forwarding message downstream', data)
         child.stdin.write(data)
       })
+
+      // on pong response, indicate we remain alive
+      ws.on('pong', heartbeat)
+
+      ws.on('close', () => {
+        debugW('killing child process, because client connection is dead')
+        child.kill()
+      })
     })
+
+    const self = this
+    const interval = setInterval(function ping() {
+      self.wss['clients'].forEach(function each(ws) {
+        if (ws.isAlive === false) {
+          debugW('killing child process, because client connection did not respond to ping')
+          child.kill()
+          return ws.terminate()
+        }
+
+        // assume it is dead until we get a pong
+        ws.isAlive = false
+        ws.ping(() => {
+          // intentional no-op
+        })
+      })
+    }, pollInterval)
 
     child.on('exit', (code: number) => {
       debugW('child exit', code)
+      this.emit('exit', code)
     })
 
     child.stderr.on('data', (data: Buffer) => {


### PR DESCRIPTION
this introduces process.env.KUI_HEARTBEAT_INTERVAL defaulting to 30s

Fixes #2199

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
