### PR TITLE
3.0.17

### DIFF
--- a/clients/alternate/theme/css/themes/carbon-gray10.css
+++ b/clients/alternate/theme/css/themes/carbon-gray10.css
@@ -33,7 +33,7 @@ body[kui-theme="IBM Light"] {
   --color-text-02: #565656;
 
   --color-map-key: #6ea6ff;
-  --color-map-value: var(--color-text-inverted-01);
+  --color-map-value: var(--color-text-inverted01);
 
   --color-table-border1: #9e9fa1;
   --color-table-border2: #3d4144;

--- a/packages/app/src/webapp/picture-in-picture.ts
+++ b/packages/app/src/webapp/picture-in-picture.ts
@@ -85,7 +85,6 @@ const restore = (
     const curHeaderParent = curHeader.parentNode
 
     curHeaderParent.removeChild(curHeader)
-    // curHeaderParent.appendChild(node)
     curHeaderParent.insertBefore(node, nextSibling)
 
     if (redraw) {
@@ -204,12 +203,22 @@ interface CapturedHeader {
  *
  */
 const capture = (tab: Tab, selector: string, redraw?: Function): CapturedHeader => {
+  // capture the current dom via deep clone
   const node = tab.querySelector(selector)
+  const clone = node.cloneNode(true) as Element
+
+  // remember this, so we can reattach in the right place (using insertBefore)
+  const parent = node.parentNode
+  const nextSibling = node.nextSibling as Element
+
+  node.remove()
+  parent.insertBefore(clone, nextSibling)
+
   return {
     selector, // remember how to find the replacement
-    node: node.cloneNode(true) as Element, // capture the current dom via deep clone
+    node,
     redraw, // any redraw helper that might've been registered
-    nextSibling: node.nextSibling as Element // remember this, so we can reattach in the right place (using insertBefore)
+    nextSibling
   }
 }
 
@@ -247,10 +256,6 @@ export const drilldown = (
   // for the footer, we need to capture the modeButton renderer, so we can reattach the click events
   const modeButtons = css.modeContainer(tab)['capture']
   const capturedFooter = capture(tab, rawCSS.buttons, modeButtons && modeButtons())
-
-  debug('container', container)
-  debug('alreadyPipped', alreadyPipped)
-  debug('presentation', presentation)
 
   const capturedHeaders = [
     capturedHeader,

--- a/packages/app/templates/index.html
+++ b/packages/app/templates/index.html
@@ -56,7 +56,7 @@
           </div>
 
           <div class="left-tab-stripe-buttons">
-            <a href="#" class="kui-tab kui-tab--active left-tab-stripe-button left-tab-stripe-button-selected kui--tab-navigatable" data-tab-button-index="1">
+            <a href="#" class="kui-tab kui-tab--active left-tab-stripe-button left-tab-stripe-button-selected kui--tab-navigatable" data-tab-button-index="1" aria-label="tab">
               <i class="fas fa-square repl-prompt-right-element-icon deemphasize"></i>
               <div class="kui-tab--label left-tab-stripe-button-label">
                 &nbsp;
@@ -72,14 +72,14 @@
           </div>
           <div class="left-tab-stripe-bottom-buttons">
             <div class="left-tab-stripe-button smaller-button kui-new-tab" id="new-tab-button" data-balloon-disabled="Open a new tab" data-balloon-pos="right" data-balloon-length="fit">
-              <a href="#" class="kui--tab-navigatable kui-new-tab__plus" width="20" height="20">
+              <a href="#" class="kui--tab-navigatable kui-new-tab__plus" width="20" height="20" aria-label="Open a new tab">
                 <svg class="kui-new-tab__plus" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true">
                   <path d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"></path>
                 </svg>
               </a>
             </div>
             <div id="kui--custom-top-tab-stripe-button-container"></div>
-            <a href="#" class="left-tab-stripe-button smaller-button kui--tab-navigatable " id="help-button">
+            <a href="#" class="left-tab-stripe-button smaller-button kui--tab-navigatable " id="help-button" aria-label="Help">
               <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true">
                 <path d="M16 2a14 14 0 1 0 14 14A14 14 0 0 0 16 2zm0 26a12 12 0 1 1 12-12 12 12 0 0 1-12 12z"></path>
                 <circle cx="16" cy="23.5" r="1.5"></circle>
@@ -341,7 +341,7 @@
                       <div class="sidecar-non-window-buttons">
                         <!-- screenshot button -->
                         <div class="kui--hide-in-webpack sidecar-screenshot-button sidecar-bottom-stripe-button sidecar-bottom-stripe-maximize screenshot-button" data-balloon="Capture Screenshot" data-balloon-length="medium" data-balloon-pos="down-right">
-                          <a href="#" class="graphical-icon kui--tab-navigatable kui--notab-when-sidecar-hidden" tabindex="-1">
+                          <a href="#" class="graphical-icon kui--tab-navigatable kui--notab-when-sidecar-hidden" tabindex="-1" aria-label="Capture Screenshot">
                             <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true">
                               <path d="M29 26H3a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1h6.46l1.71-2.55A1 1 0 0 1 12 4h8a1 1 0 0 1 .83.45L22.54 7H29a1 1 0 0 1 1 1v17a1 1 0 0 1-1 1zM4 24h24V9h-6a1 1 0 0 1-.83-.45L19.46 6h-6.92l-1.71 2.55A1 1 0 0 1 10 9H4z"></path>
                               <path d="M16 22a6 6 0 1 1 6-6 6 6 0 0 1-6 6zm0-10a4 4 0 1 0 4 4 4 4 0 0 0-4-4z"></path>
@@ -354,14 +354,14 @@
                         <!-- maximize button -->
                         <div class="sidecar-bottom-stripe-button sidecar-bottom-stripe-maximize toggle-sidecar-maximization-button">
                           <span class="maximize-button-label">
-                            <a href="#" class="graphical-icon kui--tab-navigatable kui--notab-when-sidecar-hidden" tabindex="-1" data-balloon="Expand to full width" data-balloon-length="medium" data-balloon-pos="down-right">
+                            <a href="#" class="graphical-icon kui--tab-navigatable kui--notab-when-sidecar-hidden" tabindex="-1" data-balloon="Expand to full width" data-balloon-length="medium" data-balloon-pos="down-right" aria-label="Expand to full width">
                               <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
                                 <path d="M10 1v1h3.3L8.5 6.8l.7.7L14 2.7V6h1V1zM7.5 9.2l-.7-.7L2 13.3V10H1v5h5v-1H2.7z"></path>
                               </svg>
                             </a>
                           </span>
                           <span class="unmaximize-button-label">
-                            <a href="#" class="graphical-icon kui--tab-navigatable kui--notab-when-sidecar-hidden" tabindex="-1" data-balloon="Restore split screen" data-balloon-length="medium" data-balloon-pos="down-right">
+                            <a href="#" class="graphical-icon kui--tab-navigatable kui--notab-when-sidecar-hidden" tabindex="-1" data-balloon="Restore split screen" data-balloon-length="medium" data-balloon-pos="down-right" aria-lable="Restore split screen">
                               <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
                                 <path d="M3 9v1h2.3L1 14.3l.7.7L6 10.7V13h1V9zm10-2V6h-2.3L15 1.7l-.7-.7L10 5.3V3H9v4z"></path>
                               </svg>
@@ -371,7 +371,7 @@
 
                         <!-- close button -->
                         <div class="sidecar-bottom-stripe-button sidecar-bottom-stripe-close toggle-sidecar-button" data-balloon="Minimize" data-balloon-length="small" data-balloon-pos="down-right">
-                          <a href="#" class="graphical-icon kui--tab-navigatable kui--notab-when-sidecar-hidden" tabindex="-1">
+                          <a href="#" class="graphical-icon kui--tab-navigatable kui--notab-when-sidecar-hidden" tabindex="-1" aria-label="Minimize">
                             <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
                               <path d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"></path>
                             </svg>
@@ -380,7 +380,7 @@
 
                         <!-- Quit/Done button -->
                         <div class="sidecar-bottom-stripe-button sidecar-bottom-stripe-quit" data-balloon="Close" data-balloon-length="small" data-balloon-pos="down-right">
-                          <a href="#" class="graphical-icon kui--tab-navigatable kui--notab-when-sidecar-hidden" tabindex="-1">
+                          <a href="#" class="graphical-icon kui--tab-navigatable kui--notab-when-sidecar-hidden" tabindex="-1" aria-label="Close">
                             <!-- sign out button -->
                             <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true">
                               <path d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"></path>

--- a/plugins/plugin-k8s/src/lib/view/modes/containers.ts
+++ b/plugins/plugin-k8s/src/lib/view/modes/containers.ts
@@ -19,6 +19,7 @@ import { Tab } from '@kui-shell/core/webapp/cli'
 import drilldown from '@kui-shell/core/webapp/picture-in-picture'
 import { Row } from '@kui-shell/core/webapp/models/table'
 import { ModeRegistration } from '@kui-shell/core/webapp/views/registrar/modes'
+import { getActiveView } from '@kui-shell/core/webapp/views/sidecar'
 import { encodeComponent, qexec } from '@kui-shell/core/core/repl'
 
 import { Resource, KubeResource } from '../../model/resource'
@@ -26,7 +27,7 @@ import { Resource, KubeResource } from '../../model/resource'
 import { TrafficLight } from '../../model/states'
 
 import insertView from '../insert-view'
-import { getActiveView, formatTable } from '../formatMultiTable'
+import { formatTable } from '../formatMultiTable'
 
 import i18n from '@kui-shell/core/util/i18n'
 const strings = i18n('plugin-k8s')


### PR DESCRIPTION
cherry pick

 63efe65
ded4c2b502b7aa0ce855e2166eba47c4a735edf5
a26e981be5bb4010e7c406195d5c6fa90612b1bf
7b46288fbcded48c182f20142afb53672a6bbc63


[3.0.17 de54734] fix(pacakges/app): Accessibility Violations: Hyperlinks must contain link text
[3.0.17 61a659e2] fix(plugins/plugin-k8s): Back button on logs sidecar disappears after viewing second time from pod sidecar
[3.0.17 e5cebce4] fix: typo in map-key color in carbon-gray10 theme
[3.0.17 e6af36ba] fix(packages/app): back button does not restore click handlers