### PR TITLE
fix(plugins/plugin-k8s): commands resulting in an empty watch table fail to watch for updates

### DIFF
--- a/packages/app/src/webapp/cli.ts
+++ b/packages/app/src/webapp/cli.ts
@@ -41,6 +41,7 @@ import { ExecOptions, DefaultExecOptions, ParsedOptions } from '../models/execOp
 import * as historyModel from '../models/history'
 import { CodedError, isCodedError } from '../models/errors'
 import { Table, isTable, MultiTable, isMultiTable } from './models/table'
+import { isWatchable } from './models/basicModels'
 
 import { element, removeAllDomChildren } from './util/dom'
 import { prettyPrintTime } from './util/time'
@@ -1149,7 +1150,7 @@ export const printResults = (
   let promise: Promise<boolean>
 
   // print ok if it's an empty table
-  if (isTable(response) && response.body.length === 0) {
+  if (!isWatchable(response) && isTable(response) && response.body.length === 0) {
     response = true
   }
 

--- a/packages/app/src/webapp/views/table.ts
+++ b/packages/app/src/webapp/views/table.ts
@@ -100,7 +100,7 @@ const hasReachedFinalState = (response: Table | MultiTable): boolean => {
   let reachedFinalState = false
 
   if (isTable(response)) {
-    if (!response.body.some(row => !row.done)) {
+    if (response.body.length !== 0 && response.body.every(row => row.done)) {
       reachedFinalState = true // stop watching if all resources have reached to the finial state
     }
 


### PR DESCRIPTION
Fixes #2737

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
