### PR TITLE
fix(plugins/plugin-editor): syntax coloring not always active

### DIFF
--- a/plugins/plugin-editor/src/lib/open.ts
+++ b/plugins/plugin-editor/src/lib/open.ts
@@ -44,7 +44,7 @@ const setText = (editor: MonacoEditor.ICodeEditor, options, execOptions?) => ({
 }) => {
   // options is --language yaml command line
   // execOptions is side channel progmmatic information passed via repl.exec
-  const lang: string = (options && options.language) || (execOptions && execOptions.language) || language(kind)
+  const lang: string = (options && options.language) || language(kind)
   debug('setText language', kind, lang)
   debug('setText code', code.substring(0, 20))
 


### PR DESCRIPTION
Fixes #3043

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
