### PR TITLE
fix(plugins/plugin-bash-like): pty output sometimes not visible

### DIFF
--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -939,6 +939,7 @@ export const doExec = (
 
               if (execOptions.type !== ExecType.Nested || execOptions.quiet === false) {
                 pendingWrites++
+                definitelyNotUsage = true
                 terminal.write(msg.data)
               }
             }


### PR DESCRIPTION
if ascii-to-usage discovers usage-like output mid-stream, it will swallow subsequent output; this PR backs that off aggressively

Fixes #2627

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
