### PR TITLE
fix(plugins/plugin-k8s): latest and previous logs labels are translated but not externalized

### DIFF
--- a/plugins/plugin-k8s/src/lib/controller/kubectl.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kubectl.ts
@@ -241,7 +241,7 @@ const executeLocally = (command: string) => (opts: Commands.Arguments<Options>) 
       options.o ||
       (command === 'helm' && verb === 'get' && 'yaml') || // helm get seems to spit out yaml without our asking
         (isKube && verb === 'describe' && 'yaml') ||
-        (isKube && verb === 'logs' && 'Latest') ||
+        (isKube && verb === 'logs' && 'latest') ||
         (isKube && verb === 'get' && execOptions.raw && 'json'))
 
     if (
@@ -566,6 +566,7 @@ const executeLocally = (command: string) => (opts: Commands.Arguments<Options>) 
         if (verb === 'logs') {
           modes.push({
             mode: 'previous',
+            label: strings('previous'),
             direct: `${rawCommand} --previous`,
             execOptions: {
               exec: 'pexec'


### PR DESCRIPTION
Fixes #3038

i18n after fix:
![image](https://user-images.githubusercontent.com/21212160/67112296-dca14d80-f1a4-11e9-8dc3-09fe031448f9.png)


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
