### PR TITLE
fix(plugins/plugin-editor): in clients/alternate light theme, editor keys sometimes too low contrast

### DIFF
--- a/plugins/plugin-editor/web/css/theme-alignment.css
+++ b/plugins/plugin-editor/web/css/theme-alignment.css
@@ -94,7 +94,7 @@
 [kui-theme-style] .monaco-editor .selector-id,
 [kui-theme-style] .monaco-editor .selector-class {
   transition: color 300ms ease-in-out;
-  color: var(--color-base0D);
+  color: var(--color-map-key);
 }
 
 [kui-theme-style] .monaco-editor .meta,


### PR DESCRIPTION
Fixes #2595
![Screen Shot 2019-08-29 at 12 00 01 PM](https://user-images.githubusercontent.com/21212160/63956507-8d685780-ca54-11e9-8656-e18b19ef392f.png)




<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
