### PR TITLE
fix(packages/builder): linux packaging issues

### DIFF
--- a/clients/base/package.json
+++ b/clients/base/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "The base of Kui client definition",
   "scripts": {
-    "preinstall": "rm -rf node_modules; if [ ! -d /tmp/kui-packs ]; then (cd ../../ && npm run pack); fi",
+    "preinstall": "rm -rf node_modules; cd ../../ && npm run pack",
     "build:electron": "build() { npx --no-install kui-build-electron /tmp $1 Kui-base; }; build"
   },
   "author": "Mengting Yan",

--- a/packages/builder/dist/electron/build.sh
+++ b/packages/builder/dist/electron/build.sh
@@ -210,8 +210,11 @@ function win32 {
 	    --win32metadata.CompanyName="Apache" \
 	    --win32metadata.ProductName="${PRODUCT_NAME}")
 
-      # we want the electron app name to be PRODUCT_NAME, but the app to be in <CLIENT_NAME>-<platform>-<arch>
-      mv "$BUILDDIR/${PRODUCT_NAME}-win32-x64/" "$BUILDDIR/${CLIENT_NAME}-win32-x64/"
+	# we want the electron app name to be PRODUCT_NAME, but the app to be in <CLIENT_NAME>-<platform>-<arch>
+	if [ "${PRODUCT_NAME}" != "${CLIENT_NAME}" ]; then
+	    rm -rf "$BUILDDIR/${CLIENT_NAME}-win32-x64/"
+	    mv "$BUILDDIR/${PRODUCT_NAME}-win32-x64/" "$BUILDDIR/${CLIENT_NAME}-win32-x64/"
+	fi
 
         #
         # deal with win32 packaging
@@ -255,7 +258,10 @@ function mac {
         cp $ICON_MAC "$BUILDDIR/${PRODUCT_NAME}-darwin-x64/${PRODUCT_NAME}.app/Contents/Resources/electron.icns"
 
         # we want the electron app name to be PRODUCT_NAME, but the app to be in <CLIENT_NAME>-<platform>-<arch>
-        mv "$BUILDDIR/${PRODUCT_NAME}-darwin-x64/" "$BUILDDIR/${CLIENT_NAME}-darwin-x64/"
+	if [ "${PRODUCT_NAME}" != "${CLIENT_NAME}" ]; then
+	    rm -rf "$BUILDDIR/${CLIENT_NAME}-darwin-x64/"
+            mv "$BUILDDIR/${PRODUCT_NAME}-darwin-x64/" "$BUILDDIR/${CLIENT_NAME}-darwin-x64/"
+	fi
 
         # create the installers
         #if [ -n "$ZIP_INSTALLER" ]; then
@@ -309,8 +315,11 @@ function linux {
             --icon=$ICON_LINUX \
 	    --overwrite)
 
-      # we want the electron app name to be PRODUCT_NAME, but the app to be in <CLIENT_NAME>-<platform>-<arch>
-      mv "$BUILDDIR/${PRODUCT_NAME}-linux-x64/" "$BUILDDIR/${CLIENT_NAME}-linux-x64/"
+	# we want the electron app name to be PRODUCT_NAME, but the app to be in <CLIENT_NAME>-<platform>-<arch>
+	if [ "${PRODUCT_NAME}" != "${CLIENT_NAME}" ]; then
+	    rm -rf "$BUILDDIR/${CLIENT_NAME}-linux-x64/"
+	    mv "$BUILDDIR/${PRODUCT_NAME}-linux-x64/" "$BUILDDIR/${CLIENT_NAME}-linux-x64/"
+	fi
 
         if [ -z "$NO_INSTALLER" ]; then
             echo "Zip build for linux"

--- a/packages/builder/dist/electron/dpkg-config.json
+++ b/packages/builder/dist/electron/dpkg-config.json
@@ -1,4 +1,4 @@
 {
-  "name": "kui",
-  "bin": "kui"
+  "name": "Kui",
+  "bin": "Kui"
 }


### PR DESCRIPTION
1) the `mv` command on all platforms fails if PRODUCT_NAME=CLIENT_NAME
2) on linux, the deb builders fail because our dpkg-config.json names "kui" with a lowercase k

Fixes #2968

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
