### PR TITLE
fix(packages/app): make settings.largeIcon optional in the data type

### DIFF
--- a/packages/app/src/core/settings.ts
+++ b/packages/app/src/core/settings.ts
@@ -44,7 +44,7 @@ interface Theme {
 
   tableStyle?: keyof typeof TableStyle
 
-  largeIcon: string
+  largeIcon?: string
   wideIcon?: string
 
   userAgent?: string


### PR DESCRIPTION
cherry pick

9e4b63c28d35764cfca5ed1938b67c93d5d6af63