### PR TITLE
fix(plugins/plugin-core-support): restore much simpler repl-focus logic

### DIFF
--- a/plugins/plugin-core-support/src/lib/new-tab.ts
+++ b/plugins/plugin-core-support/src/lib/new-tab.ts
@@ -277,6 +277,10 @@ const closeTab = (tab = getCurrentTab()) => {
   return true
 }
 
+function isElement(target: EventTarget): target is Element {
+  return (target as Element).classList !== undefined
+}
+
 /**
  * Initialize events for a new tab
  *
@@ -289,6 +293,15 @@ const perTabInit = (tab: Tab, doListen = true) => {
   if (doListen) {
     listen(getCurrentPrompt(tab))
   }
+
+  // keep repl prompt focused, if possible
+  tab.querySelector('.repl-inner').addEventListener('click', (evt: MouseEvent) => {
+    if (isElement(evt.target)) {
+      if (evt.target.classList.contains('repl-inner') || evt.target.classList.contains('repl-output')) {
+        getCurrentPrompt(tab).focus()
+      }
+    }
+  })
 
   // tab close button
   getTabCloser(tab).onclick = (event: MouseEvent) => {


### PR DESCRIPTION
this is only a few lines of code that tries to be fairly conservative in grabbing focus back to the current prompt

Fixes #2323

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
