### PR TITLE
fix: clean up transition effects

### DIFF
--- a/clients/alternate/theme/css/top-tab-stripe-alt.css
+++ b/clients/alternate/theme/css/top-tab-stripe-alt.css
@@ -104,7 +104,6 @@ body.kui-alternate .kui--input-stripe {
 body.kui-alternate .repl .repl-input {
   padding-left: 2em;
   padding-right: 2em;
-  padding-bottom: 0.5em;
 }
 
 body.kui-alternate .repl-output {

--- a/packages/app/src/webapp/views/table.ts
+++ b/packages/app/src/webapp/views/table.ts
@@ -390,7 +390,7 @@ export const formatOneRowResult = (tab: Tab, options: RowFormatOptions = {}) => 
   }
   if ((!options || !options.excludePackageName) && entity.packageName) {
     const packagePrefix = document.createElement('span')
-    packagePrefix.className = 'package-prefix lighter-text smaller-text'
+    packagePrefix.className = 'package-prefix sub-text'
     packagePrefix.innerText = entity.packageName + '/'
     entityNameGroup.appendChild(packagePrefix)
   }

--- a/packages/app/templates/index.html
+++ b/packages/app/templates/index.html
@@ -155,24 +155,24 @@
                               <div class="sidecar-header-text">
                                 <div class="sidecar-header-name" data-base-class="sidecar-header-name">
                                   <!--<span class="activation-content">of</span>-->
-                                  <span class="sidecar-header-name-content" data-base-class="sidecar-header-name-content">
+                                  <div class="sidecar-header-name-content" data-base-class="sidecar-header-name-content">
                                     <span class="activation-content activation-id"></span>
-                                    <span class="entity-name-line">
+                                    <div class="entity-name-line">
                                       <span class="entity-name"></span>
 
                                       <div class="repl-input">
                                         <div class="repl-prompt hide-with-screenshot">
-                                          <span class="repl-prompt-righty">
+                                          <div class="repl-prompt-righty">
                                             <!-- ChevronRight20 -->
                                             <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true">
                                               <path d="M22 16L12 26l-1.4-1.4 8.6-8.6-8.6-8.6L12 6z"></path>
                                             </svg>
-                                          </span>
+                                          </div>
                                         </div>
                                         <input type="text" aria-label="Command Input" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="enter your command" class="repl-input-like sidecar-header-input" />
                                       </div>
-                                    </span>
-                                  </span>
+                                    </div>
+                                  </div>
                                 </div>
                               </div>
                             </div>

--- a/packages/app/web/css/carbon-overrides-common.css
+++ b/packages/app/web/css/carbon-overrides-common.css
@@ -1,3 +1,27 @@
+body {
+  --transition-duration: 70ms;
+  --transition-timing-function: cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+body span,
+body div:empty,
+body input,
+body textarea,
+body svg *,
+body a {
+  transition-property: color, background-color, border-color, opacity, filter, text-decoration-color, fill;
+  transition-duration: var(--transition-duration);
+  transition-timing-function: var(--transition-timing-function);
+}
+body div:not(:empty),
+repl,
+sidecar,
+body th,
+body td {
+  transition-property: background-color, border-color, opacity, filter;
+  transition-duration: var(--transition-duration);
+  transition-timing-function: var(--transition-timing-function);
+}
+
 sidecar .bx--tabs,
 sidecar .bx--tabs .bx--tabs__nav,
 sidecar .bx--tabs .bx--tabs__nav li {
@@ -53,7 +77,7 @@ body[kui-theme-style] .bx--link {
   font-weight: 600;
   color: var(--color-brand-01);
   /* text-decoration: underline; */
-  transition: 250ms;
+  transition-duration: 250ms;
   pointer-events: unset;
   touch-action: unset;
 }

--- a/packages/app/web/css/kui-tables.css
+++ b/packages/app/web/css/kui-tables.css
@@ -1,7 +1,7 @@
 /* carbon overrides */
 
-[kui-theme-style] .result-table-title-outer {
-  display: flex;
+[kui-theme-style] .result-as-table .result-table:not([kui-table-style="Light"]) {
+  font-family: var(--font-sans-serif);
 }
 
 [kui-theme-style] .result-as-table .result-table {
@@ -9,7 +9,6 @@
   border-spacing: 0;
   border-collapse: collapse;
   border: 1px solid var(--color-ui-04);
-  margin-top: 0.75em;
   /* this causes odd flickering on chrome: transition: border-color 300ms ease-in-out; */
   background: transparent;
 }
@@ -34,6 +33,10 @@
 
 [kui-theme-style] .bx--data-table td {
   color: var(--color-text-01);
+}
+[kui-theme-style] .bx--data-table[kui-table-style="Light"] .bx--table-header-label {
+  /* for Light tables, there is no th background color, thus no need for extra space above */
+  padding-top: 0;
 }
 [kui-theme-style] .bx--data-table:not([kui-table-style="Light"]) th.header-cell {
   border-bottom: none;
@@ -107,7 +110,6 @@
   display: table-cell;
   vertical-align: middle;
   padding: 0.6875em;
-  transition: all 300ms ease-in-out;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -172,7 +174,6 @@
 .result-table .entity:nth-child(2n + 1) .entity-attributes {
   /* table row striping */
   background-color: var(--color-ui-02);
-  transition: background-color 300ms ease-in-out;
 }
 body sidecar .result-table .entity:nth-child(2n + 1) td,
 body sidecar .result-table .entity:nth-child(2n + 1) .entity-attributes {
@@ -193,7 +194,6 @@ body sidecar .result-table .entity:nth-child(2n + 1) .entity-attributes {
 .result-as-table .bx--data-table.result-table[kui-table-style="Light"],
 .result-as-table .bx--data-table.result-table[kui-table-style="Medium"] {
   border: none;
-  margin-top: 0;
 }
 .result-as-table .bx--data-table.result-table[kui-table-style="Light"] .header-row .header-cell,
 .result-as-table .bx--data-table.result-table[kui-table-style="Light"] .header-row .header-cell {

--- a/packages/app/web/css/top-tab-stripe.css
+++ b/packages/app/web/css/top-tab-stripe.css
@@ -35,7 +35,7 @@ body.subwindow:not(.sidecar-is-minimized) .left-tab-stripe {
   padding-left: 1ex;
   min-width: 0;
   background-color: var(--color-stripe-01);
-  transition: background-color 150ms ease-in-out;
+  transition-property: background-color;
 }
 
 .left-tab-stripe-buttons {
@@ -53,7 +53,7 @@ body.subwindow:not(.sidecar-is-minimized) .left-tab-stripe {
   align-items: center;
   justify-content: center;
   font-size: 3em;
-  transition: filter 150ms ease-in-out, color 150ms ease-in-out, background-color 150ms ease-in-out;
+  transition-property: filter, color, background-color;
 }
 
 /* these two rules give us the tab index label that appears inside of the tabs */
@@ -66,13 +66,13 @@ body.subwindow:not(.sidecar-is-minimized) .left-tab-stripe {
   right: 0.25em;
   transform: translateY(-50%);
   font-size: 1em;
-  transition: background-color 150ms ease-in-out;
+  transition-property: background-color;
   padding: 1px;
   display: flex;
 }
 .left-tab-stripe-buttons .left-tab-stripe-button-closer svg path {
   fill: transparent;
-  transition: fill 150ms ease-in-out;
+  transition-property: fill;
 }
 .left-tab-stripe-buttons .left-tab-stripe-button:hover .left-tab-stripe-button-closer {
   cursor: pointer;
@@ -118,25 +118,17 @@ body.subwindow:not(.sidecar-is-minimized) .left-tab-stripe {
 body.not-electron .repl-input {
   padding-left: 0.375rem;
 }
-.repl-output {
-  padding-top: 0.375rem;
-  padding-left: 0.375rem;
-}
-.repl-result > div,
-.repl:not(.sidecar-visible) .repl-result .result-table-outer {
-  padding-right: 0.375rem;
+.repl .repl-block:not(.processing) .repl-result:not(:empty) {
+  padding: 0.625em 1.25em 0;
 }
 .repl-prompt-right-elements {
   padding-right: 0.375rem;
-}
-.repl.sidecar-visible .repl-output {
-  padding-right: 0.75rem;
 }
 
 .left-tab-stripe-button svg circle,
 .left-tab-stripe-button svg path {
   fill: var(--color-text-02);
-  transition: fill 150ms ease-in-out;
+  transition-property: fill;
 }
 
 #help-button.left-tab-stripe-button {
@@ -167,7 +159,7 @@ body.not-electron .repl-input {
   border-bottom: none;
   border-top-left-radius: 3px 6px;
   border-top-right-radius: 3px 6px;
-  transition: all 150ms ease-in-out;
+  transition-property: all;
 }
 
 .left-tab-stripe-button:not(.left-tab-stripe-button-selected) .left-tab-stripe-button-label {
@@ -176,7 +168,7 @@ body.not-electron .repl-input {
 
   border-left: 1px solid transparent;
   border-right: 1px solid transparent;
-  transition: color 150ms ease-in-out;
+  transition-property: color;
 }
 body[kui-theme-style="dark"]
   .left-tab-stripe-button:not(.left-tab-stripe-button-selected)

--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -32,7 +32,7 @@ body a.plain-anchor {
   transition: none;
 }
 body a {
-  transition: color 150ms ease-in-out;
+  transition-property: color;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -147,7 +147,6 @@ body.still-loading .repl {
   margin: 0;
   padding-top: 1rem;
   flex: 4;
-  transition: flex 300ms ease-in-out, opacity 300ms ease-in-out, background-color 300ms ease-in-out;
   background-color: var(--color-ui-01);
 }
 .repl-inner {
@@ -245,7 +244,6 @@ body:not(.subwindow) repl.sidecar-visible .repl-block,
 }
 .repl-prompt-righty {
   display: flex;
-  transition: border-color 150ms ease-in-out;
 }
 .repl-context {
   font-size: 0.875em;
@@ -253,7 +251,6 @@ body:not(.subwindow) repl.sidecar-visible .repl-block,
   background-color: var(--color-prompt-background);
   display: flex;
   align-items: center;
-  transition: background-color 150ms ease-in-out, color 150ms ease-in-out;
   letter-spacing: 0.32px;
   filter: opacity(87.5%) grayscale(50%);
 }
@@ -268,7 +265,6 @@ body:not(.subwindow) repl.sidecar-visible .repl-block,
 }
 .repl-prompt-righty {
   color: var(--color-brand-01);
-  min-height: 1.25em;
 }
 .repl-prompt-righty svg path {
   fill: var(--color-brand-01);
@@ -291,7 +287,6 @@ body:not(.subwindow) repl.sidecar-visible .repl-block,
 }
 .kui--repl-prompt-buttons .graphical-icon {
   opacity: 0.0375;
-  transition: opacity 150ms ease-in-out;
 }
 .repl-block .repl-input:hover .kui--repl-prompt-buttons .graphical-icon {
   opacity: 0.25;
@@ -307,7 +302,7 @@ body:not(.subwindow) repl.sidecar-visible .repl-block,
   margin-left: 0.5em;
   font-size: 0.875em; /* see the comment for repl-input re: min-height; that should match this */
   opacity: 1;
-  transition: all 300ms ease-in-out;
+  transition-property: all;
 }
 .repl-prompt-right-element-status-icon.deemphasize .bx--loading {
   width: unset;
@@ -323,7 +318,6 @@ body:not(.subwindow) repl.sidecar-visible .repl-block,
 .repl-prompt-right-element-status-icon.deemphasize svg {
   display: none;
   filter: opacity(0.75) grayscale(0.5);
-  transition: filter 150ms ease-in-out;
 }
 .repl-block:hover .repl-prompt-right-element-status-icon.deemphasize svg.kui--icon-error {
   filter: grayscale(0.25);
@@ -480,7 +474,6 @@ sidecar.rule-enabled-false .sidecar-header-icon,
   height: auto;
   width: auto;
   opacity: 1;
-  transition-property: background-color;
   transition-delay: 100ms; /* only show the spinner block if the command takes a bit longer */
   display: inline-block;
   background-color: var(--color-processing);
@@ -491,6 +484,7 @@ sidecar.rule-enabled-false .sidecar-header-icon,
 }
 .repl-result pre {
   margin: 2px 0; /* firefox needs some vertical padding, otherwise descenders like "y" crop; weird */
+  white-space: pre-wrap;
 }
 .repl-result code {
   /* more invocation results */
@@ -562,7 +556,6 @@ tab:not(.sidecar-full-screen) sidecar .fifty-fifty {
   text-overflow: ellipsis;
   white-space: nowrap;
   flex: 1;
-  transition: all 150ms ease-in-out;
   background: transparent;
 }
 .repl-result .activation-start-time {
@@ -592,7 +585,6 @@ tab:not(.sidecar-full-screen) sidecar .fifty-fifty {
 .repl-result-prefix,
 .sidecar-header badge:not(.badge-as-image) {
   font-weight: 500;
-  transition: all 150ms ease-in-out;
   font-size: 0.825em;
   border-radius: 0.9375em;
   margin: 0.1875em;
@@ -606,9 +598,6 @@ tab:not(.sidecar-full-screen) sidecar .fifty-fifty {
 badge:only-child {
   /* we only need margins around badges if there is more than one badge */
   margin: 0;
-}
-badge {
-  transition: color 300ms ease-in-out, background-color 300ms ease-in-out;
 }
 sidecar .sidecar-header badge.version {
   /* badge for action version */
@@ -645,8 +634,8 @@ badge.clickable:hover {
 sidecar {
   flex: 0 0 0%;
   min-width: 0;
-  transition: flex 300ms ease-in-out, background-color 150ms ease-in-out, color 150ms ease-in-out,
-    border-color 150ms ease-in-out;
+  transition-property: flex, background-color, color, border-color;
+  transition-duration: calc(var(--transition-duration) * 2); /* twice the normal duration */
   display: flex;
   flex-direction: column;
   overflow-y: hidden;
@@ -702,7 +691,7 @@ sidecar
 sidecar .sidecar-bottom-stripe-close-icon {
   letter-spacing: -1ex;
   opacity: 0.6;
-  transition: all 150ms ease-in-out;
+  transition-property: all;
 }
 body.os-win32 sidecar .sidecar-bottom-stripe-close-icon {
   /* dunno why windows is weird here */
@@ -717,7 +706,6 @@ sidecar .sidecar-bottom-stripe .sidecar-bottom-stripe-maximize {
 }
 .maximize-button-label,
 .unmaximize-button-label {
-  transition: opacity 300ms ease-in-out;
   display: inline-block;
 }
 body:not(.subwindow) .sidecar-full-screen sidecar .sidecar-bottom-stripe-maximize .maximize-button-label,
@@ -731,9 +719,6 @@ body:not(.subwindow) tab:not(.sidecar-full-screen) sidecar .sidecar-bottom-strip
 .sidecar-bottom-stripe-left-bits .sidecar-bottom-stripe-button[data-mode] {
   /* for bottom mode-switching buttons, capitalize the text; for actual buttons, keep the capitalization as it was given */
   text-transform: capitalize;
-}
-sidecar .sidecar-bottom-stripe-button {
-  transition: all 150ms ease-in-out, border-color 300ms ease-in-out;
 }
 sidecar .sidecar-bottom-stripe .package-prefix {
   /* kubectl namespace and openwhisk package name, etc. */
@@ -780,7 +765,6 @@ sidecar .sidecar-bottom-stripe-back-bits,
   margin-right: 0.475rem;
 }
 sidecar .sidecar-bottom-stripe-back-bits > div {
-  transition: all 150ms ease-in-out;
   display: flex;
   align-items: center;
 }
@@ -857,7 +841,6 @@ sidecar .sidecar-bottom-stripe-toolbar .sidecar-bottom-stripe-button:hover {
 }
 sidecar .sidecar-bottom-stripe-toolbar .sidecar-bottom-stripe-button [role="tab"] {
   font-size: 0.875em;
-  transition: color 150ms ease-in-out;
 }
 sidecar .sidecar-bottom-stripe-toolbar .sidecar-bottom-stripe-button:hover [role="tab"] {
   color: var(--color-base0D);
@@ -897,7 +880,6 @@ sidecar .sidecar-header {
   border-bottom: 1px solid var(--color-content-divider);
   flex-basis: 8rem;
   min-height: 8rem; /* see shell issue #712 */
-  transition: background-color 300ms ease-in-out, border-color 300ms ease-in-out;
 }
 sidecar .sidecar-header .header-main-content {
   flex: 1;
@@ -1004,10 +986,6 @@ sidecar .sidecar-header .badges {
 sidecar .sidecar-header .badges:first-child {
   margin-left: 0;
 }
-sidecar .sidecar-header badge {
-  /* badges next to the entity name */
-  transition: all 150ms ease-in-out;
-}
 sidecar .sidecar-header badge.clickable:hover {
   filter: brightness(1.1);
 }
@@ -1045,7 +1023,6 @@ sidecar.entity-is-activations .sidecar-header-name .activation-id {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  transition: all 150ms ease-in-out;
 }
 sidecar.entity-is-activations .sidecar-header-name .package-prefix {
   /* don't display package name for activations? hmm */
@@ -1188,7 +1165,6 @@ sidecar:not(.entity-is-sequence) .sequence-components {
   justify-content: center;
   padding: 1em;
   position: relative;
-  transition: all 150ms ease-in-out;
 }
 .sequence-component:before {
   content: " ";
@@ -1379,7 +1355,6 @@ code.fancy-code.hljs {
   font-size: 0.75em;
   opacity: 0.7;
   vertical-align: middle;
-  transition: color 150ms ease-in-out;
 }
 .deemphasize.deemphasize-partial {
   font-weight: 400;
@@ -1485,10 +1460,6 @@ pre.monospace {
 .top-pad {
   margin-top: 1em;
 }
-.repl .big-top-pad > div,
-.big-top-pad:not(:first-child) > div {
-  padding-top: 0.25em;
-}
 .repl:not(.sidecar-visible) .result-as-multi-table-flex-wrap .big-top-pad:not(:last-child) > div,
 body.subwindow .result-as-multi-table-flex-wrap .big-top-pad:not(:last-child) > div {
   padding-right: 2em;
@@ -1516,10 +1487,6 @@ sidecar .result-as-table .big-top-pad:first-child {
 .count-with-label[data-is-plural="true"] .label-singular {
   display: none;
 }
-.clickable,
-.clickable-block {
-  transition: color 150ms ease-in-out, text-decoration-color 150ms ease-in-out;
-}
 .clickable-color {
   color: var(--color-base09);
 }
@@ -1533,14 +1500,10 @@ sidecar .result-as-table .big-top-pad:first-child {
   text-decoration: underline;
 }
 .clickable-block {
-  transition: border-color 150ms ease-in-out;
   cursor: pointer;
 }
 .clickable-block:hover {
   border-color: var(--color-ui-05) !important;
-}
-.graphical-clickable {
-  transition: all 150ms ease-in-out;
 }
 .graphical-clickable:hover {
   cursor: pointer;
@@ -1549,7 +1512,7 @@ sidecar .result-as-table .big-top-pad:first-child {
   display: none;
 }
 .toggle-visibility-on-hover .visible-on-hover {
-  transition: opacity 500ms ease-in-out;
+  transition-property: opacity;
   font-size: 70%;
   font-weight: 900;
   opacity: 0;
@@ -1558,7 +1521,7 @@ sidecar .result-as-table .big-top-pad:first-child {
   opacity: 0.5;
 }
 .hideable {
-  transition: all 150ms ease-in-out;
+  transition-property: all;
 }
 .hidden {
   opacity: 0;
@@ -1633,7 +1596,6 @@ sidecar .result-as-table .big-top-pad:first-child {
 }
 .help-option {
   display: table-row;
-  transition: all 150ms ease-in-out;
 }
 .help-option > div {
   display: table-cell;
@@ -1643,7 +1605,6 @@ sidecar .result-as-table .big-top-pad:first-child {
 .help-option-left-column {
   font-weight: bold; /* make the command name bold */
   text-align: right;
-  transition: all 150ms ease-in-out;
   border-left: 3px solid transparent;
   width: 10em;
 }
@@ -1655,7 +1616,6 @@ sidecar .result-as-table .big-top-pad:first-child {
 .help-option .help-option-synonyms-column {
   padding-right: 1.5em;
   width: 10em;
-  transition: all 150ms ease-in-out;
 }
 .sidecar-visible .help-option .help-option-synonyms-column {
   /* with the sidecar visible, there isn't room for the synonyms column */
@@ -1665,9 +1625,6 @@ sidecar .result-as-table .big-top-pad:first-child {
   color: transparent;
   width: 0;
   padding: 0;
-}
-.help-option .help-option-synonym {
-  transition: all 150ms ease-in-out;
 }
 .help-option-synonyms-list {
   display: flex;
@@ -1784,7 +1741,6 @@ sidecar .activation-result .log-line .log-field > div > div:first-child code {
   min-width: 2px;
   height: 1.25em;
   position: absolute;
-  transition: all 180ms ease-in-out;
 }
 .log-lines .log-line:hover .log-line-bar {
   z-index: 10; /* tooltip layering */
@@ -1843,7 +1799,7 @@ sidecar .log-lines .log-line:nth-child(2n) .log-field {
 }
 .legend-list {
   padding-bottom: 0.75em;
-  transition: height 300ms ease-in-out, width 300ms ease-in-out;
+  transition-property: height, width;
 }
 .repl.sidecar-visible .legend-list {
   /* don't show legend when the sidecar is open. see issue #138 */
@@ -1890,9 +1846,6 @@ sidecar .log-lines .log-line:nth-child(2n) .log-field {
 .legend-trace[data-hover-type] .legend-entry {
   /* legend entries that don't match the current hover type get more opaque */
   opacity: 0.3;
-}
-.legend-entry {
-  transition: all 600ms ease-in-out;
 }
 .legend-list:hover .legend-entry,
 .legend-trace:hover .legend-entry {
@@ -2214,8 +2167,6 @@ a.kui--tab-navigatable:hover {
   /* these two rules are an attempt to push the tooltips just above the bottom stripe */
   height: 100%;
   align-items: center;
-
-  transition: opacity 150ms ease-in-out;
 }
 .graphical-icon.disabled {
   opacity: 0.3;
@@ -2232,7 +2183,6 @@ a.kui--tab-navigatable:hover {
 }
 .graphical-icon svg path {
   fill: var(--color-text-against-dark-bg);
-  transition: fill 150ms ease-in-out;
 }
 body:not(.no-tooltips-anywhere) .graphical-icon:hover svg path {
   fill: var(--color-brand-01);
@@ -2298,7 +2248,6 @@ body:not(.oops-total-catastrophe) #restart-needed-warning {
   opacity: 0;
 }
 #restart-needed-warning {
-  transition: all 300ms ease-in-out;
   position: absolute;
   top: 0;
   left: 0;
@@ -2399,13 +2348,13 @@ sidecar [data-balloon]:after {
 }
 
 .go-away-able {
-  transition: opacity 450ms ease-in-out;
+  transition-property: opacity;
 }
 .go-away {
   opacity: 0;
 }
 .go-away-able .go-away-button {
-  transition: all 150ms ease-in-out;
+  transition-property: all;
 }
 .go-away-able .go-away-button:hover {
   filter: brightness(1.2);
@@ -2417,21 +2366,20 @@ sidecar [data-balloon]:after {
   justify-content: flex-end;
   font-family: var(--font-sans-serif);
   color: var(--color-text-02);
-  background: var(--color-ui-01);
+  background-color: transparent;
   border: 1px solid var(--color-ui-04);
   border-top: none;
-  height: 3em;
+  height: 2em;
 }
 .list-paginator .list-paginator-left-buttons {
   display: flex;
   align-items: center;
-  padding: 0.5rem 1rem;
+  padding: 0 1em;
   flex: 1;
-  letter-spacing: 1px;
 }
 .list-paginator .list-paginator-left-buttons > span {
   /* a list paginator left button */
-  transition: all 150ms ease-in-out;
+  transition-property: all;
 }
 .list-paginator .list-paginator-left-buttons > span:hover {
   opacity: 1;
@@ -2452,7 +2400,7 @@ sidecar [data-balloon]:after {
 }
 .list-paginator .list-paginator-button {
   border-left: 1px solid var(--color-ui-04);
-  transition: all 250ms;
+  transition-property: all;
   width: 2.625rem;
   display: flex;
   align-items: center;
@@ -2461,10 +2409,9 @@ sidecar [data-balloon]:after {
 }
 .list-paginator .list-paginator-button svg path {
   fill: var(--color-text-02);
-  transition: fill 150ms ease-in-out;
 }
 .list-paginator .list-paginator-button.list-paginator-button-disabled svg path {
-  fill: var(--color-ui-04);
+  fill: var(--color-ui-05);
 }
 .list-paginator .list-paginator-button:not(.list-paginator-button-disabled):hover {
   cursor: pointer;
@@ -2674,7 +2621,6 @@ sidecar .usage-error-wrapper .hideable {
   letter-spacing: 0;
   line-height: 1.25;
   padding: 0;
-  transition: 0.25s cubic-bezier(0.5, 0, 0.1, 1);
 }
 .page-content h2,
 .page-h2 {
@@ -2861,7 +2807,7 @@ sidecar.rule-enabled-false .sidecar-header-icon,
 
 sidecar.activation-success-false .sidecar-header-icon,
 span[data-extra-decoration="application error"] {
-  color: var(--color-support-01-lighter);
+  color: var(--color-red);
 }
 
 .repl-block.processing .repl-input input {
@@ -2871,7 +2817,7 @@ span[data-extra-decoration="application error"] {
 sidecar .sidecar-header badge.version {
   /* badge for action version */
   background-color: var(--color-tag-ibm-fill);
-  color: var(--color-tag-ibm-text);
+  mix-blend-mode: difference;
 }
 
 badge.clickable:not(.badge-as-fontawesome):hover {
@@ -2901,7 +2847,6 @@ badge.clickable:not(.badge-as-fontawesome):hover {
 .sidecar-bottom-stripe {
   color: var(--color-text-01);
   background: var(--color-stripe-02);
-  transition: background-color 300ms ease-in-out, color 300ms ease-in-out;
 }
 .sidecar-non-window-buttons .sidecar-bottom-stripe-button:last-child .graphical-icon {
   border-right: 1px solid var(--color-table-border1);
@@ -3100,7 +3045,6 @@ body {
 
   --color-text-against-dark-bg: var(--color-text-01);
   --color-support-01: var(--color-red);
-  --color-support-01-lighter: var(--color-light-red);
   --color-support-02: var(--color-green);
   --color-support-03: var(--color-yellow);
   --color-support-03-darker: var(--color-yellow);
@@ -3122,7 +3066,6 @@ body {
   --color-selection-background: var(--color-base04);
   --color-selection-foreground: var(--color-text-01);
 
-  --color-tag-ibm-text: var(--color-text-01);
   --color-ok: var(--color-green);
   --color-error: var(--color-red);
 
@@ -3137,7 +3080,6 @@ body {
   --color-tag-beta-fill: var(--color-base05);
   --color-tag-beta-text: var(--color-base01);
   --color-tag-ibm-fill: var(--color-base0D);
-  --color-tag-ibm-text: var(--color-base01);
 
   /* default latency color spectrum */
   --color-latency-0: #2166ac;
@@ -3223,7 +3165,6 @@ body {
     height: 2.75em;*/
   flex-basis: 2.75em;
   background-color: var(--color-stripe-01);
-  transition: border-color 150ms ease-in-out, background-color 150ms ease-in-out;
 }
 body.kui--bottom-input .kui--input-stripe {
   display: flex;
@@ -3274,10 +3215,6 @@ body.kui--bottom-input .repl-context {
   font-size: 1.25em;
   color: var(--color-brand-03);
   animation: selected-pulse 300ms 3;
-  transition: all 150ms ease-in-out;
-}
-.row-selection-context .selected-entity svg path {
-  transition: fill 300ms ease-in-out;
 }
 .row-selection-context.selected-row .selected-entity svg path {
   fill: var(--color-name) !important;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/atelier-seaside.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/atelier-seaside.css
@@ -22,10 +22,7 @@ body[kui-theme="Atelier"] {
 
   --color-ui-06: hsla(120, 8%, 14%, 1);
 
-  --color-light-red: hsla(350, 80%, 50%, 0.75);
-  --color-light-green: hsla(120, 60%, 40%, 0.75);
   --color-yellow: var(--color-base09);
-  --color-light-yellow: hsla(48, 65%, 32%, 0.75);
 
   --color-latency-0: #01665e;
   --color-latency-1: #5ab4ac;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/dark.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/dark.css
@@ -40,10 +40,6 @@ body[kui-theme="Dark"] {
   --color-content-divider: #3F4548;
   --color-selection-background: #0074C7;
 
-  --color-light-red: hsla(357, 96%, 64%, 50%);
-  --color-light-green: hsla(134, 43%, 52%, 50%);
-  --color-light-yellow: hsla(46, 98%, 61%, 50%);
-
   --color-brand-03: #418cff;
   --color-tag-beta-fill: #202529;
   --color-tag-beta-text: var(--color-text-01);

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/dracula.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/dracula.css
@@ -20,11 +20,8 @@ body[kui-theme="Dracula"] {
   --color-base0E: #b45bcf;
   --color-base0F: #00f769;
 
-  --color-light-red: hsla(322, 78%, 62%, 0.75);
   --color-green: var(--color-base0A);
-  --color-light-green: hsla(146, 100%, 48%, 0.75);
   --color-yellow: var(--color-base0B);
-  --color-light-yellow: hsla(70, 100%, 76%, 0.75);
 
   --color-latency-0: #4d4d4d;
   --color-latency-1: #999999;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/gruvbox-dark-medium.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/gruvbox-dark-medium.css
@@ -20,10 +20,6 @@ body[kui-theme="Gruvbox"] {
   --color-base0E: #d3869b;
   --color-base0F: #d65d0e;
 
-  --color-light-red: hsla(6, 96%, 59%, 0.75);
-  --color-light-green: hsla(61, 66%, 44%, 0.75);
-  --color-light-yellow: hsla(42, 95%, 58%, 0.75);
-
   --color-latency-0: #1b7837;
   --color-latency-1: #7fbf7b;
   --color-latency-2: #d9f0d3;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/light.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/light.css
@@ -49,10 +49,6 @@ body[kui-theme="Light"] {
   --color-stripe-02: var(--color-base04);
   --color-sidecar-toolbar-background: #D7DCE3;
   --color-sidecar-toolbar-foreground: var(--color-base06);
-
-  --color-light-red: hsla(354, 81%, 51%, 50%);
-  --color-light-green: hsla(143, 73%, 43%, 50%);
-  --color-light-yellow: hsla(46, 98%, 61%, 50%);
 }
 
 /* mono-blue hightlightjs theme */

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/lucario.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/lucario.css
@@ -22,12 +22,7 @@ body[kui-theme="Lucario"] {
   --color-base0E: #ff73fd;
   --color-base0F: #e6b5ff;
 
-  /*     --color-support-01: #e3bf21; */
   --color-ui-06: hsla(209, 25%, 22%, 1);
-
-  --color-light-red: rgba(255, 108, 96, 50%);
-  --color-light-green: hsla(108, 67%, 68%, 50%);
-  --color-light-yellow: rgba(255, 255, 182, 50%);
 
   --color-latency-0: #1b7837;
   --color-latency-1: #7fbf7b;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/monokai.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/monokai.css
@@ -19,10 +19,6 @@ body[kui-theme="Monokai"] {
   --color-base0D: #66d9ef;
   --color-base0E: #ae81ff;
   --color-base0F: #cc6633;
-
-  --color-light-red: hsla(338, 95%, 56%, 0.75);
-  --color-light-green: hsla(80, 76%, 53%, 0.75);
-  --color-light-yellow: hsla(35, 85%, 71%, 0.75);
 }
 
 /* monokai highlightjs theme */

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/nord.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/nord.css
@@ -27,10 +27,6 @@ body[kui-theme="Nord"] {
   --color-green: var(--color-base0E);
   --color-yellow: var(--color-base0D);
 
-  --color-light-red: hsla(354, 42%, 56%, 0.75);
-  --color-light-green: hsla(92, 28%, 65%, 0.75);
-  --color-light-yellow: hsla(40, 71%, 73%, 0.75);
-
   --color-latency-0: #4575b4;
   --color-latency-1: #91bfdb;
   --color-latency-2: #e0f3f8;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/paraiso.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/paraiso.css
@@ -21,10 +21,6 @@ body[kui-theme="Paraiso"] {
   --color-base0E: hsl(271, 29%, 60%); /* from L=50% #815ba4 */
   --color-base0F: #e96ba8;
 
-  --color-light-red: hsla(5, 83%, 64%, 0.75);
-  --color-light-green: hsla(153, 43%, 50%, 0.75);
-  --color-light-yellow: hsla(45, 99%, 55%, 0.75);
-
   --color-latency-0: #542788;
   --color-latency-1: #998ec3;
   --color-latency-2: #d8daeb;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/solarized-dark.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/solarized-dark.css
@@ -26,10 +26,6 @@ body[kui-theme="Solarized"] {
   --color-base0E: #6c71c4;
   --color-base0F: #d33682;
 
-  --color-light-red: hsla(1, 71%, 52%, 0.75);
-  --color-light-green: hsla(68, 100%, 30%, 0.75);
-  --color-light-yellow: hsla(45, 100%, 35%, 0.75);
-
   --color-ui-06: hsla(194, 20%, 20%, 0.8);
 
   --color-latency-0: #4575b4;

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/tomorrow-night.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/tomorrow-night.css
@@ -26,9 +26,6 @@ body[kui-theme="tomorrow-night"] {
   --color-base0F: #a3685a; /* BROWN: Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?> */
 
   --color-black: var(--color-base05); /* e.g. husky's "No partially staged files found" */
-  --color-light-red: hsla(0, 80%, 75%, 50%);
-  --color-light-green: hsla(66, 69%, 57%, 50%);
-  --color-light-yellow: hsl(40, 81%, 70%);
 }
 
 /* tomorrow-night hightlightjs theme */

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/zenburn.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/zenburn.css
@@ -20,10 +20,6 @@ body[kui-theme="Zenburn"] {
   --color-base0E: #dc8cc3;
   --color-base0F: #000000;
 
-  --color-light-red: hsla(0, 45%, 60%, 0.75);
-  --color-light-green: hsla(120, 14%, 60%, 75%);
-  --color-light-yellow: hsl(40, 81%, 70%);
-
   --color-latency-0: #1a9850;
   --color-latency-1: #91cf60;
   --color-latency-2: #d9ef8b;

--- a/plugins/plugin-bash-like/src/lib/cmds/git-status.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/git-status.ts
@@ -113,7 +113,7 @@ export const status2Html = (tab: Tab, rawOut: string, stats: Promise<Stats> = nu
     )
     .replace(
       /modified:/g,
-      `<td class='yellow-text larger-text icon-width'><svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32" aria-hidden="true"><path d="M13 21h13.17l-2.58 2.59L25 25l5-5-5-5-1.41 1.41L26.17 19H13v2z"></path><path d="M22 14v-4a1 1 0 0 0-.29-.71l-7-7A1 1 0 0 0 14 2H4a2 2 0 0 0-2 2v24a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-2h-2v2H4V4h8v6a2 2 0 0 0 2 2h6v2zm-8-4V4.41L19.59 10z"></path></svg></td>`
+      `<td class='larger-text icon-width'><svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32" aria-hidden="true"><path d="M13 21h13.17l-2.58 2.59L25 25l5-5-5-5-1.41 1.41L26.17 19H13v2z"></path><path d="M22 14v-4a1 1 0 0 0-.29-.71l-7-7A1 1 0 0 0 14 2H4a2 2 0 0 0-2 2v24a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-2h-2v2H4V4h8v6a2 2 0 0 0 2 2h6v2zm-8-4V4.41L19.59 10z"></path></svg></td>`
     )
     .replace(
       /new file:/g,

--- a/plugins/plugin-bash-like/web/css/my-diff2html.css
+++ b/plugins/plugin-bash-like/web/css/my-diff2html.css
@@ -106,14 +106,14 @@ td > .d2h-code-side-linenumber {
 .d2h-code-line ins,
 .d2h-code-side-line ins {
   /* character-level inserts */
-  background-color: var(--color-light-green);
+  background-color: var(--color-green);
   color: var(--color-white);
 }
 
 .d2h-code-line del,
 .d2h-code-side-line del {
   /* character-level deletes */
-  background-color: var(--color-light-red);
+  background-color: var(--color-red);
   color: var(--color-white);
 }
 
@@ -170,9 +170,9 @@ td > .d2h-code-side-linenumber {
 }
 
 .d2h-changed {
-  color: var(--color-yellow);
+  color: var(--color-base0E);
   background-color: var(--color-ui-02);
-  border-color: var(--color-light-yellow);
+  border-color: var(--color-base0E);
 }
 
 .d2h-file-stats-wrapper {
@@ -182,17 +182,21 @@ td > .d2h-code-side-linenumber {
 .d2h-file-stats {
   justify-content: flex-end;
 }
+body[kui-theme-style="dark"] .d2h-file-stats > span {
+  mix-blend-mode: hard-light;
+  color: var(--color-base00);
+}
 .d2h-file-stats > span {
-  color: var(--color-white);
+  color: var(--color-text-01);
   border-color: transparent;
   padding: 0.25em;
   font-size: 0.875em;
 }
 .d2h-lines-added {
-  background: var(--color-light-green);
+  background: var(--color-green);
 }
 .d2h-lines-deleted {
-  background: var(--color-light-red);
+  background: var(--color-red);
 }
 
 /* + prefix text for insert */

--- a/plugins/plugin-core-support/src/lib/new-tab.ts
+++ b/plugins/plugin-core-support/src/lib/new-tab.ts
@@ -405,14 +405,17 @@ const perTabInit = (tab: Tab, tabButton: HTMLElement, doListen = true) => {
   }
 
   // keep repl prompt focused, if possible
-  tab.querySelector('.repl-inner').addEventListener('click', (evt: MouseEvent) => {
+  const grabFocus = (checkPath: boolean) => (evt: MouseEvent) => {
     const target = evt.target
     if (isElement(target)) {
       setTimeout(() => {
         const prompt = getCurrentPrompt(tab)
         if (
           getSelectionText().length === 0 &&
-          (target.classList.contains('repl-inner') || target.classList.contains('repl-output'))
+          (target.classList.contains('repl-inner') ||
+            target.classList.contains('repl-output') ||
+            target.classList.contains('kui--tab-navigatable') ||
+            (checkPath && evt['path'] && evt['path'].find(_ => isElement(_) && /header/i.test(_.tagName))))
         ) {
           if (target.classList.contains('repl-inner') || isInViewport(prompt)) {
             prompt.focus()
@@ -420,7 +423,9 @@ const perTabInit = (tab: Tab, tabButton: HTMLElement, doListen = true) => {
         }
       }, 0)
     }
-  })
+  }
+  tab.querySelector('sidecar').addEventListener('click', grabFocus(false))
+  tab.querySelector('.repl-inner').addEventListener('click', grabFocus(true))
 
   // tab close button
   getTabCloser(tab).onclick = (event: MouseEvent) => {

--- a/plugins/plugin-k8s/tests/lib/k8s/utils.d.ts
+++ b/plugins/plugin-k8s/tests/lib/k8s/utils.d.ts
@@ -26,6 +26,12 @@ import { CLI as ui } from '@kui-shell/core/tests/lib/ui'
 declare var defaultModeForGet: string
 
 /**
+ * Do singleton tables have a title decoration?
+ *
+ */
+declare let singletonTablesHaveTitle: boolean
+
+/**
  * Allocate a new unique namespace name
  *
  * @param prefix the (optional) prefix of the generated namespace name

--- a/plugins/plugin-k8s/tests/lib/k8s/utils.js
+++ b/plugins/plugin-k8s/tests/lib/k8s/utils.js
@@ -21,8 +21,11 @@ const common = require('@kui-shell/core/tests/lib/common')
 const ui = require('@kui-shell/core/tests/lib/ui')
 const { cli, selectors } = ui
 
-// the default tab we expect to see on "get"
+/** the default tab we expect to see on "get" */
 exports.defaultModeForGet = 'summary'
+
+/** Do singleton tables have a title decoration? */
+exports.singletonTablesHaveTitle = false
 
 /**
  * Wait for a green badge

--- a/plugins/plugin-openwhisk/src/lib/views/cli/activations/list.ts
+++ b/plugins/plugin-openwhisk/src/lib/views/cli/activations/list.ts
@@ -194,6 +194,7 @@ const _render = (args: Args) => {
   if (newTable) {
     logTable = document.createElement('table')
     logTable.className = 'log-lines fixed-table-layout log-lines-loose'
+    logTable.setAttribute('kui-table-style', 'Medium')
 
     if (entity) {
       // for the sidecar only, clean things out
@@ -507,14 +508,14 @@ const _render = (args: Args) => {
           {
             command: 'summary',
             icon:
-              '<svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 32 32" aria-hidden="true"><path d="M29 5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v22a2 2 0 0 0 2 2h22a2 2 0 0 0 2-2zm-2 0v4H5V5zm0 22H5v-4h22zm0-6H5v-4h22zm0-6H5v-4h22z"></path></svg>',
+              '<svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/1600/svg" width="16" height="16" viewBox="0 0 32 32" aria-hidden="true"><path d="M29 5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v22a2 2 0 0 0 2 2h22a2 2 0 0 0 2-2zm-2 0v4H5V5zm0 22H5v-4h22zm0-6H5v-4h22zm0-6H5v-4h22z"></path></svg>',
             balloon: 'Open a statistical summary view'
           },
           // 'timeline', // disabled for now shell issue #794
           {
             command: 'grid',
             icon:
-              '<svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 32 32" aria-hidden="true"><path d="M12 4H6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm0 8H6V6h6zm14-8h-6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm0 8h-6V6h6zm-14 6H6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2zm0 8H6v-6h6zm14-8h-6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2zm0 8h-6v-6h6z"></path></svg>',
+              '<svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32" aria-hidden="true"><path d="M12 4H6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm0 8H6V6h6zm14-8h-6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm0 8h-6V6h6zm-14 6H6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2zm0 8H6v-6h6zm14-8h-6a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2zm0 8h-6v-6h6z"></path></svg>',
             balloon: 'Open a grid view',
             balloonPos: 'up-left'
           }
@@ -530,7 +531,8 @@ const _render = (args: Args) => {
           buttonContainer.setAttribute('data-balloon', balloon)
           buttonContainer.setAttribute('data-balloon-pos', balloonPos)
 
-          const iconContainer = document.createElement('span')
+          const iconContainer = document.createElement('div')
+          iconContainer.style.display = 'flex'
           iconContainer.innerHTML = icon
           button.appendChild(iconContainer)
           button.classList.add('clickable')
@@ -551,12 +553,12 @@ const _render = (args: Args) => {
 
         const nextSVG = document.createElement('span')
         nextSVG.innerHTML =
-          '<svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 32 32" aria-hidden="true"><path d="M22 16L12 26l-1.4-1.4 8.6-8.6-8.6-8.6L12 6z"></path></svg>'
+          '<svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true"><path d="M22 16L12 26l-1.4-1.4 8.6-8.6-8.6-8.6L12 6z"></path></svg>'
         next.appendChild(nextSVG)
 
         const prevSVG = document.createElement('span')
         prevSVG.innerHTML =
-          '<svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 32 32" aria-hidden="true"><path d="M10 16L20 6l1.4 1.4-8.6 8.6 8.6 8.6L20 26z"></path></svg>'
+          '<svg focusable="false" preserveAspectRatio="xMidYMid meet" style="will-change: transform;" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true"><path d="M10 16L20 6l1.4 1.4-8.6 8.6 8.6 8.6L20 26z"></path></svg>'
         prev.appendChild(prevSVG)
       } else {
         const paginator = container.querySelector('.list-paginator')


### PR DESCRIPTION
this PR also cleans up a few other elements of design:
- sans-serif tables
- git status/diff coloring
- as part of the previous, remove no-longer-needed light-red/yellow/green css rules
- improved behavior for clicks versus active and prompt focus in sidecar

Fixes #2626

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
