### PR TITLE
fix(plugins/plugin-k8s): pod creation staus UI improvement

### DIFF
--- a/plugins/plugin-k8s/src/lib/model/states.ts
+++ b/plugins/plugin-k8s/src/lib/model/states.ts
@@ -200,7 +200,20 @@ const getStatusFromConditions = (response: KubeResource) => {
   if (response.status && !response.status.state && response.status.conditions) {
     // use the status.conditions, rather than status.state
     const conditions = response.status.conditions
-    conditions.sort((a, b) => -(new Date(a.lastTransitionTime).getTime() - new Date(b.lastTransitionTime).getTime()))
+
+    conditions.sort((a, b) => {
+      // sort conditions by their lastTransitionTime
+      let swap = -(new Date(a.lastTransitionTime).getTime() - new Date(b.lastTransitionTime).getTime())
+      // for conditions with the same lastTransitionTime and status, sort them by type
+      if (swap === 0 && a.status === b.status) {
+        // for conition with the same status, put not pending type at lower index
+        if (isPendingLike(a.type) && !isPendingLike(b.type)) {
+          swap = 1
+        }
+      }
+
+      return swap
+    })
     // debug('using condition for status', conditions[0], conditions)
 
     const conditionForMessage = conditions.find(_ => _.message) || conditions[0]

--- a/plugins/plugin-k8s/src/test/k8s1/apply-pod.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/apply-pod.ts
@@ -62,6 +62,7 @@ describe(`${process.env.MOCHA_RUN_TARGET || ''} apply pod`, function(this: commo
             .then(sidecar.expectShowing('nginx'))
 
           // make sure we have a last applied tab
+          await this.app.client.waitForExist(selectors.SIDECAR_MODE_BUTTON('last applied'))
           await this.app.client.click(selectors.SIDECAR_MODE_BUTTON('last applied'))
 
           return this.app.client.waitUntil(() => {


### PR DESCRIPTION
when sorting pod conditions to get pod status, Kui should sort the conditions by type if they have the same lastTransitionTime and status

Fixes #2327

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
