### PR TITLE
fix(packages/core): eliminate repl/exec -> spawn-electron import path

### DIFF
--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -721,18 +721,8 @@ class InProcessExecutor implements Executor {
     } catch (err) {
       const e = err as CodedError
 
-      if (isHeadless() && e.code !== 404) {
-        try {
-          debug('attempting to run the command graphically', e)
-          const command = commandUntrimmed.trim().replace(patterns.commentLine, '')
-          const argv = split(command)
-          await import('../main/spawn-electron').then(({ initElectron }) =>
-            initElectron(argv, { forceUI: true }, true, { fullscreen: true })
-          )
-        } catch (err) {
-          debug('nope, we failed to run the command graphically')
-          console.error(err)
-        }
+      if (e.code !== 404) {
+        console.error(err)
       }
 
       if (execOptions && execOptions.failWithUsage) {


### PR DESCRIPTION
this should resolve an issue with spawn-electron's dependence on electron-context-menu, which has a dependence on cli-truncate that (with v2.0.0 of cli-truncate) is no longer compatible with edge.

Fixes #3014

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
