### PR TITLE
Feat(plugins-plugin-editor) Enable edit new files

### DIFF
--- a/plugins/plugin-editor/src/usage.ts
+++ b/plugins/plugin-editor/src/usage.ts
@@ -45,6 +45,7 @@ export const editUsage = command => ({
     }
   ],
   optional: [
+    { name: '--create', docs: 'Indicates that you want to create the file (and parent directories as needed)'},
     {
       name: '--language',
       hidden: true,


### PR DESCRIPTION
#### Description of what you did:

Added a `--create` flag to the `edit` command, enabling the editing of new files.
Fixes #2565

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x ] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
