### PR TITLE
fix(packages/core): Allow space bar to 'click' table name and help menu buttons

### DIFF
--- a/packages/core/src/core/usage-error.ts
+++ b/packages/core/src/core/usage-error.ts
@@ -609,7 +609,7 @@ const format = async (message: UsageLike, options: UsageOptions = new DefaultUsa
             cmdPart.classList.add('clickable')
             cmdPart.classList.add('clickable-blatant')
             cmdPart.setAttribute('tabindex', '0')
-            cmdPart.onclick = async event => {
+            const handler = async (event: Event) => {
               const Prompt = await import('../webapp/prompt')
               const { getCurrentTab } = await import('../webapp/tab')
               if (partial) {
@@ -629,6 +629,8 @@ const format = async (message: UsageLike, options: UsageOptions = new DefaultUsa
                 }
               }
             }
+            cmdPart.onclick = handler
+            cmdPart.onkeypress = event => event.keyCode === 32 && handler(event) // will only support space bar for now since there is a global listen for enter key...
           }
         }
       } /* renderRow */

--- a/packages/core/src/webapp/views/table.ts
+++ b/packages/core/src/webapp/views/table.ts
@@ -411,7 +411,7 @@ export const formatOneRowResult = (tab: Tab, options: RowFormatOptions = {}) => 
     packagePrefix.innerText = entity.packageName + '/'
     entityNameGroup.appendChild(packagePrefix)
   }
-  const entityNameClickable = document.createElement('span')
+  const entityNameClickable = document.createElement('a')
   entityNameClickable.className = 'entity-name cell-inner'
   if (!isHeaderCell) {
     entityNameClickable.classList.add('clickable')
@@ -470,12 +470,14 @@ export const formatOneRowResult = (tab: Tab, options: RowFormatOptions = {}) => 
     entityNameClickable.classList.remove('clickable')
   } else {
     if (isPopup() || options.usePip) {
+      console.log('first')
       entityNameClickable.onclick = async (evt: MouseEvent) => {
         const { drilldown } = await import('../picture-in-picture')
         return drilldown(tab, entity.onclick, undefined, undefined, 'previous view')(evt)
       }
     } else if (typeof entity.onclick === 'string') {
-      entityNameClickable.onclick = async () => {
+      console.log('second')
+      const handler = async () => {
         if (!entity.onclickExec || entity.onclickExec === 'pexec') {
           const { pexec } = await import('../../repl/exec')
           pexec(entity.onclick, { tab })
@@ -484,7 +486,10 @@ export const formatOneRowResult = (tab: Tab, options: RowFormatOptions = {}) => 
           qexec(entity.onclick, undefined, undefined, { tab })
         }
       }
+      entityNameClickable.onclick = handler
+      entityNameClickable.onkeypress = event => event.keyCode === 32 && handler() // will only support space bar for now since there is a global listen for enter key...
     } else {
+      console.log('third')
       entityNameClickable.onclick = entity.onclick
     }
   }

--- a/packages/core/src/webapp/views/table.ts
+++ b/packages/core/src/webapp/views/table.ts
@@ -411,7 +411,7 @@ export const formatOneRowResult = (tab: Tab, options: RowFormatOptions = {}) => 
     packagePrefix.innerText = entity.packageName + '/'
     entityNameGroup.appendChild(packagePrefix)
   }
-  const entityNameClickable = document.createElement('a')
+  const entityNameClickable = document.createElement('span')
   entityNameClickable.className = 'entity-name cell-inner'
   if (!isHeaderCell) {
     entityNameClickable.classList.add('clickable')
@@ -470,13 +470,11 @@ export const formatOneRowResult = (tab: Tab, options: RowFormatOptions = {}) => 
     entityNameClickable.classList.remove('clickable')
   } else {
     if (isPopup() || options.usePip) {
-      console.log('first')
       entityNameClickable.onclick = async (evt: MouseEvent) => {
         const { drilldown } = await import('../picture-in-picture')
         return drilldown(tab, entity.onclick, undefined, undefined, 'previous view')(evt)
       }
     } else if (typeof entity.onclick === 'string') {
-      console.log('second')
       const handler = async () => {
         if (!entity.onclickExec || entity.onclickExec === 'pexec') {
           const { pexec } = await import('../../repl/exec')
@@ -489,7 +487,6 @@ export const formatOneRowResult = (tab: Tab, options: RowFormatOptions = {}) => 
       entityNameClickable.onclick = handler
       entityNameClickable.onkeypress = event => event.keyCode === 32 && handler() // will only support space bar for now since there is a global listen for enter key...
     } else {
-      console.log('third')
       entityNameClickable.onclick = entity.onclick
     }
   }


### PR DESCRIPTION
Fixes https://github.com/IBM/kui/issues/3094

#### Description of what you did:

Previous PRs allowed focus of table name buttons and CLI help menu buttons; but the user was not able to use the keyboard to use them with the keyboard.  This PR will allow the user to use the space bar to trigger the associated events.  I wanted to allow support for `Enter` key as well; but there is a conflict with other listeners waiting for `Enter` key presses that was causing empty command input to show up.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
