### PR TITLE
feat: add carbon gray10/90 themes to clients/default

### DIFF
--- a/packages/app/web/css/top-tab-stripe-alt.css
+++ b/packages/app/web/css/top-tab-stripe-alt.css
@@ -1,0 +1,1 @@
+/Users/nickm/git/whisk/nickm/kui/clients/default/theme/css/top-tab-stripe-alt.css

--- a/packages/app/web/css/top-tab-stripe.css
+++ b/packages/app/web/css/top-tab-stripe.css
@@ -247,7 +247,7 @@ body[kui-theme-style="dark"]
   border-bottom: 0.5px solid var(--color-content-divider);
   box-shadow: 0 1px 10px 0 rgba(21, 41, 53, 0.1);
 }
-.kui-header__title {
+[kui-theme-style] .kui-header__title {
   /* by default, don't show tool name in top tab */
   display: none;
 }

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/carbon-gray10.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/carbon-gray10.css
@@ -1,0 +1,196 @@
+/* color variables */
+body[kui-theme="Carbon Gray10"] {
+  --color-base00: #ffffff;
+  --color-base01: #f3f3f3;
+  --color-base02: #8c8c8c;
+  --color-base03: #dcdcdc;
+  --color-base04: #f2f4f8;
+  --color-base05: #50565b;
+  --color-base06: #171717;
+  --color-base07: #fff;
+  --color-base08: #da1e28;
+  --color-base09: #bf5b17;
+  --color-base0A: #8e6926;
+  --color-base0B: #198038;
+  --color-base0C: #0072c3;
+  --color-base0D: #054ada;
+  --color-base0E: #d12765;
+  --color-base0F: #8a3ffc;
+
+  /* SidecarThin */
+  --color-background-inverted01: var(--color-sidecar-background);
+  --color-background-inverted02: var(--color-sidecar-header);
+  --color-text-inverted01: #fff;
+  --color-text-inverted02: var(--color-text-inverted01);
+  --color-text-inverted03: var(--color-text-01);
+  --color-tab-selected-inverted: var(--color-name);
+
+  --color-brand-01: #0062ff;
+  --color-brand-02: #171717;
+  --color-brand-03: #0062ff;
+
+  --color-ui-05: #171717;
+  --color-ui-03: var(--color-background-inverted02);
+  --color-text-02: #565656;
+
+  --color-map-key: #6ea6ff;
+  --color-map-value: var(--color-text-inverted01);
+
+  --color-table-border1: #9e9fa1;
+  --color-table-border2: #3d4144;
+  --color-table-border3: #a5adb4;
+
+  --color-sidecar-toolbar-background: #bebebe;
+  --color-sidecar-toolbar-foreground: var(--color-text-01);
+
+  --color-sidecar-header: #282828;
+  --color-sidecar-background: var(--color-base06);
+  --color-sidecar-border: #e4e4e4;
+
+  --color-brand-03: #008fff;
+  --color-content-divider: #bfc0c2;
+  --color-selection-background: #b3e6ff;
+
+  --color-screenshot-background: #0062ff;
+
+  --color-stripe-01: #f5f7fa;
+  --color-stripe-02: var(--color-base03);
+  --tab-gray-text-color: var(--color-text-01);
+  --active-tab-color: #0062ff;
+
+  --color-light-red: hsla(354, 81%, 51%, 50%);
+  --color-light-green: hsla(143, 73%, 43%, 50%);
+  --color-light-yellow: hsla(46, 99%, 59%, 50%);
+}
+
+body[kui-theme="Carbon Gray10"] sidecar .sidecar-header {
+  border-bottom-color: #4c4c4c;
+}
+
+body[kui-theme="Carbon Gray10"] .result-table-title-outer {
+  background-color: transparent;
+}
+body[kui-theme="Carbon Gray10"] sidecar .bx--data-table-header__title {
+  color: var(--color-base07);
+}
+
+body[kui-theme="Carbon Gray10"] sidecar .bx--link {
+  color: var(--color-map-key);
+}
+body[kui-theme="Carbon Gray10"] sidecar,
+body[kui-theme="Carbon Gray10"] sidecar .sidecar-bottom-stripe,
+body[kui-theme="Carbon Gray10"] sidecar .monaco-editor,
+body[kui-theme="Carbon Gray10"] sidecar .monaco-editor .mtk5,
+body[kui-theme="Carbon Gray10"]
+  sidecar
+  .bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled)
+  .bx--tabs__nav-link {
+  color: var(--color-base07);
+}
+body[kui-theme="Carbon Gray10"]
+  sidecar
+  .bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled)
+  .bx--tabs__nav-link {
+  border-bottom-color: var(--color-map-key);
+}
+body[kui-theme="Carbon Gray10"]
+  sidecar
+  .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled)
+  .bx--tabs__nav-link {
+  color: var(--color-base01);
+}
+
+body[kui-theme="Carbon Gray10"] sidecar .sidecar-bottom-stripe svg path {
+  fill: var(--color-base07);
+}
+body[kui-theme="Carbon Gray10"] sidecar a.bx--tabs__nav-link,
+body[kui-theme="Carbon Gray10"] sidecar .sidecar-bottom-stripe {
+  background-color: var(--color-sidecar-header);
+  border-bottom-color: #6f6f6f;
+  color: var(--color-sidecar-toolbar-background);
+}
+body[kui-theme="Carbon Gray10"] .monaco-editor .margin-view-overlays .current-line-margin,
+body[kui-theme="Carbon Gray10"] .monaco-editor .view-overlays .current-line {
+  border-color: #565656;
+}
+body[kui-theme="Carbon Gray10"] sidecar .sidecar-header-secondary-content,
+body[kui-theme="Carbon Gray10"] sidecar .monaco-editor .mtk7,
+body[kui-theme="Carbon Gray10"] sidecar .monaco-editor .line-numbers {
+  color: var(--color-sidecar-toolbar-background);
+}
+body[kui-theme="Carbon Gray10"] .monaco-editor .current-line ~ .line-numbers {
+  color: #fa75a6;
+}
+body[kui-theme="Carbon Gray10"] .kui--input-stripe .repl-input {
+  background-color: var(--color-base04);
+}
+body[kui-theme="Carbon Gray10"] .repl,
+body[kui-theme="Carbon Gray10"] .left-tab-stripe-button-selected{
+  background-color: var(--color-base01);
+}
+body[kui-theme="Carbon Gray10"] .kui--input-stripe {
+  background-color: var(--color-base00);
+}
+body[kui-theme="Carbon Gray10"] .kui--input-stripe input {
+  background-color: var(--color-base01);
+}
+
+body[kui-theme="Carbon Gray10"] .bx--data-table {
+  font-family: var(--font-sans-serif);
+}
+body[kui-theme="Carbon Gray10"] .bx--data-table td {
+  background-color: var(--color-base00);
+}
+
+/* mono-blue hightlightjs theme */
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  background: #eaeef3;
+}
+.hljs {
+  color: #00193a;
+}
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-title,
+.hljs-section,
+.hljs-doctag,
+.hljs-name,
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-comment {
+  color: #738191;
+}
+.hljs-string,
+.hljs-title,
+.hljs-section,
+.hljs-built_in,
+.hljs-literal,
+.hljs-params,
+.hljs-type,
+.hljs-addition,
+.hljs-tag,
+.hljs-quote,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class {
+  color: #0048ab;
+}
+.hljs-meta,
+.hljs-subst,
+.hljs-symbol,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-deletion,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-link,
+.hljs-bullet {
+  color: #4c81c9;
+}
+.hljs-emphasis {
+  font-style: italic;
+}

--- a/packages/kui-builder/examples/build-configs/default/theme/css/themes/carbon-gray90.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/themes/carbon-gray90.css
@@ -1,0 +1,166 @@
+/* color variables */
+body[kui-theme="Carbon Gray90"][kui-theme-style] {
+  --color-base00: #282828;
+  --color-base01: #171717;
+  --color-base02: #565656;
+  --color-base03: #565656;
+  --color-base04: #8c8c8c;
+  --color-base05: #adadad;
+  --color-base06: #f3f3f3;
+  --color-base07: #fff;
+  --color-base08: #fb4b53;
+  --color-base09: #bf5b17;
+  --color-base0A: #fdd13a;
+  --color-base0B: #56d679;
+  --color-base0C: #30b0ff;
+  --color-base0D: #0353e9;
+  --color-base0E: #fa75a6;
+  --color-base0F: #bb8eff;
+
+  /* SidecarThin */
+  --color-background-inverted01: var(--color-sidecar-background);
+  --color-background-inverted02: var(--color-sidecar-header);
+  --color-text-inverted01: #fff;
+  --color-text-inverted02: var(--color-text-inverted01);
+  --color-text-inverted03: var(--color-text-01);
+  --color-tab-selected-inverted: var(--active-tab-color);
+
+  --color-confirm-background: var(--color-sidecar-header);
+  --color-confirm-foreground: var(--color-base06);
+
+  --color-brand-01: #97c1ff;
+  --color-brand-03: #0062ff;
+
+  --color-sidecar-toolbar-background: #bebebe;
+  --color-sidecar-toolbar-foreground: var(--color-base01);
+
+  --color-text-02: #bebebe; /**/
+
+  --color-sidecar-header: #3d3d3d;
+  --color-sidecar-background: #171717;
+  --color-sidecar-border: transparent;
+
+  --color-brand-03: #408bfc;
+  --color-content-divider: #4c4c4c;
+
+  --color-selection-background: #6f6f6f;
+
+  --color-screenshot-background: var(--color-brand-03);
+
+  --color-stripe-01: var(--color-base02);
+  --color-stripe-02: var(--color-sidecar-header);
+  --tab-gray-text-color: #b5b5b5;
+  --active-tab-color: #6ea6ff;
+
+  --color-prompt-text: #408bfc;
+
+  --color-light-red: hsla(354, 81%, 51%, 50%);
+  --color-light-green: hsla(143, 73%, 43%, 50%);
+  --color-light-yellow: hsla(46, 99%, 59%, 50%);
+}
+
+/* some carbon-overrides */
+body[kui-theme="Carbon Gray90"] .bx--modal-close__icon {
+  fill: #ebebeb;
+}
+body[kui-theme="Carbon Gray90"] .bx--data-table {
+  font-family: var(--font-sans-serif);
+}
+body[kui-theme="Carbon Gray90"] .bx--data-table tr:hover td,
+body[kui-theme="Carbon Gray90"] .bx--data-table tr:hover th {
+  color: var(--color-text-01);
+  border-color: var(--color-base02);
+  background-color: #4c4c4c;
+}
+body[kui-theme="Carbon Gray90"] .bx--data-table th {
+  color: var(--color-base06);
+  background-color: var(--color-base02); /* ui-03 */
+}
+body[kui-theme="Carbon Gray90"] .bx--data-table td {
+  color: var(--color-text-02); /* lighter text for body, as specified by design */
+  border-color: var(--color-base02);
+  background-color: var(--color-sidecar-header); /* ui-01 */
+}
+body[kui-theme="Carbon Gray90"] .bx--tabs__nav-link {
+  color: var(--color-base06);
+  border-bottom-color: var(--color-base02);
+}
+body[kui-theme="Carbon Gray90"] .bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link {
+  color: var(--color-base06);
+}
+body[kui-theme="Carbon Gray90"]
+  .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled)
+  .bx--tabs__nav-link {
+  color: var(--color-text-01);
+}
+body[kui-theme="Carbon Gray90"] .bx--modal-header__heading,
+body[kui-theme="Carbon Gray90"] .bx--modal-content {
+  color: var(--color-text-01);
+}
+body[kui-theme="Carbon Gray90"] .bx--btn--secondary {
+  background-color: #6f6f6f;
+}
+body[kui-theme="Carbon Gray90"] .bx--btn--danger {
+  background-color: #ff3751;
+}
+body[kui-theme="Carbon Gray90"] .repl {
+  background-color: var(--color-base00);
+}
+
+/* mono-blue hightlightjs theme */
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  background: #eaeef3;
+}
+.hljs {
+  color: #00193a;
+}
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-title,
+.hljs-section,
+.hljs-doctag,
+.hljs-name,
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-comment {
+  color: #738191;
+}
+.hljs-string,
+.hljs-title,
+.hljs-section,
+.hljs-built_in,
+.hljs-literal,
+.hljs-params,
+.hljs-type,
+.hljs-addition,
+.hljs-tag,
+.hljs-quote,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class {
+  color: #0048ab;
+}
+.hljs-meta,
+.hljs-subst,
+.hljs-symbol,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-deletion,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-link,
+.hljs-bullet {
+  color: #4c81c9;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+
+/* input placeholder text */
+body[kui-theme="Carbon Gray90"][kui-theme-style] ::placeholder {
+  opacity: 0.875 !important;
+}

--- a/packages/kui-builder/examples/build-configs/default/theme/css/top-tab-stripe-alt.css
+++ b/packages/kui-builder/examples/build-configs/default/theme/css/top-tab-stripe-alt.css
@@ -1,0 +1,144 @@
+/* mostly an example of an alternate top tab stripe UI */
+
+.kui-alternate .kui-header__title {
+  display: none;
+}
+.kui-header__title,
+.kui-tab,
+.kui-new-tab {
+  color: var(--tab-gray-text-color);
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+}
+
+.kui-header {
+  width: 100%;
+  height: 48px;
+  flex-basis: 48px;
+  display: flex;
+  background-color: var(--color-stripe-01);
+  padding: 0 1em 0 3em;
+  font-weight: 600;
+  box-shadow: 0 1px 10px 0 rgba(21, 41, 53, 0.1);
+  z-index: 1;
+}
+
+.kui-header__title {
+  padding-right: 28px;
+}
+
+.kui-tab {
+  position: relative;
+  border: none;
+  background: transparent;
+}
+
+.kui-tab--label {
+  text-align: left;
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 0.5em 0 0;
+  border: none !important;
+}
+body.kui-alternate .left-tab-stripe-buttons .left-tab-stripe-button-closer {
+  transform: translateY(calc(-50% + 0.25em));
+}
+
+.left-tab-stripe-button.processing .kui-tab--label {
+  color: var(--active-tab-color);
+}
+
+.kui-tab--label-index:before {
+  content: counter(tab-index);
+}
+
+.kui-tab--active {
+  color: var(--active-tab-color);
+}
+
+.kui-tab.left-tab-stripe-button-selected {
+  margin-top: 0;
+}
+
+.kui-tab::after {
+  display: block;
+  content: "";
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  background-color: transparent;
+  bottom: 0;
+  transition: all 0.2s;
+  pointer-events: none;
+}
+
+.kui-tab:hover:after,
+.kui-tab--active:after {
+  background-color: currentColor;
+}
+
+#new-tab-button.kui-new-tab {
+  padding-top: 0.5em;
+}
+
+.kui-header a.kui--tab-navigatable {
+  padding: 0.5em;
+}
+
+.kui-new-tab__text {
+  color: var(--tab-gray-text-color);
+}
+
+body.kui-alternate .kui--input-stripe {
+  flex-basis: 90px;
+  box-shadow: 0 -3px 10px 0 rgba(60, 60, 60, 0.1);
+}
+body.kui-alternate .repl .repl-input {
+  padding-left: 2em;
+  padding-right: 2em;
+}
+
+body.kui-alternate .repl-output {
+  padding: 0 2em;
+}
+
+body.kui-alternate .repl-prompt {
+  border: none;
+}
+
+body.kui-alternate .repl-prompt-righty {
+  color: var(--color-text-01);
+}
+body.kui-alternate .repl-prompt-righty svg path {
+  fill: var(--color-text-01);
+}
+
+/* status indicators */
+body.kui-alternate .repl-block .repl-prompt-right-element-status-icon svg {
+  transform: scale(0.875);
+  filter: none;
+}
+body.kui-alternate .repl-block.valid-response .repl-prompt-right-element-status-icon svg.kui--icon-ok {
+  display: none;
+}
+body.kui-alternate .repl .repl-prompt-right-element-status-icon.deemphasize {
+  order: -1;
+  margin-right: 0.5em;
+  margin-left: 0;
+}
+body.kui-alternate .kui--repl-prompt-buttons {
+  order: -2;
+}
+body.kui-alternate .repl-block.processing .repl-prompt-right-element-status-icon .kui--icon-processing svg circle {
+  stroke: var(--color-brand-03);
+}
+body.kui-alternate
+  .repl-block.processing
+  .repl-prompt-right-element-status-icon
+  .kui--icon-processing
+  svg
+  circle.bx--loading__stroke-kui {
+  stroke-dashoffset: 170;
+}

--- a/packages/kui-builder/examples/build-configs/default/theme/theme.json
+++ b/packages/kui-builder/examples/build-configs/default/theme/theme.json
@@ -35,6 +35,18 @@
       "style": "dark"
     },
     { "name": "Atelier", "css": "themes/atelier-seaside.css", "style": "dark" },
+    {
+      "name": "Carbon Gray10",
+      "css": ["themes/carbon-gray10.css", "top-tab-stripe-alt.css"],
+      "attrs": ["kui--alternate"],
+      "style": "light"
+    },
+    {
+      "name": "Carbon Gray90",
+      "css": ["themes/carbon-gray90.css", "top-tab-stripe-alt.css"],
+      "attrs": ["kui--alternate"],
+      "style": "dark"
+    },
     { "name": "Dracula", "css": "themes/dracula.css", "style": "dark" },
     {
       "name": "Gruvbox",

--- a/plugins/plugin-core-support/src/preload.ts
+++ b/plugins/plugin-core-support/src/preload.ts
@@ -32,9 +32,13 @@ const registration: PreloadRegistration = async (commandTree: CommandRegistrar) 
 
   if (!isHeadless()) {
     asyncs.push(import('./lib/cmds/zoom').then(_ => _.default(commandTree)))
-    asyncs.push(import('./lib/new-tab').then(_ => _.default(commandTree)))
+    asyncs.push(
+      import('./lib/cmds/theme')
+        .then(_ => _.preload())
+        .then(() => import('./lib/new-tab'))
+        .then(_ => _.default(commandTree))
+    )
     asyncs.push(import('./lib/cmds/history/reverse-i-search').then(_ => _.default()))
-    asyncs.push(import('./lib/cmds/theme').then(_ => _.preload()))
     asyncs.push(import('./lib/cmds/about/about').then(_ => _.preload()))
     asyncs.push(import('./lib/tab-completion').then(_ => _.default()))
   }


### PR DESCRIPTION
this also enriches themes to allow for injecting more than one css, and adding body classes

Fixes #2714

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
