### PR TITLE
fix(plugins/plugin-core-support): getting started text is stretched in non-English

### DIFF
--- a/plugins/plugin-core-support/web/css/about.css
+++ b/plugins/plugin-core-support/web/css/about.css
@@ -3,10 +3,6 @@
   flex: 1;
 }
 
-.about-window-long-description {
-  text-align: justify;
-}
-
 .about-window .logo {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Fixes https://github.com/IBM/kui/issues/3252

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

In non-English languages; the about/getting started panel text could get stretched out and creates a defect in the character spacing leading to a less readable experience.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
