### PR TITLE
fix(plugins/plugin-core-support): tab completion versus cursor motion

### DIFF
--- a/plugins/plugin-core-support/src/lib/tab-completion.ts
+++ b/plugins/plugin-core-support/src/lib/tab-completion.ts
@@ -281,15 +281,11 @@ const complete = (
   }
 
   const addToPrompt = (extra: string): void => {
-    const pos = prompt.selectionStart + extra.length
-    prompt.value =
-      prompt.value.substring(0, prompt.selectionStart) + extra + prompt.value.substring(prompt.selectionStart)
-    prompt.setSelectionRange(pos, pos)
+    prompt.value = prompt.value + extra
 
     // make sure the new text is visible
     // see https://github.com/IBM/kui/issues/1367
-    prompt.scrollLeft =
-      (prompt.scrollWidth * Math.max(0, pos - partial.length - extra.length - 1)) / prompt.value.length
+    prompt.scrollLeft = prompt.scrollWidth
   }
 
   if (dirname) {
@@ -416,8 +412,10 @@ const updateReplToReflectLongestPrefix = (
     const partialComplete = (idx: number) => {
       // debug('partial complete', idx)
       const completion = completeWith(partial, matches[0].substring(0, idx), true)
-      temporaryContainer.partial = temporaryContainer.partial + completion
-      prompt.value = prompt.value + completion
+      if (completion.length > 0) {
+        temporaryContainer.partial = completion
+        prompt.value = prompt.value + completion
+      }
       return temporaryContainer.partial
     }
 
@@ -467,8 +465,8 @@ const presentEnumeratorSuggestions = (
       temporaryContainer = makeCompletionContainer(block, prompt, partial, dirname, lastIdx)
     }
 
-    const prefix = updateReplToReflectLongestPrefix(prompt, filteredList, temporaryContainer)
-    filteredList.forEach(addSuggestion(temporaryContainer, prefix || last, dirname, prompt))
+    updateReplToReflectLongestPrefix(prompt, filteredList, temporaryContainer)
+    filteredList.forEach(addSuggestion(temporaryContainer, last, dirname, prompt))
   }
 }
 
@@ -513,7 +511,7 @@ const suggestLocalFile = (
       if (err) {
         debug('fs.readdir error', err)
       } else {
-        const partial = basename(last)
+        const partial = basename(last) + (lastIsDir ? '/' : '')
         const matches: string[] = files.filter(_f => {
           const f = shellescape(_f)
           return (lastIsDir || f.indexOf(partial) === 0) && !f.endsWith('~') && f !== '.' && f !== '..'
@@ -545,17 +543,14 @@ const suggestLocalFile = (
             temporaryContainer = makeCompletionContainer(block, prompt, partial, dirname, lastIdx)
           }
 
-          const prefix = updateReplToReflectLongestPrefix(prompt, matches, temporaryContainer)
+          updateReplToReflectLongestPrefix(prompt, matches, temporaryContainer)
 
           // add each match to that temporary div
           matches.forEach((match, idx) => {
-            const { option, optionInner, innerPost } = addSuggestion(
-              temporaryContainer,
-              prefix || '',
-              dirname,
-              prompt,
-              true
-            )(match, idx)
+            const { option, optionInner, innerPost } = addSuggestion(temporaryContainer, '', dirname, prompt, true)(
+              match,
+              idx
+            )
 
             // see if the match is a directory, so that we add a trailing slash
             const filepath = join(dirname, match)
@@ -622,9 +617,9 @@ const filterAndPresentEntitySuggestions = (
       temporaryContainer = makeCompletionContainer(block, prompt, partial, dirname, lastIdx)
     }
 
-    const prefix = updateReplToReflectLongestPrefix(prompt, filteredList, temporaryContainer)
+    updateReplToReflectLongestPrefix(prompt, filteredList, temporaryContainer)
 
-    filteredList.forEach(addSuggestion(temporaryContainer, prefix || last, dirname, prompt))
+    filteredList.forEach(addSuggestion(temporaryContainer, last, dirname, prompt))
   }
 }
 

--- a/plugins/plugin-core-support/src/test/core-support/tab-completion.ts
+++ b/plugins/plugin-core-support/src/test/core-support/tab-completion.ts
@@ -57,7 +57,7 @@ describe('Tab completion core', function(this: Common.ISuite) {
     return tabbyWithOptions(
       this.app,
       `ls ${join(tmp2.name, 'foo')}`,
-      ['foo\\ bar1', 'foo\\ bar2'],
+      ['foo bar1', 'foo bar2'],
       `ls ${join(tmp2.name, 'foo bar1')}`,
       { click: 0 }
     )
@@ -67,7 +67,7 @@ describe('Tab completion core', function(this: Common.ISuite) {
     return tabbyWithOptions(
       this.app,
       `ls -l ${join(tmp2.name, 'foo')}`,
-      ['foo\\ bar1', 'foo\\ bar2'],
+      ['foo bar1', 'foo bar2'],
       `ls -l ${join(tmp2.name, 'foo bar1')}`,
       { click: 0 }
     )
@@ -77,7 +77,7 @@ describe('Tab completion core', function(this: Common.ISuite) {
     return tabbyWithOptions(
       this.app,
       `ls ${join(tmp2.name, 'foo\\ ')}`,
-      ['foo\\ bar1', 'foo\\ bar2'],
+      ['foo bar1', 'foo bar2'],
       `ls ${join(tmp2.name, 'foo bar2')}`,
       { click: 1 }
     )
@@ -86,17 +86,6 @@ describe('Tab completion core', function(this: Common.ISuite) {
   Common.localIt('should tab complete file with spaces unique with backslash escape variant 2', () => {
     return tabby(this.app, `ls ${join(tmp2.name, 'foo\\ bar1')}`, `ls ${join(tmp2.name, 'foo bar1')}`)
   })
-
-  // tab completion using default file completion handler (i.e. if the
-  // command does not register a usage model, then always tab
-  // completion local files)
-  Common.localIt('should complete on the single-entry directory with git diff', () =>
-    tabby(
-      this.app,
-      `git diff ${ROOT}/data/core/core_single_entry_dir`,
-      `git diff ${ROOT}/data/core/core_single_entry_directory/`
-    )
-  )
 
   // tab completion of directories
   Common.localIt('should complete on the single-entry directory', () =>


### PR DESCRIPTION
Fixes #3087

this also fixes a long-standing bug with completion versus partial completion, where e.g.

"ls plugins/<tab>" would partially complete as "ls plugins/plugin-"
but then selecting a completion item would result in a doubling of plugin-

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
