### PR TITLE
fix(plugins/plugin-editor): A11y - fix sidecar editor tooltip contrast issue

### DIFF
--- a/plugins/plugin-editor/web/css/editor.css
+++ b/plugins/plugin-editor/web/css/editor.css
@@ -130,3 +130,8 @@ body[kui-theme-style] .monaco-editor .selected-text {
   transition: background 300ms ease-in-out;
   background: var(--color-selection-background);
 }
+
+/* tooltip text is unreadble */
+.monaco-editor .monaco-editor-hover .hover-row p {
+  color: #171717;
+}

--- a/plugins/plugin-editor/web/css/editor.css
+++ b/plugins/plugin-editor/web/css/editor.css
@@ -133,5 +133,6 @@ body[kui-theme-style] .monaco-editor .selected-text {
 
 /* tooltip text is unreadble */
 .monaco-editor .monaco-editor-hover .hover-row p {
-  color: #171717;
+  background: var(--color-sidecar-toolbar-background);
+  color: var(--color-sidecar-toolbar-foreground);
 }


### PR DESCRIPTION
Fixes https://github.com/IBM/kui/issues/3075

#### Description of what you did:

Before:
<img width="254" alt="Screen Shot 2019-10-22 at 3 37 58 PM" src="https://user-images.githubusercontent.com/26075187/67324709-08dd0700-f4e2-11e9-852b-77cb35e40308.png">

After:
<img width="371" alt="Screen Shot 2019-10-22 at 3 37 48 PM" src="https://user-images.githubusercontent.com/26075187/67324741-0f6b7e80-f4e2-11e9-84c9-add301e3d1ae.png">

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
