### PR TITLE
feat(packages/core): default click behavior for tables should not ech…

### DIFF
--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -676,6 +676,10 @@ class InProcessExecutor implements Executor {
                         resolve(response)
                       }, 100)
                     } else {
+                      // even if we aren't installing a new block,
+                      // make sure that the input is focused (but
+                      // don't scroll to make it visible)
+                      getPrompt(block).focus({ preventScroll: true })
                       resolve(response)
                     }
                   })
@@ -757,7 +761,7 @@ class InProcessExecutor implements Executor {
           const resultDom = blockForError.querySelector('.repl-result') as HTMLElement
           return Promise.resolve(cmd)
             .then(printResults(blockForError, nextBlock, tab, resultDom))
-            .then(installBlock(blockForError.parentNode, blockForError, nextBlock))
+            .then(() => installBlock(blockForError.parentNode, blockForError, nextBlock)())
         }
       })
     }

--- a/packages/core/src/webapp/models/table.ts
+++ b/packages/core/src/webapp/models/table.ts
@@ -63,6 +63,8 @@ export class Row {
 
   rowCSS?: string | string[]
 
+  onclickSilence?: boolean
+
   onclickExec?: 'pexec' | 'qexec'
 
   onclick?: any // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/packages/core/src/webapp/views/table.ts
+++ b/packages/core/src/webapp/views/table.ts
@@ -415,7 +415,7 @@ export const formatOneRowResult = (tab: Tab, options: RowFormatOptions = {}) => 
   entityNameClickable.className = 'entity-name cell-inner'
   if (!isHeaderCell) {
     entityNameClickable.classList.add('clickable')
-    entityNameClickable.setAttribute('tabindex', '0')
+    // entityNameClickable.setAttribute('tabindex', '0') <-- see https://github.com/IBM/kui/issues/2507
   } else {
     entityNameClickable.classList.add('bx--table-header-label')
   }
@@ -478,7 +478,7 @@ export const formatOneRowResult = (tab: Tab, options: RowFormatOptions = {}) => 
       entityNameClickable.onclick = async () => {
         if (!entity.onclickExec || entity.onclickExec === 'pexec') {
           const { pexec } = await import('../../repl/exec')
-          pexec(entity.onclick, { tab })
+          pexec(entity.onclick, { tab, echo: !entity.onclickSilence })
         } else {
           const { qexec } = await import('../../repl/exec')
           qexec(entity.onclick, undefined, undefined, { tab })

--- a/packages/core/web/css/kui-tables.css
+++ b/packages/core/web/css/kui-tables.css
@@ -151,7 +151,7 @@ sidecar
   .repl-result:not(.result-table-with-custom-entity-colors)
   .entity-name-group:not(.header-cell)
   .entity-name[data-key="NAME"] {
-  color: var(--color-name-sidecar);
+  color: var(--color-map-key);
 }
 .repl-result:not(.result-table-with-custom-entity-colors)
   .entity-name-group:not(.header-cell)

--- a/packages/core/web/css/ui.css
+++ b/packages/core/web/css/ui.css
@@ -357,6 +357,7 @@ body:not(.subwindow) .repl .repl-prompt-right-element-status-icon.deemphasize {
 .repl-block.processing .repl-prompt-right-element-status-icon .kui--icon-processing svg circle {
   stroke: var(--color-brand-03);
 }
+svg.kui--error-icon path[data-icon-path="inner-path"],
 .repl-block .repl-prompt-right-element-status-icon svg path[data-icon-path="inner-path"] {
   opacity: 1;
   stroke: var(--color-ui-01);
@@ -370,6 +371,7 @@ body:not(.subwindow) .repl .repl-prompt-right-element-status-icon.deemphasize {
   stroke: var(--color-ok);
   stroke-opacity: 0.5;
 }
+svg.kui--error-icon path:not([data-icon-path="inner-path"]),
 .repl-block.error .repl-prompt-right-element-status-icon svg.kui--icon-error path:not([data-icon-path="inner-path"]) {
   fill: var(--color-error);
   stroke: var(--color-error);
@@ -1379,6 +1381,15 @@ code.fancy-code.hljs {
   opacity: 1;
   font-size: 1em;
 }
+.normal-text svg path {
+  fill: var(--color-text-01);
+}
+.kui--sidecar-inverted sidecar .normal-text {
+  color: var(--color-text-inverted01);
+}
+.kui--sidecar-inverted sidecar .normal-text svg path {
+  fill: var(--color-text-inverted01);
+}
 .even-larger-text {
   font-size: 2em;
   line-height: 1em;
@@ -1397,6 +1408,9 @@ code.fancy-code.hljs {
 }
 .sub-text {
   color: var(--color-text-02);
+}
+.kui--sidecar-inverted sidecar .sub-text {
+  color: var(--color-text-inverted03);
 }
 .lighter-text {
   font-weight: 300;
@@ -3329,7 +3343,7 @@ body.kui--bottom-input .repl-context {
 }
 
 /* row selection */
-.row-selection-context .clickable {
+.has-row-selection .row-selection-context .clickable {
   display: inline-block;
 }
 .row-selection-context.selected-row .selected-entity {

--- a/plugins/plugin-k8s/src/lib/view/formatTable.ts
+++ b/plugins/plugin-k8s/src/lib/view/formatTable.ts
@@ -302,6 +302,7 @@ export const formatTable = (
         name: nameForDisplay,
         fontawesome: idx !== 0 && rows[0].key === 'CURRENT' && 'fas fa-check',
         onclick: nameColumnIdx === 0 && onclick, // if the first column isn't the NAME column, no onclick; see onclick below
+        onclickSilence: true,
         css: firstColumnCSS,
         rowCSS,
         outerCSS: `${header} ${outerCSSForKey[rows[0].key] || ''}`,


### PR DESCRIPTION
…o to repl

table producers can opt for `onclickExec: 'qexec'` if they want the prior behavior; see plugin-bash-like/src/lib/cmds/ls.ts

this PR only changes the behavior of k8s table clicks

Fixes #3154

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
