### PR TITLE
fix(plugins/plugin-k8s): helm history should be a kui table

### DIFF
--- a/packages/app/tests/lib/ui.d.ts
+++ b/packages/app/tests/lib/ui.d.ts
@@ -41,6 +41,7 @@ declare function expectYAML (struct1: object, subset?: boolean, failFast?: boole
 declare function expectYAMLSubset (struct1: object, failFast?: boolean): (str: string) => boolean
 declare function expectSubset (struct1: object, failFast?: boolean): (str: string) => boolean
 declare function expectValidActivationId (): (activationId: string) => boolean
+declare function expectText (app: Application, expectedText: string): (selector: string) => Promise<void>
 
 declare function expectedNamespace (space?: string, org?: string): string
 
@@ -189,6 +190,7 @@ declare class Selectors {
   LIST_RESULTS_N: (N: number) => string
   LIST_RESULTS_BY_NAME_N: (N: number) => string
   LIST_RESULT_BY_N_FOR_NAME: (N: number, name: string) => string
+  TABLE_CELL: (rowKey: string, cellKey: string) => string
   BY_NAME: (name: string) => string
   LIST_RESULT_BY_N_AND_NAME: (N: number, name: string) => string
   OK_N: (N: number) => string

--- a/packages/app/tests/lib/ui.js
+++ b/packages/app/tests/lib/ui.js
@@ -92,6 +92,8 @@ selectors.OUTPUT_LAST = `${selectors.PROMPT_BLOCK_LAST} .repl-result`
 selectors.LIST_RESULTS_N = N => `${selectors.PROMPT_BLOCK_N(N)} .repl-result .entity:not(.header-row)`
 selectors.LIST_RESULTS_BY_NAME_N = N => `${selectors.LIST_RESULTS_N(N)} .entity-name`
 selectors.LIST_RESULT_BY_N_FOR_NAME = (N, name) => `${selectors.LIST_RESULTS_N(N)}[data-name="${name}"]`
+selectors.TABLE_CELL = (rowKey, cellKey) =>
+  `.entity:not(.header-row)[data-name="${rowKey}"] .cell-inner[data-key="${cellKey}"]`
 selectors.BY_NAME = name => `.entity:not(.header-row)[data-name="${name}"]`
 selectors.LIST_RESULT_BY_N_AND_NAME = (N, name) => `${selectors.LIST_RESULT_BY_N_FOR_NAME(N, name)} .entity-name`
 selectors.OK_N = N => `${selectors.PROMPT_BLOCK_N(N)} .repl-output .ok`
@@ -482,6 +484,11 @@ exports.sidecar = {
         }
       })
       .then(() => app)
+}
+
+exports.expectText = (app, expectedText) => async selector => {
+  const actualText = await app.client.getText(selector)
+  assert.strictEqual(actualText, expectedText)
 }
 
 /** get the monaco editor text */

--- a/plugins/plugin-k8s/src/lib/controller/kubectl.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kubectl.ts
@@ -136,6 +136,7 @@ const possiblyExportCredentials = (execOptions: KubeExecOptions, env: NodeJS.Pro
 const shouldWeDisplayAsTable = (verb: string, entityType: string, output: string, options: ParsedOptions) => {
   const hasTableVerb =
     verb === 'ls' ||
+    verb === 'history' ||
     verb === 'search' ||
     verb === 'list' ||
     verb === 'get' ||

--- a/plugins/plugin-k8s/src/test/k8s1/helm.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/helm.ts
@@ -15,7 +15,7 @@
  */
 
 import * as common from '@kui-shell/core/tests/lib/common'
-import { cli, selectors, sidecar, AppAndCount } from '@kui-shell/core/tests/lib/ui'
+import { cli, selectors, sidecar, AppAndCount, expectText } from '@kui-shell/core/tests/lib/ui'
 import * as assert from 'assert'
 
 import { createNS, allocateNS, deleteNS } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
@@ -63,17 +63,35 @@ common.localDescribe('helm commands', function(this: common.ISuite) {
       .catch(common.oops(this))
   })
 
-  it(`should show the status of that new release`, () => {
+  it(`should show history`, () => {
     return cli
-      .do(`helm status ${name}`, this.app)
-      .then(checkHelmStatus)
+      .do(`helm history ${name}`, this.app)
+      .then(cli.expectOKWithCustom({ selector: selectors.TABLE_CELL('1', 'REVISION') }))
+      .then(expectText(this.app, '1'))
       .catch(common.oops(this))
   })
 
+  // confirm that helm list shows a row for our release
   it(`should list that new release via helm list`, () => {
     return cli
       .do(`helm list ${inNamespace}`, this.app)
       .then(cli.expectOKWith(name))
+      .catch(common.oops(this))
+  })
+
+  // also confirm that there is a REVISION column in that row
+  it(`should list that new release via helm list`, () => {
+    return cli
+      .do(`helm list ${inNamespace}`, this.app)
+      .then(cli.expectOKWithCustom({ selector: selectors.TABLE_CELL(name, 'REVISION') }))
+      .then(expectText(this.app, '1'))
+      .catch(common.oops(this))
+  })
+
+  it(`should show the status of that new release`, () => {
+    return cli
+      .do(`helm status ${name}`, this.app)
+      .then(checkHelmStatus)
       .catch(common.oops(this))
   })
 


### PR DESCRIPTION
also fixes some long-standing formatting issues in helm tables: "REVISION UPDATED" columns were conjoined

Fixes #2341

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
