### PR TITLE
fix(plugins/plugin-k8s): fixed `helm get notes` error in sidecar

### DIFF
--- a/plugins/plugin-k8s/src/lib/controller/helm/get.ts
+++ b/plugins/plugin-k8s/src/lib/controller/helm/get.ts
@@ -70,6 +70,9 @@ export default async function helmGet(args: Commands.Arguments): Promise<Command
     maybeVerb === 'values'
   ) {
     debug('delegating to underlining helm')
+    if (maybeVerb === 'notes') {
+      args.parsedOptions.o = 'raw' // bypass yaml formatting
+    }
     return _helm(args)
   }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

Fixes #2787 

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->
Updates:
- Added an if statement in `get.ts` to make sure `helm get notes` not parsed as a yaml file.

Details:
- `helm get notes` returns a txt file instead of yaml. 
    However, plugin-k8s always treat `helm get` returns as `yaml` files. Thus it will fail and throw an exception, so the `notes` tab will never show.

Reference in kubectl.ts:
https://github.com/IBM/kui/blob/master/plugins/plugin-k8s/src/lib/controller/kubectl.ts#L238-L245
```
    const output =
      !options.help &&
      (options.output ||
      options.o ||
      (command === 'helm' && verb === 'get' && 'yaml') || // helm get seems to spit out yaml without our asking
        (isKube && verb === 'describe' && 'yaml') ||
        (isKube && verb === 'logs' && 'latest') ||
        (isKube && verb === 'get' && execOptions.raw && 'json'))
```
Screen shot after fix:
<img width="698" alt="Screen Shot 2019-10-23 at 11 06 34 AM" src="https://user-images.githubusercontent.com/31426239/67407402-6f673100-f585-11e9-9336-3bedc76f26e3.png">


#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [X] Multiple commits are squashed into one commit.
- [X] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [X] All npm dependencies are pinned.
