### PR TITLE
fix(packages/core): adjust REPL tables to be a bit more standard

### DIFF
--- a/packages/core/web/css/kui-tables.css
+++ b/packages/core/web/css/kui-tables.css
@@ -36,7 +36,9 @@
   /* for Light tables, there is no th background color, thus no need for extra space */
   padding-top: 0;
   padding-bottom: 0;
-  font-weight: bold;
+  font-weight: 300;
+  color: var(--color-text-02);
+  text-transform: uppercase;
 }
 [kui-theme-style] .repl .bx--data-table:not([kui-table-style="Light"]) th.header-cell {
   border-bottom: none;
@@ -58,7 +60,6 @@
 [kui-theme-style] .result-table-title-outer {
   background-color: transparent;
   color: var(--color-name);
-  padding: 0.6875em 0;
 }
 .result-as-multi-table .result-table-outer-wrapper:first-child .result-table-title-outer {
   padding-top: 0;
@@ -82,9 +83,7 @@ sidecar .result-table[kui-table-style="Light"] .header-cell .cell-inner {
 .header-cell:not(:first-child) .cell-inner {
   border-left: 1px solid var(--color-table-border3);
 }
-.log-lines .header-cell,
-.repl .result-as-table .result-table[kui-table-style="Light"] .header-row .header-cell,
-.repl .result-as-table.result-table[kui-table-style="Light"] .header-row .header-cell {
+.log-lines .header-cell {
   border-bottom: 1px solid var(--color-content-divider);
 }
 
@@ -243,10 +242,6 @@ sidecar .log-lines[kui-table-style="Light"] .log-line,
 .repl .bx--data-table[kui-table-style="Light"] .entity-attributes > th .cell-inner,
 .repl .bx--data-table[kui-table-style="Light"] .entity-attributes > td .cell-inner {
   border: none;
-}
-.repl .bx--data-table[kui-table-style="Light"] badge {
-  height: 1.75em;
-  line-height: 1.75em;
 }
 .result-as-table .result-table-outer[kui-table-style="Light"] .result-table-title,
 .result-as-table .result-table-outer[kui-table-style="Medium"] .result-table-title {

--- a/packages/core/web/css/top-tab-stripe.css
+++ b/packages/core/web/css/top-tab-stripe.css
@@ -119,9 +119,6 @@ body.subwindow:not(.sidecar-is-minimized) .left-tab-stripe {
 body.not-electron .repl-input {
   padding-left: 0.375rem;
 }
-.repl .repl-block:not(.processing) .result-as-table .repl-result:not(:empty):not(.result-vertical) {
-  padding: 0.625em 1.25em 0;
-}
 .repl-prompt-right-elements {
   padding-right: 0.375rem;
 }


### PR DESCRIPTION
this PR adjusts the table rendering in the repl to look more conventionally like a console, while keeping the badge and clickable decorations

the changes are limited to: row height; table padding; and header presentation (bottom border, font weight, font color, and all-caps)

Fixes #3036

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
