### PR TITLE
feat(packages/core): plugin commands table should support command prefix

### DIFF
--- a/packages/core/src/plugins/commands.ts
+++ b/packages/core/src/plugins/commands.ts
@@ -78,7 +78,7 @@ export default async function commandsOffered(plugin?: string): Promise<Tables.T
       .filter(_ => !_.usage || (!_.usage.synonymFor && !_.usage.children))
       .map(({ command, name }) => ({
         type: 'command',
-        name,
+        name: process.env.KUI_BIN_PREFIX_FOR_COMMANDS ? `${process.env.KUI_BIN_PREFIX_FOR_COMMANDS} ${name}` : name,
         attributes: [{ key: 'about', value: docs[command] }],
         onclick: name
       }))


### PR DESCRIPTION
this PR adds support for process.env.KUI_BIN_PREFIX_FOR_COMMANDS. if set, then the commands table rows will prefix all command strings with that given prefix

Fixes #3070

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
