### PR TITLE
fix(plugins/plugin-k8s): drilldown failed for `k get -w pods`

### DIFF
--- a/packages/app/src/models/command.ts
+++ b/packages/app/src/models/command.ts
@@ -232,7 +232,10 @@ export function isCommandHandlerWithEvents(evaluator: Evaluator): evaluator is C
 
 export type CommandTreeResolution = boolean | CommandHandlerWithEvents | CodedError
 
-export type YargsParserFlags = { [key in 'boolean' | 'alias']: string[] }
+export type YargsParserFlags = {
+  boolean?: string[]
+  alias?: string[]
+}
 
 /** a catch all handler is presented with an offer to handle a given argv */
 export type CatchAllOffer = (argv: string[]) => boolean


### PR DESCRIPTION
Updated yarg-parse boolean flag for `k get`

Fixed the splice bug when we tried to remove watch flags from raw arguments

Fixes #2719

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
