### PR TITLE
3.0.11

### DIFF
--- a/clients/alternate/theme/css/themes/carbon-gray10.css
+++ b/clients/alternate/theme/css/themes/carbon-gray10.css
@@ -10,9 +10,9 @@ body[kui-theme="IBM Light"] {
   --color-base07: #fff;
   --color-base08: #da1e28;
   --color-base09: #bf5b17;
-  --color-base0A: #fdd13a;
-  --color-base0B: #24a249;
-  --color-base0C: #1191e6;
+  --color-base0A: #8e6926;
+  --color-base0B: #198038;
+  --color-base0C: #0072c3;
   --color-base0D: #054ada;
   --color-base0E: #d12765;
   --color-base0F: #8a3ffc;
@@ -24,9 +24,6 @@ body[kui-theme="IBM Light"] {
   --color-text-inverted02: var(--color-text-inverted01);
   --color-text-inverted03: var(--color-text-01);
   --color-tab-selected-inverted: var(--color-name);
-
-  /* xterm ANSI yellow text color */
-  --color-yellow-text: #bb9002;
 
   --color-brand-01: #0062ff;
   --color-brand-02: #171717;

--- a/clients/alternate/theme/css/themes/carbon-gray90.css
+++ b/clients/alternate/theme/css/themes/carbon-gray90.css
@@ -11,7 +11,7 @@ body[kui-theme="IBM Dark"][kui-theme-style] {
   --color-base08: #fb4b53;
   --color-base09: #bf5b17;
   --color-base0A: #fdd13a;
-  --color-base0B: #3dbb61;
+  --color-base0B: #56d679;
   --color-base0C: #30b0ff;
   --color-base0D: #0353e9;
   --color-base0E: #fa75a6;
@@ -43,8 +43,7 @@ body[kui-theme="IBM Dark"][kui-theme-style] {
   --color-brand-03: #408bfc;
   --color-content-divider: #4c4c4c;
 
-  --color-selection-background: #0353e9;
-  --color-selection-foreground: #97c1ff;
+  --color-selection-background: #6f6f6f;
 
   --color-screenshot-background: var(--color-brand-03);
 

--- a/packages/app/web/css/not-electron.css
+++ b/packages/app/web/css/not-electron.css
@@ -10,9 +10,6 @@ body.not-electron .repl-prompt {
 body.not-electron .repl-context {
   display: none;
 }
-body.not-electron .repl-prompt-righty {
-  margin-top: -3px;
-}
 
 body.not-electron .kui--hide-in-webpack {
   /* e.g. don't show screenshot buttons in webpack clients */

--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -3056,7 +3056,7 @@ sidecar .custom-content .log-field pre > code {
   color: var(--color-support-01);
 }
 .dir-listing-is-link {
-  color: var(--color-brand-03);
+  color: var(--color-base0E);
 }
 
 body {

--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -391,14 +391,18 @@ body/*:not(.sidecar-full-screen)*/ repl.sidecar-visible .repl-selection, body/*.
 }
 .repl-input input,
 .repl-input-like {
+  --color-caret: var(--color-support-01);
   color: var(--color-text-01);
   background: transparent;
   border: none;
   flex: 1;
-  caret-color: var(--color-support-01);
+  caret-color: var(--color-caret);
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+.kui--prompt-like:empty {
+  border-right: 1ex solid var(--color-caret);
 }
 .repl-input input:focus,
 .repl-input-like:focus {
@@ -3234,6 +3238,9 @@ body.kui--bottom-input tab > .kui--rows > .kui--columns {
   flex: 1;
   background-color: var(--color-sidecar-header);
   padding: 0.5em 0.375em;
+}
+.kui--input-stripe .repl-input-like {
+  overflow: unset;
 }
 .kui--input-stripe input {
   background-color: transparent;

--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -3,7 +3,7 @@
 }
 ::selection {
   background-color: var(--color-selection-background);
-  color: var(--color-selection-foreground);
+  color: inherit;
 }
 html,
 body,

--- a/plugins/plugin-bash-like/src/lib/cmds/bash-like.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/bash-like.ts
@@ -49,6 +49,7 @@ export const doExec = (
     // purposefully imported lazily, so that we don't spoil browser mode (where shell is not available)
 
     const proc = exec(cmdLine, {
+      maxBuffer: 5 * 1024 * 1024,
       env: Object.assign({}, process.env, execOptions['env'] || {})
     })
 
@@ -227,7 +228,7 @@ const cd = ({ command, parsedOptions, execOptions }: EvaluatorArgs) => {
 }
 
 const bcd = async ({ command, execOptions }: EvaluatorArgs) => {
-  const pwd = await repl.qexec(command.replace(/^cd/, 'kuicd'), undefined, undefined, execOptions)
+  const pwd: string = await repl.qexec(command.replace(/^cd/, 'kuicd'), undefined, undefined, execOptions)
   debug('pwd', pwd)
   process.env.PWD = pwd
   return pwd

--- a/plugins/plugin-core-support/src/lib/cmds/history/reverse-i-search.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/history/reverse-i-search.ts
@@ -81,6 +81,7 @@ class ActiveISearch {
     this.placeholder.appendChild(this.placeholderFixedPart)
     this.placeholder.classList.add('repl-temporary')
     this.placeholder.classList.add('normal-text')
+    this.placeholder.classList.add('monospace')
     this.placeholderFixedPart.classList.add('smaller-text')
     this.placeholderFixedPart.classList.add('small-right-pad')
     this.promptLeft.appendChild(this.placeholder)
@@ -91,7 +92,7 @@ class ActiveISearch {
     //    this.prompt.style.width = '0'
 
     this.placeholderContentPart = document.createElement('span') // container for Typed and Matched
-    this.placeholderTypedPart = document.createElement('span') // what the user has typed; e.g. "is" in "history"
+    this.placeholderTypedPart = document.createElement('strong') // what the user has typed; e.g. "is" in "history"
     this.placeholderMatchedPrefixPart = document.createElement('span') // what was matched, but not typed; e.g. "h" in "history"
     this.placeholderMatchedSuffixPart = document.createElement('span') // what was matched, but not typed; e.g. "tory" in "history"
     this.placeholderContentPart.appendChild(this.placeholderMatchedPrefixPart)
@@ -101,6 +102,7 @@ class ActiveISearch {
     this.placeholder.appendChild(this.placeholderContentPart)
 
     this.placeholderTypedPart.classList.add('red-text')
+    this.placeholderTypedPart.classList.add('kui--prompt-like')
     this.placeholderMatchedPrefixPart.classList.add('slightly-deemphasize')
     this.placeholderMatchedSuffixPart.classList.add('slightly-deemphasize')
 


### PR DESCRIPTION
cherry pick

6850720
7612a0e
d235669
95d5f4d

[3.0.11 c479024] fix: reverse-i-search should use monospace
[3.0.11 96550fb] fix(packages/app): links in ls output have low contrast
[3.0.11 e49e5a6] fix(plugins/plugin-bash-like): ls on large directories has poor output
[3.0.11 40a8bf1] fix(packages/app): green and cyan text colors with high contrast