### PR TITLE
fix: allow ascii-to-table drilldown effect for `oc` commands

### DIFF
--- a/packages/core/src/webapp/util/ascii-to-table.ts
+++ b/packages/core/src/webapp/util/ascii-to-table.ts
@@ -16,6 +16,8 @@
 
 import stripClean from 'strip-ansi'
 
+import * as repl from '../../core/repl'
+import { ParsedOptions } from '../../models/command'
 import { Cell, Row, Table, TableStyle } from '../models/table'
 
 import formatAsPty from './pretty-print'
@@ -201,6 +203,17 @@ const capitalize = (str: string): string => {
   return str.length === 0 ? str : str[0].toUpperCase() + str.slice(1).toLowerCase()
 }
 
+/**
+ * Several commands seem to be cropping up that give a facade over
+ * kubectl; this is a start at such a list
+ *
+ * 1) kubectl, bien sûr
+ * 2) oc, redhat openshift CLI
+ *
+ */
+const kubelike = /kubectl|oc/
+const isKubeLike = (command: string): boolean => kubelike.test(command)
+
 /** decorate certain columns specially */
 export const outerCSSForKey: { [key: string]: string } = {
   NAME: 'entity-name-group',
@@ -334,22 +347,89 @@ export const cssForValue: { [key: string]: string } = {
  * TODO factor out kube-specifics to plugin-k8s
  *
  */
-export const formatTable = (entityType: string, lines: Pair[][]): Table => {
+export const formatTable = (
+  command: string,
+  verb: string,
+  entityType: string,
+  options: ParsedOptions,
+  lines: Pair[][]
+): Table => {
+  // for helm status, table clicks should dispatch to kubectl;
+  // otherwise, stay with the command (kubectl or helm) that we
+  // started with
+  const isHelmStatus = command === 'helm' && verb === 'status'
+  const drilldownCommand = isHelmStatus ? 'kubectl' : command
+  const isKube = isKubeLike(drilldownCommand)
+
+  const drilldownVerb =
+    (verb === 'get'
+      ? 'get'
+      : command === 'helm' && (verb === 'list' || verb === 'ls')
+      ? 'status'
+      : isHelmStatus
+      ? 'get'
+      : undefined) || verb
+
+  // helm doesn't support --output
+  const drilldownFormat = isKube && drilldownVerb === 'get' ? '-o yaml' : ''
+
+  const namespace = options.n || options.namespace
+  const drilldownNamespace = namespace && !Array.isArray(namespace) ? `-n ${repl.encodeComponent(namespace)}` : ''
+
+  const config =
+    options.config && !Array.isArray(options.config) ? `--config ${repl.encodeComponent(options.config)}` : ''
+
+  const drilldownKind = (nameSplit: string[]): string => {
+    if (drilldownVerb === 'get') {
+      const kind = nameSplit.length > 1 ? nameSplit[0] : entityType
+      return kind ? ' ' + kind : ''
+      /* } else if (drilldownVerb === 'config') {
+         return ' use-context'; */
+    } else if (drilldownVerb === verb && entityType && !/-get$/.test(entityType)) {
+      return ` ${entityType.replace(/s$/, '')}-get`
+    } else {
+      return ''
+    }
+  }
+
   // maximum column count across all rows
   const nameColumnIdx = Math.max(0, lines[0].findIndex(({ key }) => key === 'NAME'))
+  const namespaceColumnIdx = lines[0].findIndex(({ key }) => key === 'NAMESPACE')
   const maxColumns = lines.reduce((max, columns) => Math.max(max, columns.length), 0)
 
   // e.g. Name: -> NAME
   const keyForFirstColumn = lines[0][nameColumnIdx].key.replace(/:/g, '').toUpperCase()
 
   const allRows: Row[] = lines.map((columns: Pair[], idx: number) => {
+    const name = columns[nameColumnIdx].value
+    const nameSplit = name.split(/\//) // for "get all", the name field will be <kind/entityName>
     const nameForDisplay = columns[0].value
+    const nameForDrilldown = nameSplit[1] || name
     const firstColumnCSS = idx === 0 || columns[0].key !== 'CURRENT' ? '' : 'selected-entity'
 
     const rowIsSelected = columns[0].key === 'CURRENT' && nameForDisplay === '*'
     // const rowKey = columns[0].key
     // const rowValue = columns[0].value
     const rowCSS = [rowIsSelected ? 'selected-row' : '']
+
+    // if there isn't a global namespace specifier, maybe there is a row namespace specifier
+    // we use the row specifier in preference to a global specifier -- is that right?
+    const ns =
+      (namespaceColumnIdx >= 0 &&
+        command !== 'helm' &&
+        `-n ${repl.encodeComponent(columns[namespaceColumnIdx].value)}`) ||
+      drilldownNamespace ||
+      ''
+
+    // idx === 0: don't click on header row
+    const onclick =
+      idx === 0 || /[":]/.test(nameForDrilldown)
+        ? false
+        : drilldownVerb
+        ? `${drilldownCommand} ${drilldownVerb}${drilldownKind(nameSplit)} ${repl.encodeComponent(
+            nameForDrilldown
+          )} ${drilldownFormat} ${ns} ${config}`
+        : false
 
     const attributes: Cell[] = columns
       .slice(1)
@@ -362,7 +442,7 @@ export const formatTable = (entityType: string, lines: Pair[][]): Table => {
       .map(({ key, value: column, valueDom, css }, colIdx) => ({
         key,
         tag: (idx > 0 && tagForKey[key]) || undefined,
-        onclick: false,
+        onclick: isKube && colIdx + 1 === nameColumnIdx && onclick, // see the onclick comment: above ^^^; +1 because of slice(1)
         outerCSS:
           (outerCSSForKey[key] || '') +
           (colIdx <= 1 || colIdx === nameColumnIdx - 1 || /STATUS/i.test(key) ? '' : ' hide-with-sidecar'), // nameColumnIndex - 1 beacuse of rows.slice(1)
@@ -383,7 +463,7 @@ export const formatTable = (entityType: string, lines: Pair[][]): Table => {
       name: nameForDisplay,
       nameDom: columns[0].valueDom,
       fontawesome: idx !== 0 && columns[0].key === 'CURRENT' && 'fas fa-network-wired',
-      onclick: false,
+      onclick: isKube && nameColumnIdx === 0 && onclick, // if the first column isn't the NAME column, no onclick; see onclick below
       css: firstColumnCSS,
       rowCSS,
       // title: tables.length > 1 && idx === 0 && lines.length > 1 && kindFromResourceName(lines[1][0].value),

--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -975,8 +975,10 @@ export const doExec = (
                   if (tableRows && tableRows.length > 0) {
                     // debug(`table came from ${stripClean(raw)}`)
                     // debug(`tableRows ${tableRows.length}`)
+                    const command = argvNoOptions[0]
+                    const verb = argvNoOptions[1]
                     const entityType = /\w+/.test(argvNoOptions[2]) && argvNoOptions[2]
-                    const tableModel = formatTable(entityType, tableRows)
+                    const tableModel = formatTable(command, verb, entityType, parsedOptions, tableRows)
                     debug('tableModel', tableModel)
 
                     const trailingStrings = tables.map(_ => _.trailingString).filter(x => x)


### PR DESCRIPTION
Revert "fix(packages/core): broken clickable resource names for CLIs that don't have a kui plugin"
Also white-listed `oc` comamnds

This reverts commit 39500ba350b7896c831d88d4424affc376a9ed9d.

Fixes #3168

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
