### PR TITLE
fix(packages/core) make fancy help menu buttons focusable

### DIFF
--- a/packages/core/src/core/usage-error.ts
+++ b/packages/core/src/core/usage-error.ts
@@ -608,6 +608,7 @@ const format = async (message: UsageLike, options: UsageOptions = new DefaultUsa
           if (!noclick) {
             cmdPart.classList.add('clickable')
             cmdPart.classList.add('clickable-blatant')
+            cmdPart.setAttribute('tabindex', '0')
             cmdPart.onclick = async event => {
               const Prompt = await import('../webapp/prompt')
               const { getCurrentTab } = await import('../webapp/tab')


### PR DESCRIPTION
Fixes https://github.com/IBM/kui/issues/3077

#### Description of what you did:

Fancy UI CLI help menu buttons were not able to receive focus, this PR allows those buttons to be accessed by keyboard users.

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
