### PR TITLE
fix(packages/core): remove use of "open" npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "marked": "^0.7.0",
         "mkdirp": "0.5.1",
         "needle": "2.4.0",
-        "open": "6.4.0",
         "pretty-ms": "5.0.0",
         "properties-parser": "0.3.1",
         "strip-ansi": "5.2.0",
@@ -3956,11 +3955,6 @@
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
-    "is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -5079,14 +5073,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
-      }
-    },
-    "open": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
-      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
-      "requires": {
-        "is-wsl": "^1.1.0"
       }
     },
     "opencollective-postinstall": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,6 @@
     "marked": "^0.7.0",
     "mkdirp": "0.5.1",
     "needle": "2.4.0",
-    "open": "6.4.0",
     "pretty-ms": "5.0.0",
     "properties-parser": "0.3.1",
     "strip-ansi": "5.2.0",

--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -235,7 +235,7 @@ export function createWindow(
           })
         } else {
           event.preventDefault()
-          require('open')(url)
+          Electron.shell.openExternal(url)
         }
       }
     )


### PR DESCRIPTION
it uses the spread operator, which is incompatible with older Edge releases. we should be using electron.shell.openExternal, anyway

Fixes #3090

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
