### PR TITLE
test: expand clients/test mmr-mode-via-registration

### DIFF
--- a/clients/test/plugins/plugin-test/src/lib/cmds/mmr-mode-via-registration.ts
+++ b/clients/test/plugins/plugin-test/src/lib/cmds/mmr-mode-via-registration.ts
@@ -24,14 +24,12 @@
 
 import { Commands, UI } from '@kui-shell/core'
 import { metadataWithNameOnly as metadata } from './metadata'
+import { textModes } from './content/modes'
 
 // exporting this for consumption in tests
 export { metadata }
 
-// these are the modes we return to the REPL, not the modes we expect
-// to be displayed; those modes come from the mode registrations in
-// preload.ts
-const modes: UI.MultiModalMode[] = []
+const modes: UI.MultiModalMode[] = textModes
 
 interface Options extends Commands.ParsedOptions {
   foo: boolean

--- a/clients/test/plugins/plugin-test/src/test/response/mmr-mode-via-registration.ts
+++ b/clients/test/plugins/plugin-test/src/test/response/mmr-mode-via-registration.ts
@@ -34,11 +34,26 @@ const test = new TestMMR({
   command: 'test mmr mode-via-registration'
 })
 
-const expectModes: MMRExpectMode[] = [
+const modes: MMRExpectMode[] = [
+  { mode: 'text', label: 'Plain Text', content: 'test plain text', contentType: 'text/plain' },
+  { mode: 'html', label: 'HTML Text', contentType: 'text/html' },
+  { mode: 'markdown', contentType: 'text/markdown' },
+  {
+    mode: 'yaml',
+    label: 'raw',
+    content: 'apiVersion: this is the api version field\nkind: this is the kind field',
+    contentType: 'yaml'
+  }
+]
+
+// these modes come from the mode registrations in preload.ts
+const modesFromRegistration: MMRExpectMode[] = [
   { mode: 'mode1', content: 'yo: this is mode1', contentType: 'text/plain' },
   { mode: 'mode2', content: 'this is mode2', contentType: 'text/plain' },
   { mode: 'mode3', label: 'mode3 label', contentType: 'text/markdown' }
 ]
+
+const expectModes: MMRExpectMode[] = modes.concat(modesFromRegistration)
 
 test.badges(badges)
 test.modes(expectModes, { testWindowButtons: true })


### PR DESCRIPTION
modes-via-MMR and modes-via-registraion should both show up

Fixes #3210

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
