### PR TITLE
fix(plugins/plugin-core-support) clear will close the sidecar

### DIFF
--- a/plugins/plugin-core-support/src/lib/cmds/clear.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/clear.ts
@@ -18,6 +18,8 @@ import Debug from 'debug'
 
 import { Capabilities, Commands, UI } from '@kui-shell/core'
 import { resetCount } from '@kui-shell/core/webapp/cli'
+import Models from '@kui-shell/core/api/models'
+import { isVisible as isSidecarVisible } from '@kui-shell/core/webapp/views/sidecar-visibility'
 
 const debug = Debug('plugins/core-support/clear')
 
@@ -57,6 +59,9 @@ const clear = ({ parsedOptions, tab }: Commands.Arguments) => {
       return (tab.querySelector(processing) as HTMLElement) || true
     }
   }
+
+  // close the sidecar on clear
+  isSidecarVisible(tab) && Models.Selection.clear(tab)
 
   // tell the repl we're all good
   return true

--- a/plugins/plugin-core-support/src/test/core-support/clear.ts
+++ b/plugins/plugin-core-support/src/test/core-support/clear.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'assert'
 
-import { Common, CLI, Keys, ReplExpect, Selectors } from '@kui-shell/test'
+import { Common, CLI, Keys, ReplExpect, Selectors, SidecarExpect } from '@kui-shell/test'
 
 describe(`clear the console ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
   before(Common.before(this))
@@ -74,6 +74,7 @@ describe(`clear the console ${process.env.MOCHA_RUN_TARGET || ''}`, function(thi
   it('should clear the console', () =>
     CLI.command('clear', this.app)
       .then(() => ReplExpect.consoleToBeClear(this.app))
+      .then(() => SidecarExpect.closed)
       .catch(Common.oops(this, true)))
 
   // get something on the screen


### PR DESCRIPTION
Fixes https://github.com/IBM/kui/issues/2376

@starpit I don't know what the correct commit label this would fall under; feel free to change it.

#### Description of what you did:

When the user executes `clear`; the sidecar will also now be closed.

![clear](https://user-images.githubusercontent.com/26075187/67419825-6b460e00-f59b-11e9-85a6-1c9889c81bcd.gif)

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
