### PR TITLE
fix(packages/core): mmr/show has leftover debug output

### DIFF
--- a/packages/core/src/models/mmr/content-types.ts
+++ b/packages/core/src/models/mmr/content-types.ts
@@ -50,7 +50,10 @@ export function isStringWithContentType(entity: Entity): entity is StringContent
  * contentType } wrapper.
  *
  */
-type FunctionThatProducesContent<T extends MetadataBearing> = (tab: Tab, entity: T) => ScalarResource | ScalarContent
+type FunctionThatProducesContent<T extends MetadataBearing> = (
+  tab: Tab,
+  entity: T
+) => ScalarResource | ScalarContent | Promise<ScalarResource> | Promise<ScalarContent>
 interface FunctionContent<T extends MetadataBearing> {
   content: FunctionThatProducesContent<T>
 }

--- a/packages/core/src/models/mmr/show.ts
+++ b/packages/core/src/models/mmr/show.ts
@@ -49,7 +49,7 @@ async function format<T extends MetadataBearing>(
     return format(tab, mmr, { content: resource })
   } else if (isFunctionContent(resource)) {
     // then resource.content is a funciton that will provide the information
-    return format(tab, mmr, resource.content(tab, mmr))
+    return format(tab, mmr, await resource.content(tab, mmr))
   } else if (isCommandStringContent(resource)) {
     const content = await tab.REPL.qexec<ScalarResource | ScalarContent>(resource.content)
     return format(tab, mmr, content)
@@ -123,11 +123,10 @@ export async function show(tab: Tab, mmr: MultiModalResponse) {
 
   const modesWithButtons = mmr.buttons ? modes.concat(formatButtons(mmr.buttons)) : modes
 
-  addModeButtons(tab, modesWithButtons, mmr)
+  addModeButtons(tab, modesWithButtons, mmr, { preserveBackButton: true })
 
   const defaultMode = modes.find(_ => _.defaultMode) || modes[0]
 
-  console.error('!!!!!', modesWithButtons)
   const content = typeof defaultMode.direct === 'function' ? await defaultMode.direct(tab, mmr) : defaultMode.direct
 
   if (content) {

--- a/packages/core/src/webapp/bottom-stripe.ts
+++ b/packages/core/src/webapp/bottom-stripe.ts
@@ -96,8 +96,7 @@ const callDirect = async (
     }
   } else if (typeof makeView === 'function') {
     debug('makeView as function')
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return Promise.resolve(makeView(tab, entity) as any)
+    return Promise.resolve(makeView(tab, entity) as DirectResult)
   } else if (isDirectViewEntity(makeView)) {
     const combined = Object.assign({}, entity, makeView)
     return combined


### PR DESCRIPTION
also removes any explicit `any` from bottom-stripe.ts

Fixes #3112

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
