### PR TITLE
fix(packages/core): Commands.Registrar.synonym should have the option…

### DIFF
--- a/packages/core/src/models/command.ts
+++ b/packages/core/src/models/command.ts
@@ -251,7 +251,7 @@ type CommandListener = (route: string, handler: CommandHandler, options?: Comman
 export interface CommandRegistrar {
   find: (route: string, noOverride?: boolean) => Promise<Command>
   listen: CommandListener
-  synonym: (route: string, handler: CommandHandler, master: Command, options: CommandOptions) => void
+  synonym: (route: string, handler: CommandHandler, master: Command, options?: CommandOptions) => void
   subtree: (route: string, options: CommandOptions) => Command
   subtreeSynonym: (route: string, masterTree: Command, options?: CommandOptions) => void
 }


### PR DESCRIPTION
…s as optional

Fixes #2909

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
