### PR TITLE
fix(plugins/plugin-core-support): links in the about page can still be tabbed after sidecar closes

### DIFF
--- a/packages/app/src/webapp/views/sidecar.ts
+++ b/packages/app/src/webapp/views/sidecar.ts
@@ -22,7 +22,7 @@ debug('loading')
 
 import * as prettyPrintDuration from 'pretty-ms'
 
-import { Tab, isPopup, scrollIntoView, oops, getTabFromTarget } from '../cli'
+import { Tab, isPopup, scrollIntoView, oops, getTabFromTarget, getCurrentPrompt } from '../cli'
 import eventBus from '../../core/events'
 import { element, removeAllDomChildren } from '../util/dom'
 import { prettyPrintTime } from '../util/time'
@@ -117,8 +117,11 @@ export const hide = (tab: Tab, clearSelectionToo = false) => {
   const replView = tab.querySelector('.repl')
   replView.classList.remove('sidecar-visible')
 
-  // we just hid the sidecar. make sure the current prompt is active for text input
-  // cli.getCurrentPrompt().focus()
+  // we just hide the sidecar. make sure the current prompt is active for text input
+  const promptToFocus = getCurrentPrompt(tab)
+  if (promptToFocus) {
+    promptToFocus.focus()
+  }
 
   // were we asked also to clear the selection?
   if (clearSelectionToo && sidecar.entity) {

--- a/packages/app/tests/lib/ui.d.ts
+++ b/packages/app/tests/lib/ui.d.ts
@@ -176,6 +176,7 @@ declare class Selectors {
   SIDECAR_MODE_BUTTON: (mode: string) => string
   SIDECAR_MODE_BUTTON_SELECTED: (mode: string) => string
   SIDECAR_BACK_BUTTON: string
+  SIDECAR_SCREENSHOT_BUTTON: string
   SIDECAR_MAXIMIZE_BUTTON: string
   SIDECAR_CLOSE_BUTTON: string
   SIDECAR_FULLY_CLOSE_BUTTON: string

--- a/packages/app/tests/lib/ui.js
+++ b/packages/app/tests/lib/ui.js
@@ -76,6 +76,7 @@ selectors.SIDECAR_MODE_BUTTONS = `${selectors.SIDECAR} .sidecar-bottom-stripe-mo
 selectors.SIDECAR_MODE_BUTTON = mode => `${selectors.SIDECAR_MODE_BUTTONS}[data-mode="${mode}"]` // specific mode button in the bottom stripe
 selectors.SIDECAR_MODE_BUTTON_SELECTED = mode => `${selectors.SIDECAR_MODE_BUTTON(mode)}.bx--tabs__nav-item--selected`
 selectors.SIDECAR_BACK_BUTTON = `${selectors.SIDECAR} .sidecar-bottom-stripe-back-button` // back button in the bottom stripe
+selectors.SIDECAR_SCREENSHOT_BUTTON = `${selectors.SIDECAR} .sidecar-screenshot-button` // screenshot button in the bottom stripe
 selectors.SIDECAR_MAXIMIZE_BUTTON = `${selectors.SIDECAR} .toggle-sidecar-maximization-button` // maximize button in the bottom stripe
 selectors.SIDECAR_CLOSE_BUTTON = `${selectors.SIDECAR} .sidecar-bottom-stripe-close` // close button in the bottom stripe
 selectors.SIDECAR_FULLY_CLOSE_BUTTON = `${selectors.SIDECAR} .sidecar-bottom-stripe-quit` // fully close button in the bottom stripe

--- a/plugins/plugin-core-support/src/lib/cmds/about/about.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/about/about.ts
@@ -44,7 +44,7 @@ async function markdown(): Promise<(raw: string) => string> {
   const renderer = new marked.Renderer()
 
   renderer.link = (href: string, title: string, text: string) => {
-    return `<a href="${href}" title="${title}" class="bx--link">${text}</a>`
+    return `<a href="${href}" title="${title}" class="kui--tab-navigatable kui--notab-when-sidecar-hidden bx--link">${text}</a>`
   }
 
   return (raw: string) => marked(raw, { renderer })


### PR DESCRIPTION
Fixes #2600

 Also fixes the issue that repl doesn't grab focus when sidecar is close or hidden

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.