### PR TITLE
feat: publish kui-base electron distributions

### DIFF
--- a/packages/builder/dist/publishers/s3/push-cos.js
+++ b/packages/builder/dist/publishers/s3/push-cos.js
@@ -12,6 +12,8 @@ const {
   theme: { productName }
 } = require('../../../../../node_modules/@kui-shell/settings/config.json')
 
+const kuiBaseName = 'Kui-base'
+
 const version = process.argv[2]
 
 const Bucket = process.env.S3_BUCKET || `kui-${version}`
@@ -24,6 +26,11 @@ const platformBuilds = [
   `${productName}-win32-x64.zip`,
   `${productName}.dmg`,
   `${productName}-darwin-x64.tar.bz2`,
+  `${kuiBaseName}-linux-x64.deb`,
+  `${kuiBaseName}-linux-x64.zip`,
+  `${kuiBaseName}-win32-x64.zip`,
+  `${kuiBaseName}.dmg`,
+  `${kuiBaseName}-darwin-x64.tar.bz2`,
   `${productName}-headless.zip`,
   `${productName}-headless.tar.bz2`
 ]


### PR DESCRIPTION
!important!: This PR won't publish Kui-base correctly without https://github.com/IBM/kui/pull/2938, since the PR assumes Kui-base electron distribution is built with name `Kui-base-<platform>-<arch>`.

Fixes #2939 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.