### PR TITLE
fix(packages/core): kui hangs if prescan references non-existent plugin

### DIFF
--- a/packages/core/src/plugins/resolver.ts
+++ b/packages/core/src/plugins/resolver.ts
@@ -64,6 +64,8 @@ const prequire = async (
             console.error(`prequire error ${route}`, err)
             reject(err)
           }
+        } else {
+          reject(new Error('Internal error: plugin not found'))
         }
       })
     }


### PR DESCRIPTION
Fixes #3018

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
