### PR TITLE
fix(packages/core): broken clickable resource names for CLIs that don't have a kui plugin

### DIFF
--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -975,10 +975,8 @@ export const doExec = (
                   if (tableRows && tableRows.length > 0) {
                     // debug(`table came from ${stripClean(raw)}`)
                     // debug(`tableRows ${tableRows.length}`)
-                    const command = argvNoOptions[0]
-                    const verb = argvNoOptions[1]
                     const entityType = /\w+/.test(argvNoOptions[2]) && argvNoOptions[2]
-                    const tableModel = formatTable(command, verb, entityType, parsedOptions, tableRows)
+                    const tableModel = formatTable(entityType, tableRows)
                     debug('tableModel', tableModel)
 
                     const trailingStrings = tables.map(_ => _.trailingString).filter(x => x)


### PR DESCRIPTION
Fixed by removing the onclick hanlder in ascii-to-table

Fixes #2888

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
