### PR TITLE
fix: user-installed plugins cannot always REPL.qexec other plugins

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,6 +9,7 @@ packages/core/index.js
 packages/core/api/
 packages/core/dist/
 packages/core/core/
+packages/core/commands/
 packages/core/main/
 packages/core/models/
 packages/core/plugins/
@@ -21,3 +22,5 @@ plugins/*/dist/
 **/*/node_modules/
 **/*.d.ts
 plugins/plugin-apache-composer/tests/data/composer/composer-source-expect-errors/if-bad.js
+kui-stage
+*flycheck*.js

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -2,6 +2,7 @@ build
 dist
 /api/
 /core/
+/commands/
 /main/
 /models/
 /plugins/

--- a/packages/core/src/api/commands.ts
+++ b/packages/core/src/api/commands.ts
@@ -28,6 +28,7 @@ import * as Plugins from '../models/plugin'
 import * as Entity from '../models/entity'
 import * as Sidecar from '../webapp/views/sidecar'
 import { optionsToString } from '@kui-shell/core/core/utility'
+import * as Context from '../commands/context'
 
 export namespace Commands {
   export import Arguments = _Commands.EvaluatorArgs
@@ -38,6 +39,8 @@ export namespace Commands {
   export import DefaultExecOptions = _ExecOptions.DefaultExecOptions
   export import ExecOptions = _ExecOptions.ExecOptions
   export import withLanguage = _ExecOptions.withLanguage
+
+  export import getCurrentContext = Context.getCurrentContext
 
   export import ExecType = _Commands.ExecType
   export import Registrar = _Commands.CommandRegistrar

--- a/packages/core/src/commands/context.ts
+++ b/packages/core/src/commands/context.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-19 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { theme } from '../core/settings'
+
+/**
+ * Parse a serialized command context
+ *
+ */
+function parseCommandContext(str: string): string[] {
+  if (str) {
+    try {
+      // let's assume str is of the form '["a", "b"]'
+      return JSON.parse(str)
+    } catch (err1) {
+      // ok, that didn't work; let's see if it's of the form '/a/b'
+      try {
+        return str.split('/').filter(_ => _)
+      } catch (err2) {
+        console.error(`Could not parse command context ${str}`, err1, err2)
+      }
+    }
+  }
+  return undefined
+}
+
+/**
+ * The default command execution context. For example, if the
+ * execution context is /foo/bar, and there is a command /foo/bar/baz,
+ * then the issuance of a command "baz" will resolve to /foo/bar/baz.
+ *
+ * The default can be overridden either by changing the next line, or
+ * by calling `setDefaultCommandContext`.
+ *
+ */
+let _defaultContext: string[] =
+  (theme && theme.defaultContext) || parseCommandContext(process.env.KUI_COMMAND_CONTEXT) || []
+
+/**
+ * The command context model, defaulting to the _defaultContext, which
+ * can be overridden via `setDefaultCommandContext`.
+ *
+ */
+export const Context = {
+  current: _defaultContext
+}
+
+/**
+ * When commands are executed, the command resolver will use a
+ * fallback prefix. This routine tries to discover, from the
+ * environment, what the default fallback prefix should be.
+ *
+ */
+export const setDefaultCommandContext = (commandContext: string[]) => {
+  Context.current = _defaultContext = commandContext
+}
+
+export function getCurrentContext() {
+  return Context.current
+}

--- a/packages/core/src/commands/resolution.ts
+++ b/packages/core/src/commands/resolution.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-19 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommandHandlerWithEvents, CommandTreeResolution } from '../models/command'
+
+/**
+ * A call to `read` may or may not have successfully resolved the
+ * given `argv.` This method clarifies the situation.
+ *
+ */
+export function isSuccessfulCommandResolution(
+  resolution: CommandTreeResolution
+): resolution is CommandHandlerWithEvents {
+  return (resolution as CommandHandlerWithEvents).eval !== undefined
+}

--- a/packages/core/src/commands/tree.ts
+++ b/packages/core/src/commands/tree.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2017-19 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CatchAllHandler, Command, CommandTree, CommandTreeResolution, Disambiguator } from '../models/command'
+
+import { ExecOptions } from '../models/execOptions'
+
+/**
+ * The exported interface around the internal command model
+ * implementation.
+ *
+ */
+interface CommandModel {
+  catchalls: CatchAllHandler[]
+
+  /**
+   * Look up a command handler for the given `argv`. This is the main
+   * Read part of a REPL.
+   *
+   */
+  read(argv: string[], execOptions: ExecOptions): Promise<CommandTreeResolution>
+
+  /**
+   * Call the given callback function `fn` for each node in the command tree
+   *
+   */
+  forEachNode(fn: (command: Command) => void): void
+}
+
+/**
+ * The internal implementation of the command tree
+ *
+ */
+export class CommandModelImpl implements CommandModel {
+  /** root of the tree model */
+  private readonly _root: CommandTree = this.newTree()
+  public get root(): CommandTree {
+    return this._root
+  }
+
+  /** map from command name to disambiguations */
+  private readonly _disambiguator: Disambiguator = {}
+  public get disambiguator(): Disambiguator {
+    return this._disambiguator
+  }
+
+  /** handlers for command not found */
+  private readonly _catchalls: CatchAllHandler[] = []
+  public get catchalls(): CatchAllHandler[] {
+    return this._catchalls
+  }
+
+  /**
+   * Look up a command handler for the given `argv`. This is the main
+   * Read part of a REPL.
+   *
+   */
+  public async read(argv: string[], execOptions: ExecOptions): Promise<CommandTreeResolution> {
+    const { read: readImpl } = await import('../core/command-tree')
+    return readImpl(this.root, argv, undefined, undefined, execOptions)
+  }
+
+  /**
+   * Call the given callback function `fn` for each node in the command tree
+   *
+   */
+  public forEachNode(fn: (command: Command) => void) {
+    const iter = (root: Command) => {
+      if (root) {
+        fn(root)
+        if (root.children) {
+          for (const cmd in root.children) {
+            iter(root.children[cmd])
+          }
+        }
+      }
+    }
+
+    iter(this.root)
+  }
+
+  private newTree(): CommandTree {
+    return {
+      $: undefined,
+      key: '/',
+      route: '/',
+      children: {},
+      parent: undefined
+    }
+  }
+}
+
+interface WindowWithModel extends Window {
+  _kuiCommandModel: CommandModelImpl
+}
+
+function isWindowWithModel(win: Window): win is WindowWithModel {
+  return win && (win as WindowWithModel)._kuiCommandModel !== undefined
+}
+
+/**
+ * Global state representing the current tree of registered commands
+ *
+ */
+let theCommandModel: CommandModelImpl
+
+/**
+ * @return the command tree model for internal consumption within this
+ * file
+ *
+ */
+export function getModelInternal(): CommandModelImpl {
+  return (typeof window !== 'undefined' && isWindowWithModel(window) && window._kuiCommandModel) || theCommandModel
+}
+
+/**
+ * @return the command tree model for public consumption within the
+ * rest of @kui-shell/core. For the model we present to plugins, see
+ * `ImplForPlugins` in command-tree.ts
+ *
+ */
+export function getModel(): CommandModel {
+  return getModelInternal()
+}
+
+interface WindowWithModel extends Window {
+  _kuiCommandModel: CommandModelImpl
+}
+
+export function init() {
+  theCommandModel = new CommandModelImpl()
+
+  if (typeof window !== 'undefined') {
+    ;((window as any) as WindowWithModel)._kuiCommandModel = theCommandModel
+  }
+}
+
+export function initIfNeeded() {
+  if (!theCommandModel) {
+    init()
+  }
+}

--- a/packages/core/src/core/repl.ts
+++ b/packages/core/src/core/repl.ts
@@ -41,7 +41,6 @@ import { ExecOptions, DefaultExecOptions, DefaultExecOptionsForTab } from '../mo
 import eventBus from './events'
 import historyModel from '../models/history'
 import { CodedError } from '../models/errors'
-import * as commandTree from './command-tree'
 import { UsageError, UsageModel, UsageRow } from './usage-error'
 
 import { isHeadless, hasLocalAccess } from './capabilities'
@@ -49,6 +48,9 @@ import { streamTo as headlessStreamTo } from '../main/headless-support' // FIXME
 import { isHTML } from '../util/types'
 import { promiseEach } from '../util/async'
 import SymbolTable from './symbol-table'
+
+import { getModel } from '../commands/tree'
+import { isSuccessfulCommandResolution } from '../commands/resolution'
 
 import * as cli from '../webapp/cli'
 
@@ -375,9 +377,9 @@ class InProcessExecutor implements Executor {
 
       // the Read part of REPL
       const argvNoOptions = argv.filter(_ => _.charAt(0) !== '-')
-      const evaluator: CommandTreeResolution = await commandTree.read(argvNoOptions, false, false, execOptions)
+      const evaluator: CommandTreeResolution = await getModel().read(argvNoOptions, execOptions)
 
-      if (commandTree.isSuccessfulCommandResolution(evaluator)) {
+      if (isSuccessfulCommandResolution(evaluator)) {
         //
         // fetch the usage model for the command
         //

--- a/packages/core/src/plugins/assembler.ts
+++ b/packages/core/src/plugins/assembler.ts
@@ -23,7 +23,8 @@ import { assemble } from './scanner'
 import { PrescanCommandDefinitions, PrescanDocs, PrescanNode, PrescanModel, PrescanUsage } from './prescan'
 
 import eventBus from '../core/events'
-import { getModel, cullFromDisambiguator } from '../core/command-tree'
+import { cullFromDisambiguator } from '../core/command-tree'
+import { initIfNeeded, getModel } from '../commands/tree'
 
 const debug = Debug('core/plugins/assembler')
 
@@ -158,6 +159,7 @@ export const compile = async (
   debug('pluginRoot is %s', pluginRoot)
   debug('externalOnly is %s', externalOnly)
 
+  initIfNeeded()
   const modules = await assemble(plugins.registrar, { externalOnly, pluginRoot })
   debug('modules', modules)
 

--- a/packages/core/src/plugins/commands.ts
+++ b/packages/core/src/plugins/commands.ts
@@ -31,8 +31,8 @@ export default async function commandsOffered(plugin?: string): Promise<Tables.T
   const pluginIsInstalled = !!flat.find(({ route }) => route === plugin)
 
   if (!pluginIsInstalled) {
-    const err = new Error(`Plugin ${plugin} is not installed`)
-    err['code'] = 404
+    const err = new Error(`Plugin ${plugin} is not installed`) as Errors.CodedError
+    err.code = 404
     throw err
   }
 

--- a/packages/core/src/plugins/plugins.ts
+++ b/packages/core/src/plugins/plugins.ts
@@ -80,7 +80,7 @@ export async function userInstalledHome() {
  *
  * @return truthy value if we indeed did the initialization
  */
-export const init = async () => {
+export const init = async (): Promise<boolean> => {
   debug('init')
 
   if (prescan) {

--- a/packages/core/src/plugins/resolver.ts
+++ b/packages/core/src/plugins/resolver.ts
@@ -166,4 +166,4 @@ export const makeResolver = (prescan: PrescanModel, registrar: Record<string, Ku
   } /* resolver */
 
   return resolver
-} /* makeResolver */
+}

--- a/packages/core/src/webapp/bootstrap/boot.ts
+++ b/packages/core/src/webapp/bootstrap/boot.ts
@@ -25,6 +25,11 @@ function catastrophe(err: Error) {
   document.body.classList.add('oops-total-catastrophe')
 }
 
+async function initCommandRegistrar() {
+  const { init } = await import('../../commands/tree')
+  await init()
+}
+
 // note: the q npm doesn't like functions called "bootstrap"!
 const domReady = () => async () => {
   const initializer = import('./init')
@@ -36,11 +41,14 @@ const domReady = () => async () => {
   // const query = import('../query')
 
   try {
-    const waitForThese = []
+    const waitForThese: Promise<void>[] = []
+
+    const commands = initCommandRegistrar()
 
     waitForThese.push(
       plugins.then(async _ => {
         await _.init()
+        await commands
         await _.preload()
       })
     )

--- a/plugins/plugin-manager/src/controller/list.ts
+++ b/plugins/plugin-manager/src/controller/list.ts
@@ -64,16 +64,8 @@ const doList = async (): Promise<Tables.Table> => {
   debug('command execution started', moduleDir)
 
   const pjson = join(moduleDir, 'package.json')
-  try {
-    await pathExists(moduleDir)
-    await pathExists(pjson)
-  } catch (error) {
-    const err = error as Errors.CodedError<string>
-    if (err.code === 'ENOENT') {
-      // this error is OK; it just means that moduleDir
-      // doesn't exist, so there are no plugins to list!
-      throw new Error(strings('No user-installed plugins found'))
-    }
+  if (!(await pathExists(pjson))) {
+    throw new Error(strings('No user-installed plugins found'))
   }
 
   const { dependencies } = (await readJSON(pjson)) as { dependencies: Record<string, string> }

--- a/plugins/plugin-openwhisk/src/lib/models/auth.ts
+++ b/plugins/plugin-openwhisk/src/lib/models/auth.ts
@@ -17,8 +17,7 @@
 import Debug from 'debug'
 import * as openwhisk from 'openwhisk'
 
-import { getDefaultCommandContext } from '@kui-shell/core/core/command-tree'
-import { Capabilities, Models, Settings, Util } from '@kui-shell/core'
+import { Capabilities, Commands, Models, Settings, Util } from '@kui-shell/core'
 
 const debug = Debug('plugins/openwhisk/models/auth')
 
@@ -131,7 +130,7 @@ export const initOW = () => {
   ow = initOWFromConfig(owConfig)
   return ow
 }
-if (getDefaultCommandContext()[0] === 'wsk' && getDefaultCommandContext()[1] === 'action') {
+if (Commands.getCurrentContext()[0] === 'wsk' && Commands.getCurrentContext()[1] === 'action') {
   initOW()
 }
 

--- a/plugins/plugin-openwhisk/src/test/openwhisk4/invoke-non-existent-action.ts
+++ b/plugins/plugin-openwhisk/src/test/openwhisk4/invoke-non-existent-action.ts
@@ -46,8 +46,8 @@ describe('Check error handling for invoking a non-existent action', function(thi
       .then(ReplExpect.error(404))
       .catch(Common.oops(this)))
 
-  it('invoke with a non-existent package, but existing action name, via kui action invoke', () =>
-    CLI.command(`kui action invoke xxxxxx/${actionName}`, this.app)
+  it('invoke with a non-existent package, but existing action name, via fdsfasdjfioajdsfioads action invoke', () =>
+    CLI.command(`fdsfasdjfioajdsfioads action invoke xxxxxx/${actionName}`, this.app)
       .then(ReplExpect.error(404))
       .catch(Common.oops(this)))
 


### PR DESCRIPTION
this PR also refactors the command-tree logic, cleaning up some of the oldest (and poorest) code. the cleanup is almost entirely code shuffling and comment adding.

Fixes #2963

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
