### PR TITLE
chore: bump Kui's version to 3.0.0, including all the components Kui publishes

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*", "plugins/*"],
-  "version": "independent",
+  "version": "3.0.0",
   "command": {
     "publish": {
       "conventionalCommits": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kui-shell",
-  "version": "2.0.5",
+  "version": "3.0.0",
   "description": "This is the monorepo for Kui, the hybrid command-line/GUI electron-based Kubernetes tool",
   "main": "build/packages/app/src/main/main.js",
   "scripts": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/core",
-  "version": "2.34.0",
+  "version": "3.0.0",
   "description": "An Electron-based shell for cloud-native development",
   "homepage": "https://github.com/IBM/kui#readme",
   "license": "Apache-2.0",

--- a/packages/kui-builder/package.json
+++ b/packages/kui-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/builder",
-  "version": "0.34.0",
+  "version": "3.0.0",
   "description": "Kui plugin development helpers",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/packages/kui-builder/src/defaults/lerna.json
+++ b/packages/kui-builder/src/defaults/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*", "plugins/*"],
-  "version": "independent",
+  "version": "3.0.0",
   "command": {
     "publish": {
       "conventionalCommits": true,

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/proxy",
-  "version": "0.34.0",
+  "version": "3.0.0",
   "description": "Kui package that offers a proxy server",
   "author": "Nick Mitchell",
   "license": "Apache-2.0",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/test",
-  "version": "0.0.30",
+  "version": "3.0.0",
   "description": "",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/webpack",
-  "version": "0.0.1",
+  "version": "3.0.0",
   "description": "Kui support for webpack clients",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-apache-composer/package.json
+++ b/plugins/plugin-apache-composer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-apache-composer",
-  "version": "0.39.0",
+  "version": "3.0.0",
   "description": "Kui plugin for the Apache OpenWhisk Composer",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-bash-like/package.json
+++ b/plugins/plugin-bash-like/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-bash-like",
-  "version": "0.23.0",
+  "version": "3.0.0",
   "description": "Kui plugin that offers local bash-like shell integrations",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-core-support/package.json
+++ b/plugins/plugin-core-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-core-support",
-  "version": "0.34.0",
+  "version": "3.0.0",
   "description": "Kui plugin offering core extensions such as help and screenshot commands",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-editor/package.json
+++ b/plugins/plugin-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-editor",
-  "version": "0.23.0",
+  "version": "3.0.0",
   "description": "Kui plugin that integrates the monaco-editor component",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-grid/package.json
+++ b/plugins/plugin-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-grid",
-  "version": "0.23.0",
+  "version": "3.0.0",
   "description": "Kui plugin that offers a grid visualization of OpenWhisk function invocations",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-k8s/package.json
+++ b/plugins/plugin-k8s/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-k8s",
-  "version": "0.34.0",
+  "version": "3.0.0",
   "description": "Kui plugin for kubernetes",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-manager/package.json
+++ b/plugins/plugin-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-manager",
-  "version": "0.0.40",
+  "version": "3.0.0",
   "description": "Support for field installation of plugins",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-openwhisk-editor-extensions/package.json
+++ b/plugins/plugin-openwhisk-editor-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-openwhisk-editor-extensions",
-  "version": "0.0.33",
+  "version": "3.0.0",
   "description": "Kui plugin for OpenWhisk that extends plugin-editor",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-openwhisk/package.json
+++ b/plugins/plugin-openwhisk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-openwhisk",
-  "version": "0.34.0",
+  "version": "3.0.0",
   "description": "Kui plugin for OpenWhisk",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-operator-framework/package.json
+++ b/plugins/plugin-operator-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-operator-framework",
-  "version": "0.0.1",
+  "version": "3.0.0",
   "description": "Kui plugin for Operator Framework",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-proxy-support/package.json
+++ b/plugins/plugin-proxy-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-proxy-support",
-  "version": "0.34.0",
+  "version": "3.0.0",
   "description": "Kui plugin that adds runtime support for proxied communication",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-tekton/package.json
+++ b/plugins/plugin-tekton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-tekton",
-  "version": "0.23.0",
+  "version": "3.0.0",
   "description": "Visualizations for Tekton Pipelines",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-tutorials/package.json
+++ b/plugins/plugin-tutorials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-tutorials",
-  "version": "0.34.0",
+  "version": "3.0.0",
   "description": "IBM Cloud shell plugin for tutorials",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-wrk/package.json
+++ b/plugins/plugin-wrk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-wrk",
-  "version": "0.20.0",
+  "version": "3.0.0",
   "description": "Load testing plugin for Kui",
   "license": "Apache-2.0",
   "author": "Nick Mitchell",

--- a/plugins/plugin-wskflow/package.json
+++ b/plugins/plugin-wskflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kui-shell/plugin-wskflow",
-  "version": "0.23.0",
+  "version": "3.0.0",
   "description": "Visualizations for Composer apps",
   "license": "Apache-2.0",
   "author": "Kerry Chang",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
