### PR TITLE
fix(packages/core): A11y - Make clickable table names focusable

### DIFF
--- a/packages/core/src/webapp/views/table.ts
+++ b/packages/core/src/webapp/views/table.ts
@@ -415,6 +415,7 @@ export const formatOneRowResult = (tab: Tab, options: RowFormatOptions = {}) => 
   entityNameClickable.className = 'entity-name cell-inner'
   if (!isHeaderCell) {
     entityNameClickable.classList.add('clickable')
+    entityNameClickable.setAttribute('tabindex', '0')
   } else {
     entityNameClickable.classList.add('bx--table-header-label')
   }


### PR DESCRIPTION
Fixes https://github.com/IBM/kui/issues/2507

#### Description of what you did:

Last item left on accessibility defect list from this issue:  https://github.com/IBM/kui/issues/2507 (`Table results (kubectl get pods) aren't accessible via tab`).  Makes clickable table names focusable with keyboard navigation.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
