### PR TITLE
test: proxy test against k81 layer

### DIFF
--- a/plugins/plugin-k8s/src/test/k8s1/describe.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/describe.ts
@@ -114,7 +114,8 @@ describe(`kubectl summary ${process.env.MOCHA_RUN_TARGET}`, function(this: commo
         .catch(common.oops(this, true))
     })
 
-    it(`should flip around on summary tabs via ${kubectl}`, async () => {
+    // TODO: [20190815 myan] please enable webpack test once this issue is solved: https://github.com/IBM/kui/issues/2361
+    common.localIt(`should flip around on summary tabs via ${kubectl}`, async () => {
       try {
         // flip back and forth a few times
         await testRawTab(this)

--- a/plugins/plugin-k8s/src/test/k8s1/edit.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/edit.ts
@@ -28,7 +28,8 @@ import {
 
 const kubectl = 'kubectl'
 
-describe(`electron kubectl edit ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: common.ISuite) {
+// TODO: [20190815 myan] please enable webpack test once this issue is solved: https://github.com/IBM/kui/issues/2360
+common.localDescribe(`electron kubectl edit ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: common.ISuite) {
   before(common.before(this))
   after(common.after(this))
 

--- a/tools/travis/test/script.sh
+++ b/tools/travis/test/script.sh
@@ -131,13 +131,7 @@ if [ -n "$LAYERS" ]; then
                 (cd packages/tests && ./bin/runMochaLayers.sh $WAIT_LAYERS)
             fi
 
-            if [ "$MOCHA_RUN_TARGET" == "webpack" ] && [ "$KUI_USE_PROXY" == "true" ]; then
-                # for now, k8s1 is problematic with the proxy
-                echo "trimming k8s1"
-                TEST_THESE_LAYERS=${NON_HEADLESS_LAYERS# k8s1}
-            else
-                TEST_THESE_LAYERS=$NON_HEADLESS_LAYERS
-            fi
+            TEST_THESE_LAYERS=$NON_HEADLESS_LAYERS
 
             echo "running these non-headless layers with $MOCHA_RUN_TARGET: $NON_HEADLESS_LAYERS"
             (cd packages/tests && ./bin/runMochaLayers.sh $TEST_THESE_LAYERS) &


### PR DESCRIPTION
Not includes: kubectl edit, flipping around summary and raw tabs

Continue with #2184

Signed-off-by: Mengting Yan <mengting.yan1@ibm.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
