### PR TITLE
fix(packages/kui-builder): default dark theme has poor blue color

### DIFF
--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/dark.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/dark.css
@@ -16,7 +16,7 @@ body[kui-theme="Dark"] {
   --color-base0A: #fdd13a; /* YELLOW: Classes, Markup Bold, Search Text Background */
   --color-base0B: #3dbb61; /* GREEN: Strings, Inherited Class, Markup Code, Diff Inserted */
   --color-base0C: #6ccaff; /* CYAN: Support, Regular Expressions, Escape Characters, Markup Quotes */
-  --color-base0D: #1999b3; /* BLUE: Functions, Methods, Attribute IDs, Headings */
+  --color-base0D: #97c1ff; /* BLUE: Functions, Methods, Attribute IDs, Headings */
   --color-base0E: #ffa0c2; /* MAGENTA: Keywords, Storage, Selector, Markup Italic, Diff Changed */
   --color-base0F: #d0b0ff; /* BROWN: Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?> */
 


### PR DESCRIPTION
Fixes #2685

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
