### PR TITLE
fix(plugins/plugin-k8s): ui tweaks of k get pods --all-namepaces

### DIFF
--- a/plugins/plugin-k8s/src/lib/view/formatTable.ts
+++ b/plugins/plugin-k8s/src/lib/view/formatTable.ts
@@ -33,6 +33,7 @@ const outerCSSForKey = {
   NAME: 'entity-name-group',
   READY: 'a-few-numbers-wide',
   KIND: 'max-width-id-like entity-kind',
+  NAMESPACE: 'entity-name-group hide-with-sidecar not-a-name', // kubectl get pods --all-namespaces
 
   CLUSTER: 'entity-name-group entity-name-group-narrow hide-with-sidecar', // kubectl config get-contexts
   AUTHINFO: 'entity-name-group entity-name-group-narrow hide-with-sidecar', // kubectl config get-contexts


### PR DESCRIPTION
we should hide the namespace column when sidecar is open

Fixes #2320
![ezgif com-video-to-gif-3](https://user-images.githubusercontent.com/21212160/63186648-fe5a4900-c02a-11e9-959f-52e0996f43e8.gif)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
