### PR TITLE
feat(plugins/plugin-k8s): improve sidecar events table

### DIFF
--- a/packages/app/src/webapp/views/table.ts
+++ b/packages/app/src/webapp/views/table.ts
@@ -339,6 +339,32 @@ function formatIcon(fontawesome: string, cell: HTMLElement) {
   }
 }
 
+const formatCellValue = (key: string, value: string) => {
+  const dateKey = { 'FIRST SEEN': true, 'LAST SEEN': true }
+  /**
+   * Compute the differece between the timestamp and the current time
+   * And format the output in: hours minutes, or minutes seconds
+   *
+   */
+  const formatAge = (value: string) => {
+    const timestamp = new Date(value).getTime()
+    if (isNaN(timestamp)) {
+      return value
+    }
+
+    const ms = Date.now() - timestamp
+    const s = 1000 * Math.round(ms / 1000) // round to nearest second
+    const d = new Date(s)
+    const hours = d.getUTCHours() > 0 ? `${d.getUTCHours()}h` : ''
+    const minutes = d.getUTCMinutes() > 0 ? `${d.getUTCMinutes()}m` : ''
+    const seconds = d.getUTCSeconds() > 0 ? `${d.getUTCSeconds()}s` : ''
+
+    return hours ? `${hours}${minutes}` : `${minutes}${seconds}`
+  }
+
+  return dateKey[key] && !dateKey[value] ? formatAge(value) : value
+}
+
 /**
  * Format one row in the table
  *
@@ -563,8 +589,11 @@ export const formatOneRowResult = (tab: Tab, options: RowFormatOptions = {}) => 
     } else if (value !== undefined) {
       // value could be an empty string
       Promise.resolve(value).then(value => {
-        inner.title = value
-        inner.appendChild(document.createTextNode(isHeaderCell ? value.toLowerCase() : value || '\u00a0'))
+        const formatedValue = formatCellValue(key, value)
+        inner.title = formatedValue
+        inner.appendChild(
+          document.createTextNode(isHeaderCell ? formatedValue.toLowerCase() : formatedValue || '\u00a0')
+        )
       })
     } else {
       console.error('Invalid cell model, no value field', theCell)

--- a/plugins/plugin-k8s/i18n/resources_en_US.json
+++ b/plugins/plugin-k8s/i18n/resources_en_US.json
@@ -20,6 +20,7 @@
   "logs": "logs",
   "containers": "containers",
   "events": "events",
+  "No resources found.": "No resources found.",
   "allContexts": "Resources Across All Contexts",
   "currentContext": "This is your current context",
   "notCurrentContext": "This is not your current context"

--- a/plugins/plugin-k8s/src/test/k8s2/events.ts
+++ b/plugins/plugin-k8s/src/test/k8s2/events.ts
@@ -75,6 +75,15 @@ describe(`kubectl get events ${process.env.MOCHA_RUN_TARGET || ''}`, function(th
         await this.app.client.waitForVisible(selectors.SIDECAR_MODE_BUTTON('events'))
         await this.app.client.click(selectors.SIDECAR_MODE_BUTTON('events'))
         await this.app.client.waitForExist(selectors.SIDECAR_MODE_BUTTON_SELECTED('events'))
+
+        // test events table has correct header
+        const header = ['TYPE', 'REASON', 'LAST SEEN', 'FIRST SEEN', 'FROM', 'MESSAGE']
+        header.forEach(async _header => {
+          await this.app.client.waitForExist(
+            `${selectors.SIDECAR_CUSTOM_CONTENT} .result-table .header-row .header-cell .cell-inner[data-key="${_header}"]`
+          )
+        })
+
         await this.app.client.waitForExist(
           `${selectors.SIDECAR_CUSTOM_CONTENT} .result-table badge[data-key="REASON"].yellow-background`
         )


### PR DESCRIPTION
Fixes #2800

This PR enhances the `Events` table in Sidecar by making the content compliant with the one in `kubectl describe` output. This PR removed `Object` Column and added `Count, First Seen, and From` Columns, which are the `Event Age` in `kubectl describe`.

Before:
 
![Screen Shot 2019-09-17 5 49 30 PM](https://user-images.githubusercontent.com/21212160/65082294-940f2e00-d973-11e9-83cc-98abda42d6f7.png)

After:
![Screen Shot 2019-09-17 5 48 47 PM](https://user-images.githubusercontent.com/21212160/65082307-9b363c00-d973-11e9-8893-b8d4485c73d2.png)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
