### PR TITLE
[not ready] fix(plugins/plugin-k8s): `kubectl get events` table UI tweaks

### DIFF
--- a/plugins/plugin-k8s/src/lib/view/formatTable.ts
+++ b/plugins/plugin-k8s/src/lib/view/formatTable.ts
@@ -64,6 +64,7 @@ const cssForKey = {
   NAME: 'entity-name',
   SOURCE: 'lighter-text smaller-text',
   SUBOBJECT: 'lighter-text smaller-text',
+  MESSAGE: 'somewhat-smaller-text slightly-deemphasize',
   'CREATED AT': 'lighter-text smaller-text',
 
   AGE: 'slightly-deemphasize',
@@ -73,6 +74,7 @@ const cssForKey = {
 }
 
 const tagForKey = {
+  REASON: 'badge', // k get events
   STATUS: 'badge'
 }
 
@@ -116,6 +118,7 @@ const cssForValue = {
   Rebooted: 'green-background',
   Started: 'green-background',
   Created: 'green-background',
+  Scheduled: 'green-background',
   SuccessfulCreate: 'green-background',
   SuccessfulMountVol: 'green-background',
   ContainerCreating: 'yellow-background',
@@ -311,7 +314,7 @@ export const formatTable = (
               header +
               ' ' +
               outerCSSForKey[key] +
-              (colIdx <= 1 || colIdx === nameColumnIdx - 1 || /STATUS/i.test(key) ? '' : ' hide-with-sidecar'), // nameColumnIndex - 1 beacuse of rows.slice(1)
+              (colIdx <= 1 || colIdx === nameColumnIdx - 1 || /STATUS|REASON/i.test(key) ? '' : ' hide-with-sidecar'), // nameColumnIndex - 1 beacuse of rows.slice(1); REASON for k get events --all-namespaces
             css: css + ' ' + ((idx > 0 && cssForKey[key]) || '') + ' ' + (cssForValue[column] || ''),
             value: key === 'STATUS' && idx > 0 ? capitalize(column) : column
           }))


### PR DESCRIPTION
Part of #2438

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
1. add "message" font to messages column 
2. color coding Reason Column
 
![ezgif com-video-to-gif-4](https://user-images.githubusercontent.com/21212160/63469591-9e074500-c438-11e9-8a7c-13777b9d3b7c.gif)


<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.