### PR TITLE
fix(packages/core): CommandOptions type not exported

### DIFF
--- a/clients/test/plugins/plugin-test/src/lib/cmds/say-hello.ts
+++ b/clients/test/plugins/plugin-test/src/lib/cmds/say-hello.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Arguments, Registrar, ParsedOptions, Response } from '@kui-shell/core/api/commands'
+import { Arguments, CommandOptions, Registrar, ParsedOptions, Response } from '@kui-shell/core/api/commands'
 
 interface Options extends ParsedOptions {
   grumble?: number
@@ -24,13 +24,15 @@ const sayHello = ({ parsedOptions }: Arguments<Options>): Response => {
   return 'hello world' + (parsedOptions.grumble ? ` ${parsedOptions.grumble}` : '')
 }
 
+const options: CommandOptions = {
+  usage: {
+    command: 'string',
+    strict: 'string',
+    optional: [{ name: '--grumble', numeric: true }],
+    docs: 'The obligatory hello world'
+  }
+}
+
 export default (commandTree: Registrar) => {
-  commandTree.listen('/test/string', sayHello, {
-    usage: {
-      command: 'string',
-      strict: 'string',
-      optional: [{ name: '--grumble', numeric: true }],
-      docs: 'The obligatory hello world'
-    }
-  })
+  commandTree.listen('/test/string', sayHello, options)
 }

--- a/packages/core/src/api/commands.ts
+++ b/packages/core/src/api/commands.ts
@@ -67,6 +67,7 @@ export namespace Commands {
 // see https://github.com/IBM/kui/issues/3222
 export { PluginRegistration, PreloadRegistration } from '../models/plugin'
 export {
+  CommandOptions,
   CommandLine,
   Evaluator,
   ExecType,


### PR DESCRIPTION
Fixes #3230

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
