### PR TITLE
fix(packages/core) remove string capitalization styling for getting started tab

### DIFF
--- a/packages/core/web/css/ui.css
+++ b/packages/core/web/css/ui.css
@@ -733,11 +733,7 @@ body:not(.subwindow) tab:not(.sidecar-full-screen) sidecar .sidecar-bottom-strip
   width: 0;
   height: 0;
 }
-.sidecar-bottom-stripe-left-bits .sidecar-bottom-stripe-button-return-to::first-letter,
-.sidecar-bottom-stripe-left-bits .sidecar-bottom-stripe-button[data-mode] {
-  /* for bottom mode-switching buttons, capitalize the text; for actual buttons, keep the capitalization as it was given */
-  text-transform: capitalize;
-}
+
 sidecar .sidecar-bottom-stripe .package-prefix {
   /* kubectl namespace and openwhisk package name, etc. */
   display: block;


### PR DESCRIPTION
Fixes https://github.com/IBM/kui/issues/3254

#### Description of what you did:

KUI is creating grammatically incorrect strings in non-English languages because of a CSS styling rule that will capitalize every word.  KUI moving forward should not do this kind of string transformation and instead write strings as they are intended to be displayed.

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
