### PR TITLE
3.0.28

### DIFF
--- a/packages/app/src/models/command.ts
+++ b/packages/app/src/models/command.ts
@@ -222,7 +222,10 @@ export function isCommandHandlerWithEvents(evaluator: Evaluator): evaluator is C
 
 export type CommandTreeResolution = boolean | CommandHandlerWithEvents | CodedError
 
-export type YargsParserFlags = { [key in 'boolean' | 'alias']: string[] }
+export type YargsParserFlags = {
+  boolean?: string[]
+  alias?: string[]
+}
 
 /** a catch all handler is presented with an offer to handle a given argv */
 export type CatchAllOffer = (argv: string[]) => boolean

--- a/packages/app/src/models/command.ts
+++ b/packages/app/src/models/command.ts
@@ -222,7 +222,7 @@ export function isCommandHandlerWithEvents(evaluator: Evaluator): evaluator is C
 
 export type CommandTreeResolution = boolean | CommandHandlerWithEvents | CodedError
 
-export type YargsParserFlags = {
+export interface YargsParserFlags {
   boolean?: string[]
   alias?: string[]
 }

--- a/plugins/plugin-k8s/src/lib/controller/kubectl.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kubectl.ts
@@ -32,6 +32,7 @@ import { ExecOptions } from '@kui-shell/core/models/execOptions'
 import { SidecarMode } from '@kui-shell/core/webapp/bottom-stripe'
 import { CodedError } from '@kui-shell/core/models/errors'
 import { encodeComponent, qexec, semicolonInvoke } from '@kui-shell/core/core/repl'
+import { flatten } from '@kui-shell/core/core/utility'
 
 import abbreviations from './abbreviations'
 import { formatLogs } from '../util/log-parser'
@@ -511,7 +512,10 @@ const executeLocally = (command: string) => (opts: EvaluatorArgs) =>
             debug('return an empty watch table')
             return cleanupAndResolve(
               formatWatchableTable(new Table({ body: [] }), {
-                refreshCommand: rawCommand.replace(/--watch|-w/g, ''),
+                refreshCommand: rawCommand.replace(
+                  /--watch=true|-w=true|--watch-only=true|--watch|-w|--watch-only/g,
+                  ''
+                ),
                 watchByDefault: true
               })
             )
@@ -707,7 +711,7 @@ const executeLocally = (command: string) => (opts: EvaluatorArgs) =>
         if ((options.watch || options.w) && (isTable(tableModel) || isMultiTable(tableModel))) {
           cleanupAndResolve(
             formatWatchableTable(tableModel, {
-              refreshCommand: rawCommand.replace(/--watch|-w/g, ''),
+              refreshCommand: rawCommand.replace(/--watch=true|-w=true|--watch-only=true|--watch|-w|--watch-only/g, ''),
               watchByDefault: true
             })
           )
@@ -796,6 +800,26 @@ const dispatchViaDelegationTo = (delegate: CommandHandler) => (opts: EvaluatorAr
   return delegate(opts)
 }
 
+// use boolean flags here to tell yarg parser
+// that arguments should be parsed as booleans
+// TODO: find a better solution here to avoid hard-coding
+const flags = {
+  boolean: [
+    'w',
+    'watch',
+    'watch-only',
+    'A',
+    'all-namespaces',
+    'ignore-not-found',
+    'no-headers',
+    'R',
+    'recursive',
+    'server-print',
+    'show-kind',
+    'show-labels'
+  ]
+}
+
 /**
  * Register the commands
  *
@@ -803,22 +827,26 @@ const dispatchViaDelegationTo = (delegate: CommandHandler) => (opts: EvaluatorAr
 export default async (commandTree: CommandRegistrar) => {
   await commandTree.listen('/k8s/_kubectl', _kubectl, {
     usage: usage('kubectl'),
+    flags,
     requiresLocal: true,
     noAuthOk: ['openwhisk']
   })
   const kubectlCmd = await commandTree.listen('/k8s/kubectl', kubectl, {
     usage: usage('kubectl'),
+    flags,
     inBrowserOk: true,
     noAuthOk: ['openwhisk']
   })
   await commandTree.synonym('/k8s/k', kubectl, kubectlCmd, {
     usage: usage('kubectl'),
+    flags,
     inBrowserOk: true,
     noAuthOk: ['openwhisk']
   })
 
   await commandTree.listen('/k8s/helm', helm, {
     usage: usage('helm'),
+    flags,
     requiresLocal: true,
     noAuthOk: ['openwhisk']
   })
@@ -856,6 +884,7 @@ export default async (commandTree: CommandRegistrar) => {
     shorthands.map(verb => {
       return commandTree.listen(`/k8s/${verb}`, dispatchViaDelegationTo(kubectl), {
         usage: usage('kubectl'),
+        flags,
         requiresLocal: true,
         noAuthOk: ['openwhisk']
       })


### PR DESCRIPTION
cherry-pick

046d366
52b8ca22d04ac3c87ec59f392623990ca1de6303

[3.0.28 fc22122] fix(plugins/plugin-k8s): drilldown failed for k get -w pods
[3.0.28 bf543ca2] fix(packages/app): fix lint issue
