### PR TITLE
test: unreliable get-namespaces-with-watch test

### DIFF
--- a/packages/app/tests/lib/ui.js
+++ b/packages/app/tests/lib/ui.js
@@ -174,7 +174,7 @@ const expectOK = (appAndCount, opt) => {
 /** grab focus for the repl */
 const grabFocus = async app => {
   return app.client
-    .click(selectors.CURRENT_PROMPT_BLOCK)
+    .click(selectors.CURRENT_PROMPT)
     .then(() => app.client.waitForEnabled(selectors.CURRENT_PROMPT_BLOCK))
     .catch(err => {
       console.error(err)
@@ -373,7 +373,10 @@ exports.sidecar = {
   expectFullscreen: app => app.client.waitForVisible(selectors.SIDECAR_FULLSCREEN, timeout).then(() => app),
 
   // either minimized or fully closed
-  expectClosed: app => app.client.waitForExist(selectors.SIDECAR_HIDDEN, timeout).then(() => app),
+  expectClosed: async app => {
+    await app.client.waitForExist(selectors.SIDECAR_HIDDEN, timeout).then(() => app)
+    await new Promise(resolve => setTimeout(resolve, 600)) // wait for the transition effect
+  },
 
   // fully closed, not just minimized
   expectFullyClosed: app => app.client.waitForExist(selectors.SIDECAR_FULLY_HIDDEN, timeout).then(() => app),

--- a/plugins/plugin-k8s/src/test/k8s1/get-namespaces-with-watch.ts
+++ b/plugins/plugin-k8s/src/test/k8s1/get-namespaces-with-watch.ts
@@ -31,7 +31,12 @@ enum Status {
 }
 
 /** after a cli.do (res), wait for a table row with the given status */
-const waitForStatus = async function(this: common.ISuite, status: Status, res): Promise<string> {
+const waitForStatus = async function(
+  this: common.ISuite,
+  status: Status,
+  nsName: string,
+  res: AppAndCount
+): Promise<string> {
   const selector = await cli.expectOKWithCustom({
     selector: selectors.BY_NAME(nsName)
   })(res)
@@ -45,7 +50,7 @@ const waitForStatus = async function(this: common.ISuite, status: Status, res): 
 /** create namespace, and expect status eventually to be green */
 const createNS = async function(this: common.ISuite, kubectl: string) {
   it(`should create namespace from URL via ${kubectl}`, async () => {
-    const waitForOnline: (res: AppAndCount) => Promise<string> = waitForStatus.bind(this, Status.Online)
+    const waitForOnline: (res: AppAndCount) => Promise<string> = waitForStatus.bind(this, Status.Online, nsName)
 
     try {
       await waitForOnline(await cli.do(`${kubectl} create ns ${nsName}`, this.app))
@@ -59,7 +64,7 @@ const createNS = async function(this: common.ISuite, kubectl: string) {
 const deleteNS = function(this: common.ISuite, kubectl: string) {
   it(`should delete the namespace ${nsName} from URL via ${kubectl}`, async () => {
     try {
-      const waitForOffline: (res: AppAndCount) => Promise<string> = waitForStatus.bind(this, Status.Offline)
+      const waitForOffline: (res: AppAndCount) => Promise<string> = waitForStatus.bind(this, Status.Offline, nsName)
 
       const res = await cli.do(`${kubectl} delete ns ${nsName}`, this.app)
 
@@ -70,8 +75,11 @@ const deleteNS = function(this: common.ISuite, kubectl: string) {
   })
 }
 
-/** drilldown the watch table */
-const testDrilldown = async (name: string, res: AppAndCount) => {
+/**
+ * Drilldown to a given namespace from the watch table
+ *
+ */
+const testDrilldown = async (nsName: string, res: AppAndCount) => {
   const selector = await cli.expectOKWithCustom({
     selector: selectors.BY_NAME(nsName)
   })(res)
@@ -81,7 +89,7 @@ const testDrilldown = async (name: string, res: AppAndCount) => {
   await sidecar
     .expectOpen(res.app)
     .then(sidecar.expectMode(defaultModeForGet))
-    .then(sidecar.expectShowing(name))
+    .then(sidecar.expectShowing(nsName))
 
   await res.app.client.click(selectors.SIDECAR_FULLY_CLOSE_BUTTON)
   await sidecar.expectClosed(res.app)
@@ -91,20 +99,25 @@ const testDrilldown = async (name: string, res: AppAndCount) => {
 const watchNS = function(this: common.ISuite, kubectl: string) {
   const watchCmds = [`${kubectl} get ns -w`, `${kubectl} get ns ${nsName} -w`, `${kubectl} get -w ns ${nsName}`]
 
-  watchCmds.forEach(watchCmd => {
+  watchCmds.forEach((_watchCmd, idx) => {
+    const nsNameForIter = `${nsName}-${idx}`
+    const watchCmd = _watchCmd.replace(nsName, nsNameForIter)
+
+    it('should reload', () => common.refresh(this))
+
     it(`should watch namespaces via ${watchCmd}`, async () => {
       try {
-        const waitForOnline = waitForStatus.bind(this, Status.Online)
-        const waitForOffline = waitForStatus.bind(this, Status.Offline)
+        const waitForOnline = waitForStatus.bind(this, Status.Online, nsNameForIter)
+        const waitForOffline = waitForStatus.bind(this, Status.Offline, nsNameForIter)
 
-        const createBadge = await waitForOnline(await cli.do(`${kubectl} create ns ${nsName}`, this.app))
+        const createBadge = await waitForOnline(await cli.do(`${kubectl} create ns ${nsNameForIter}`, this.app))
 
         const testWatch = await cli.do(watchCmd, this.app)
         const watchBadge = await waitForOnline(testWatch)
         const watchBadgeButOffline = watchBadge.replace(Status.Online, Status.Offline)
-        await testDrilldown(nsName, testWatch)
+        await testDrilldown(nsNameForIter, testWatch)
 
-        const deleteBadge = await waitForOffline(await cli.do(`${kubectl} delete ns ${nsName}`, this.app))
+        const deleteBadge = await waitForOffline(await cli.do(`${kubectl} delete ns ${nsNameForIter}`, this.app))
 
         // the create and delete badges had better still exist
         await this.app.client.waitForExist(createBadge)
@@ -118,7 +131,7 @@ const watchNS = function(this: common.ISuite, kubectl: string) {
         await this.app.client.waitForExist(watchBadgeButOffline)
 
         // create again
-        await waitForOnline(await cli.do(`${kubectl} create ns ${nsName}`, this.app))
+        await waitForOnline(await cli.do(`${kubectl} create ns ${nsNameForIter}`, this.app))
 
         // the "online" badge from the watch had better now exist again after the create
         // (i.e. we had better actually be watching!)
@@ -128,7 +141,7 @@ const watchNS = function(this: common.ISuite, kubectl: string) {
         await this.app.client.waitForExist(watchBadgeButOffline, 20000, true)
 
         // delete again
-        await waitForOffline(await cli.do(`${kubectl} delete ns ${nsName}`, this.app))
+        await waitForOffline(await cli.do(`${kubectl} delete ns ${nsNameForIter}`, this.app))
 
         // the "online" badge from the watch had better *NOT* exist after the delete
         // (i.e. we had better actually be watching!)


### PR DESCRIPTION
this was probably two things: namespace deletion conflicts, and the grabFocus method in the core test utility was clicking on the prompt block, not the prompt

Fixes #2757

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
