### PR TITLE
fix(plugins/plugin-k8s): port kubectl run into watcher

### DIFF
--- a/plugins/plugin-k8s/src/lib/controller/kubectl.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kubectl.ts
@@ -721,7 +721,9 @@ const executeLocally = (command: string) => (opts: EvaluatorArgs) =>
         const namespace = options.namespace || options.n || 'default'
         debug('status after kubectl run', entity, namespace)
         repl
-          .qexec(`k status deploy "${entity}" -n "${namespace}"`)
+          .qexec(
+            `k status deploy "${entity}" -n "${namespace}" --final-state ${FinalState.OnlineLike.toString()} --watch`
+          )
           .then(cleanupAndResolve)
           .catch(reject)
       } else if ((hasFileArg || (isKube && entity)) && (verb === 'create' || verb === 'apply' || verb === 'delete')) {


### PR DESCRIPTION
Fixes #2272

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
