### PR TITLE
chore: stop using Result as a type name

### DIFF
--- a/clients/test/plugins/plugin-test/src/lib/cmds/say-hello.ts
+++ b/clients/test/plugins/plugin-test/src/lib/cmds/say-hello.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { Arguments, CommandOptions, Registrar, ParsedOptions, Response } from '@kui-shell/core/api/commands'
+import { Arguments, CommandOptions, Registrar, ParsedOptions, KResponse } from '@kui-shell/core/api/commands'
 
 interface Options extends ParsedOptions {
   grumble?: number
 }
 
-const sayHello = ({ parsedOptions }: Arguments<Options>): Response => {
+const sayHello = ({ parsedOptions }: Arguments<Options>): KResponse => {
   return 'hello world' + (parsedOptions.grumble ? ` ${parsedOptions.grumble}` : '')
 }
 

--- a/packages/core/src/api/commands.ts
+++ b/packages/core/src/api/commands.ts
@@ -32,9 +32,12 @@ import * as Context from '../commands/context'
 
 export namespace Commands {
   export import Arguments = _Commands.EvaluatorArgs
-  export import Response = _Commands.Response
+  export import KResponse = _Commands.KResponse
+
+  export import SimpleEntity = Entity.SimpleEntity
   export import CustomResponse = Sidecar.CustomSpec
   export import MixedResponse = Entity.MixedResponse
+  export import ResourceModification = Entity.ResourceModification
 
   export import DefaultExecOptions = _ExecOptions.DefaultExecOptions
   export import ExecOptions = _ExecOptions.ExecOptions
@@ -71,13 +74,17 @@ export {
   CommandLine,
   Evaluator,
   ExecType,
-  Response,
+  KResponse,
   ParsedOptions,
   EvaluatorArgs as Arguments,
   CommandRegistrar as Registrar
 } from '../models/command'
 
-export { MixedResponse, RawResponse } from '../models/entity'
+export { MixedResponse, RawResponse, ResourceModification } from '../models/entity'
+
+export { isCommandHandlerWithEvents } from '../models/command'
+
+export { withLanguage } from '../models/execOptions'
 
 export { _ExecOptions as ExecOptions }
 export default Commands

--- a/packages/core/src/commands/resolution.ts
+++ b/packages/core/src/commands/resolution.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { CommandHandlerWithEvents, CommandTreeResolution, Response, ParsedOptions } from '../models/command'
+import { CommandHandlerWithEvents, CommandTreeResolution, KResponse, ParsedOptions } from '../models/command'
 
 /**
  * A call to `read` may or may not have successfully resolved the
  * given `argv.` This method clarifies the situation.
  *
  */
-export function isSuccessfulCommandResolution<T extends Response, O extends ParsedOptions>(
+export function isSuccessfulCommandResolution<T extends KResponse, O extends ParsedOptions>(
   resolution: CommandTreeResolution<T, O>
 ): resolution is CommandHandlerWithEvents<T, O> {
   return (resolution as CommandHandlerWithEvents<T, O>).eval !== undefined

--- a/packages/core/src/commands/tree.ts
+++ b/packages/core/src/commands/tree.ts
@@ -20,7 +20,7 @@ import {
   CommandTree,
   CommandTreeResolution,
   Disambiguator,
-  Response,
+  KResponse,
   ParsedOptions
 } from '../models/command'
 
@@ -32,14 +32,14 @@ import { ExecOptions } from '../models/execOptions'
  *
  */
 interface CommandModel {
-  catchalls: CatchAllHandler<Response, ParsedOptions>[]
+  catchalls: CatchAllHandler<KResponse, ParsedOptions>[]
 
   /**
    * Look up a command handler for the given `argv`. This is the main
    * Read part of a REPL.
    *
    */
-  read<T extends Response, O extends ParsedOptions>(
+  read<T extends KResponse, O extends ParsedOptions>(
     argv: string[],
     execOptions: ExecOptions
   ): Promise<CommandTreeResolution<T, O>>
@@ -48,7 +48,7 @@ interface CommandModel {
    * Call the given callback function `fn` for each node in the command tree
    *
    */
-  forEachNode(fn: (command: Command<Response, ParsedOptions>) => void): void
+  forEachNode(fn: (command: Command<KResponse, ParsedOptions>) => void): void
 }
 
 /**
@@ -69,8 +69,8 @@ export class CommandModelImpl implements CommandModel {
   }
 
   /** handlers for command not found */
-  private readonly _catchalls: CatchAllHandler<Response, ParsedOptions>[] = []
-  public get catchalls(): CatchAllHandler<Response, ParsedOptions>[] {
+  private readonly _catchalls: CatchAllHandler<KResponse, ParsedOptions>[] = []
+  public get catchalls(): CatchAllHandler<KResponse, ParsedOptions>[] {
     return this._catchalls
   }
 
@@ -79,7 +79,7 @@ export class CommandModelImpl implements CommandModel {
    * Read part of a REPL.
    *
    */
-  public async read<T extends Response, O extends ParsedOptions>(
+  public async read<T extends KResponse, O extends ParsedOptions>(
     argv: string[],
     execOptions: ExecOptions
   ): Promise<CommandTreeResolution<T, O>> {
@@ -91,8 +91,8 @@ export class CommandModelImpl implements CommandModel {
    * Call the given callback function `fn` for each node in the command tree
    *
    */
-  public forEachNode(fn: (command: Command<Response, ParsedOptions>) => void) {
-    const iter = (root: Command<Response, ParsedOptions>) => {
+  public forEachNode(fn: (command: Command<KResponse, ParsedOptions>) => void) {
+    const iter = (root: Command<KResponse, ParsedOptions>) => {
       if (root) {
         fn(root)
         if (root.children) {

--- a/packages/core/src/core/command-tree.ts
+++ b/packages/core/src/core/command-tree.ts
@@ -31,7 +31,7 @@ import {
   CommandHandlerWithEvents,
   CommandOptions,
   Event,
-  Response,
+  KResponse,
   ParsedOptions
 } from '../models/command'
 
@@ -88,7 +88,7 @@ const exactlyTheSameRoute = (route: string, path: string[]): boolean => {
  * Navigate the given tree `model`, following the given `path` as [n1,n2,n3]
  *
  */
-const treeMatch = <T extends Response, O extends ParsedOptions>(
+const treeMatch = <T extends KResponse, O extends ParsedOptions>(
   model: CommandTree,
   path: string[],
   readonly = false,
@@ -144,7 +144,7 @@ const treeMatch = <T extends Response, O extends ParsedOptions>(
     return cur
   }
 }
-const match = <T extends Response, O extends ParsedOptions>(path: string[], readonly: boolean): Command<T, O> => {
+const match = <T extends KResponse, O extends ParsedOptions>(path: string[], readonly: boolean): Command<T, O> => {
   return treeMatch(getModelInternal().root, path, readonly)
 }
 
@@ -154,7 +154,7 @@ class DefaultCommandOptions implements CommandOptions {}
  * Register a command handler on the given route
  *
  */
-const _listen = <T extends Response, O extends ParsedOptions>(
+const _listen = <T extends KResponse, O extends ParsedOptions>(
   model: CommandTree,
   route: string,
   handler: CommandHandler<T, O>,
@@ -187,7 +187,7 @@ const _listen = <T extends Response, O extends ParsedOptions>(
   }
 }
 
-const listen = <T extends Response, O extends ParsedOptions>(
+const listen = <T extends KResponse, O extends ParsedOptions>(
   route: string,
   handler: CommandHandler<T, O>,
   options: CommandOptions
@@ -197,7 +197,7 @@ const listen = <T extends Response, O extends ParsedOptions>(
  * Register a subtree in the command tree
  *
  */
-const _subtree = <T extends Response, O extends ParsedOptions>(
+const _subtree = <T extends KResponse, O extends ParsedOptions>(
   route: string,
   options: CommandOptions
 ): Command<T, O> => {
@@ -249,7 +249,7 @@ const _subtree = <T extends Response, O extends ParsedOptions>(
  * Register a synonym of a subtree
  *
  */
-const _subtreeSynonym = <T extends Response, O extends ParsedOptions>(
+const _subtreeSynonym = <T extends KResponse, O extends ParsedOptions>(
   route: string,
   master: Command<T, O>,
   options = master.options
@@ -269,7 +269,7 @@ const _subtreeSynonym = <T extends Response, O extends ParsedOptions>(
  *    master is the return value of `listen`
  *
  */
-const _synonym = <T extends Response, O extends ParsedOptions>(
+const _synonym = <T extends KResponse, O extends ParsedOptions>(
   route: string,
   handler: CommandHandler<T, O>,
   master: Command<T, O>,
@@ -357,7 +357,7 @@ const suggestPartialMatches = (
  * @return a command handler with success and failure event handlers
  *
  */
-const withEvents = <T extends Response, O extends ParsedOptions>(
+const withEvents = <T extends KResponse, O extends ParsedOptions>(
   evaluator: CommandHandler<T, O>,
   leaf: Command<T, O>,
   partialMatches?: PartialMatch[]
@@ -419,7 +419,7 @@ const withEvents = <T extends Response, O extends ParsedOptions>(
  * Parse the given argv, and return an evaluator or throw an Error
  *
  */
-const _read = async <T extends Response, O extends ParsedOptions>(
+const _read = async <T extends KResponse, O extends ParsedOptions>(
   model: CommandTree,
   argv: string[],
   contextRetry: string[],
@@ -495,7 +495,7 @@ const _read = async <T extends Response, O extends ParsedOptions>(
 }
 
 /** read, with retries based on the current context */
-const internalRead = <T extends Response, O extends ParsedOptions>(
+const internalRead = <T extends KResponse, O extends ParsedOptions>(
   model: CommandTree,
   argv: string[]
 ): Promise<false | CommandHandlerWithEvents<T, O>> => {
@@ -563,7 +563,7 @@ const findPartialMatchesAt = (usage: PrescanUsage, partial: string): PartialMatc
  * Read part of a REPL.
  *
  */
-export const read = async <T extends Response, O extends ParsedOptions>(
+export const read = async <T extends KResponse, O extends ParsedOptions>(
   root: CommandTree,
   argv: string[],
   noRetry = false,
@@ -614,7 +614,7 @@ export class ImplForPlugins implements CommandRegistrar {
   // eslint-disable-next-line no-useless-constructor
   public constructor(protected readonly plugin: string) {}
 
-  public catchall<T extends Response, O extends ParsedOptions>(
+  public catchall<T extends KResponse, O extends ParsedOptions>(
     offer: CatchAllOffer,
     handler: CommandHandler<T, O>,
     prio = 0,
@@ -633,7 +633,7 @@ export class ImplForPlugins implements CommandRegistrar {
     })
   }
 
-  public listen<T extends Response, O extends ParsedOptions>(
+  public listen<T extends KResponse, O extends ParsedOptions>(
     route: string,
     handler: CommandHandler<T, O>,
     options?: CommandOptions
@@ -641,7 +641,7 @@ export class ImplForPlugins implements CommandRegistrar {
     return listen(route, handler, Object.assign({}, options, { plugin: this.plugin }))
   }
 
-  public synonym<T extends Response, O extends ParsedOptions>(
+  public synonym<T extends KResponse, O extends ParsedOptions>(
     route: string,
     handler: CommandHandler<T, O>,
     master: Command<T, O>,
@@ -650,11 +650,11 @@ export class ImplForPlugins implements CommandRegistrar {
     return _synonym(route, handler, master, options && Object.assign({}, options, { plugin: this.plugin }))
   }
 
-  public subtree<T extends Response, O extends ParsedOptions>(route: string, options: CommandOptions): Command<T, O> {
+  public subtree<T extends KResponse, O extends ParsedOptions>(route: string, options: CommandOptions): Command<T, O> {
     return _subtree(route, options)
   }
 
-  public subtreeSynonym<T extends Response, O extends ParsedOptions>(
+  public subtreeSynonym<T extends KResponse, O extends ParsedOptions>(
     route: string,
     master: Command<T, O>,
     options = master.options
@@ -662,7 +662,7 @@ export class ImplForPlugins implements CommandRegistrar {
     return _subtreeSynonym(route, master, options)
   }
 
-  public async override<T extends Response, O extends ParsedOptions>(
+  public async override<T extends KResponse, O extends ParsedOptions>(
     route: string,
     fromPlugin: string,
     overrideHandler: CommandOverrideHandler<T, O>,
@@ -677,7 +677,7 @@ export class ImplForPlugins implements CommandRegistrar {
     return this.listen(route, handler, options)
   }
 
-  public async find<T extends Response, O extends ParsedOptions>(
+  public async find<T extends KResponse, O extends ParsedOptions>(
     route: string,
     fromPlugin?: string,
     noOverride = true

--- a/packages/core/src/models/repl.ts
+++ b/packages/core/src/models/repl.ts
@@ -16,7 +16,7 @@
 
 import { Tab } from '../webapp/cli'
 import { MixedResponse, RawContent, RawResponse } from './entity'
-import { EvaluatorArgs, Response } from './command'
+import { EvaluatorArgs, KResponse } from './command'
 import { ExecOptions } from './execOptions'
 
 export default interface REPL {
@@ -25,7 +25,7 @@ export default interface REPL {
    * emitting output to the console.
    *
    */
-  qexec<T extends Response>(
+  qexec<T extends KResponse>(
     command: string,
     block?: HTMLElement | boolean,
     contextChangeOK?: boolean,
@@ -46,7 +46,7 @@ export default interface REPL {
    * the REPL interaction to appear on the console.
    *
    */
-  pexec<T extends Response>(command: string, execOptions?: ExecOptions): Promise<T>
+  pexec<T extends KResponse>(command: string, execOptions?: ExecOptions): Promise<T>
 
   /**
    * Execute a command in response to an in-view click in a sidecar

--- a/packages/core/src/plugins/prescan.ts
+++ b/packages/core/src/plugins/prescan.ts
@@ -15,7 +15,7 @@
  */
 
 import { UsageModel } from '../core/usage-error'
-import { Disambiguator, CapabilityRequirements, CatchAllHandler, Response, ParsedOptions } from '../models/command'
+import { Disambiguator, CapabilityRequirements, CatchAllHandler, KResponse, ParsedOptions } from '../models/command'
 
 export interface PrescanNode extends CapabilityRequirements {
   route: string
@@ -48,7 +48,7 @@ export interface PrescanModel {
   overrides: { [key: string]: string }
   usage: PrescanUsage
   disambiguator?: Disambiguator
-  catchalls: CatchAllHandler<Response, ParsedOptions>[]
+  catchalls: CatchAllHandler<KResponse, ParsedOptions>[]
 }
 
 /**

--- a/packages/core/src/plugins/scanner.ts
+++ b/packages/core/src/plugins/scanner.ts
@@ -22,7 +22,7 @@ import { pluginRoot } from './plugins'
 import { PrescanModel, PrescanUsage } from './prescan'
 
 import * as commandTree from '../core/command-tree'
-import { Command, CommandHandler, CommandOptions, Response, ParsedOptions } from '../models/command'
+import { Command, CommandHandler, CommandOptions, KResponse, ParsedOptions } from '../models/command'
 import { isCodedError } from '../models/errors'
 import { KuiPlugin, PluginRegistration } from '../models/plugin'
 
@@ -70,7 +70,7 @@ class CommandRegistrarForScan extends commandTree.ImplForPlugins {
     super(plugin)
   }
 
-  public subtreeSynonym<T extends Response, O extends ParsedOptions>(route: string, master: Command<T, O>) {
+  public subtreeSynonym<T extends KResponse, O extends ParsedOptions>(route: string, master: Command<T, O>) {
     if (route !== master.route) {
       this.scanCache.isSubtreeSynonym[route] = true
       this.scanCache.isSubtreeSynonym[master.route] = true
@@ -78,7 +78,7 @@ class CommandRegistrarForScan extends commandTree.ImplForPlugins {
     }
   }
 
-  public listen<T extends Response, O extends ParsedOptions>(
+  public listen<T extends KResponse, O extends ParsedOptions>(
     route: string,
     handler: CommandHandler<T, O>,
     options: CommandOptions
@@ -87,7 +87,7 @@ class CommandRegistrarForScan extends commandTree.ImplForPlugins {
     return super.listen(route, handler, options)
   }
 
-  public subtree<T extends Response, O extends ParsedOptions>(route: string, options: CommandOptions): Command<T, O> {
+  public subtree<T extends KResponse, O extends ParsedOptions>(route: string, options: CommandOptions): Command<T, O> {
     return super.subtree(
       route,
       Object.assign(
@@ -99,7 +99,7 @@ class CommandRegistrarForScan extends commandTree.ImplForPlugins {
     )
   }
 
-  public synonym<T extends Response, O extends ParsedOptions>(
+  public synonym<T extends KResponse, O extends ParsedOptions>(
     route: string,
     handler: CommandHandler<T, O>,
     master: Command<T, O>,

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -26,7 +26,7 @@ debug('loading')
 import encodeComponent from './encode'
 import { split, patterns } from './split'
 
-import { ExecType, Evaluator, EvaluatorArgs, Response, ParsedOptions, YargsParserFlags } from '../models/command'
+import { ExecType, Evaluator, EvaluatorArgs, KResponse, ParsedOptions, YargsParserFlags } from '../models/command'
 
 import REPL from '../models/repl'
 import { ElementMimic } from '../util/mimic-dom'
@@ -69,7 +69,7 @@ import * as minimist from 'yargs-parser'
  */
 export interface Executor {
   name: string
-  exec<T extends Response, O extends ParsedOptions>(
+  exec<T extends KResponse, O extends ParsedOptions>(
     commandUntrimmed: string,
     execOptions: ExecOptions
   ): Promise<T | CodedError<number> | HTMLElement>
@@ -81,7 +81,7 @@ export interface Executor {
  */
 export interface ReplEval {
   name: string
-  apply<T extends Response, O extends ParsedOptions>(
+  apply<T extends KResponse, O extends ParsedOptions>(
     commandUntrimmed: string,
     execOptions: ExecOptions,
     evaluator: Evaluator<T, O>,
@@ -97,7 +97,7 @@ export interface ReplEval {
 export class DirectReplEval implements ReplEval {
   public name = 'DirectReplEval'
 
-  public apply<T extends Response, O extends ParsedOptions>(
+  public apply<T extends KResponse, O extends ParsedOptions>(
     commandUntrimmed: string,
     execOptions: ExecOptions,
     evaluator: Evaluator<T, O>,
@@ -148,7 +148,7 @@ const emptyExecOptions = (): ExecOptions => new DefaultExecOptions()
 class InProcessExecutor implements Executor {
   public name = 'InProcessExecutor'
 
-  public async exec<T extends Response, O extends ParsedOptions>(
+  public async exec<T extends KResponse, O extends ParsedOptions>(
     commandUntrimmed: string,
     execOptions = emptyExecOptions()
   ): Promise<T | CodedError<number> | HTMLElement> {
@@ -808,7 +808,7 @@ export const doEval = ({ block = getCurrentBlock(), prompt = getPrompt(block) } 
  * If, while evaluating a command, it needs to evaluate a sub-command...
  *
  */
-export const qexec = <T extends Response>(
+export const qexec = <T extends KResponse>(
   command: string,
   block?: HTMLElement | boolean,
   contextChangeOK?: boolean,
@@ -857,7 +857,7 @@ export const rexec = <Raw extends RawContent>(
  * Programmatic exec, as opposed to human typing and hitting enter
  *
  */
-export const pexec = <T extends Response>(command: string, execOptions?: ExecOptions): Promise<T> => {
+export const pexec = <T extends KResponse>(command: string, execOptions?: ExecOptions): Promise<T> => {
   return exec(command, Object.assign({ echo: true, type: ExecType.ClickHandler }, execOptions)) as Promise<T>
 }
 

--- a/packages/core/src/webapp/models/table.ts
+++ b/packages/core/src/webapp/models/table.ts
@@ -130,7 +130,7 @@ export enum TableStyle {
 export class Table<RowType extends Row = Row> {
   body: RowType[]
 
-  type?: string
+  // type?: string
 
   style?: TableStyle
 

--- a/packages/core/src/webapp/print.ts
+++ b/packages/core/src/webapp/print.ts
@@ -36,7 +36,7 @@ import { promiseEach } from '../util/async'
 
 import { isWatchable } from './models/basicModels'
 import { Streamable, Stream } from '../models/streamable'
-import { CommandHandlerWithEvents, ExecType, Response, ParsedOptions } from '../models/command'
+import { CommandHandlerWithEvents, ExecType, KResponse, ParsedOptions } from '../models/command'
 import { Table, isTable, isMultiTable } from './models/table'
 import { ExecOptions } from '../models/execOptions'
 import { isMultiModalResponse } from '../models/mmr/is'
@@ -204,7 +204,7 @@ export const printResults = (
   echo = true,
   execOptions?: ExecOptions,
   command?: string,
-  evaluator?: CommandHandlerWithEvents<Response, ParsedOptions>
+  evaluator?: CommandHandlerWithEvents<KResponse, ParsedOptions>
 ) => async (response: Entity): Promise<boolean> => {
   debug('printResults', response)
 

--- a/packages/core/src/webapp/views/sidecar-core.ts
+++ b/packages/core/src/webapp/views/sidecar-core.ts
@@ -30,7 +30,7 @@ export type CustomContent =
   | HTMLElement
   | Promise<HTMLElement>
 
-export interface CustomSpec<Content = void> extends /* EntitySpec, */ MetadataBearing<CustomContent> {
+export interface CustomSpec<Content = void> extends MetadataBearing<CustomContent> {
   /** noZoom: set to true for custom content to control the zoom event handler */
   type: 'custom'
   noZoom?: boolean

--- a/plugins/plugin-bash-like/src/lib/cmds/ls.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/ls.ts
@@ -392,7 +392,6 @@ const tabularize = (cmd: string, { REPL, parsedOptions }: Arguments, parent = ''
   )
 
   return new Tables.Table({
-    type: cmd,
     style: Tables.TableStyle.Light,
     noEntityColors: true,
     noSort: true,

--- a/plugins/plugin-bash-like/src/lib/cmds/open.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/open.ts
@@ -20,7 +20,7 @@ import { basename, dirname } from 'path'
 import Util from '@kui-shell/core/api/util'
 import { i18n } from '@kui-shell/core/api/i18n'
 import { isHeadless } from '@kui-shell/core/api/capabilities'
-import { Arguments, Registrar, Response } from '@kui-shell/core/api/commands'
+import { Arguments, Registrar, KResponse } from '@kui-shell/core/api/commands'
 
 import markdownify from '../util/markdown'
 import { localFilepath } from '../util/usage-helpers'
@@ -33,7 +33,7 @@ const debug = Debug('plugins/bash-like/cmds/open')
  * Decide how to display a given filepath
  *
  */
-async function open({ tab, argvNoOptions, REPL }: Arguments): Promise<Response> {
+async function open({ tab, argvNoOptions, REPL }: Arguments): Promise<KResponse> {
   const filepath = argvNoOptions[argvNoOptions.indexOf('open') + 1]
   debug('open', filepath)
 

--- a/plugins/plugin-core-support/src/lib/cmds/about/about.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/about/about.ts
@@ -209,7 +209,7 @@ interface Options extends Commands.ParsedOptions {
  * bringYourOwnWindow behavior, for the `about` command.
  *
  */
-const aboutWindow = async (args: Commands.Arguments<Options>): Promise<Commands.Response> => {
+const aboutWindow = async (args: Commands.Arguments<Options>): Promise<Commands.KResponse> => {
   debug('aboutWindow')
 
   const { parsedOptions, REPL } = args

--- a/plugins/plugin-core-support/src/lib/cmds/history/history.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/history/history.ts
@@ -158,7 +158,6 @@ const showHistory = ({ argv, parsedOptions: options }) => {
     .filter(x => x)
 
   return new Tables.Table({
-    type: 'history',
     noSort: true,
     body
   })

--- a/plugins/plugin-core-support/src/lib/cmds/theme.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/theme.ts
@@ -111,7 +111,6 @@ const list = async () => {
   )
 
   return new Tables.Table({
-    type: 'theme',
     noSort: true,
     header,
     body

--- a/plugins/plugin-editor/src/lib/readonly.ts
+++ b/plugins/plugin-editor/src/lib/readonly.ts
@@ -16,8 +16,8 @@
 
 import Debug from 'debug'
 
-import UI from '@kui-shell/core/api/ui'
-import Commands from '@kui-shell/core/api/commands'
+import { Tab } from '@kui-shell/core/api/ui-lite'
+import { KResponse } from '@kui-shell/core/api/commands'
 
 const debug = Debug('plugins/editor/readonly')
 
@@ -25,7 +25,7 @@ const debug = Debug('plugins/editor/readonly')
  * Enter read-only mode
  *
  */
-export const gotoReadonlyLocalFile = ({ getEntity }) => async (tab: UI.Tab): Promise<Commands.Response> => {
+export const gotoReadonlyLocalFile = ({ getEntity }) => async (tab: Tab): Promise<KResponse> => {
   const entity = await getEntity(tab)
   debug('readonly', entity.name, entity)
   return tab.REPL.pexec(`open ${tab.REPL.encodeComponent(entity.filepath)}`)
@@ -35,7 +35,7 @@ export const gotoReadonlyLocalFile = ({ getEntity }) => async (tab: UI.Tab): Pro
  * Enter edit mode
  *
  */
-export const edit = ({ getEntity, lock = undefined }) => async (tab: UI.Tab): Promise<Commands.Response> => {
+export const edit = ({ getEntity, lock = undefined }) => async (tab: Tab): Promise<KResponse> => {
   const { namespace, name } = await getEntity(tab)
 
   return tab.REPL.qexec(`edit "/${namespace}/${name}"`, undefined, undefined, {

--- a/plugins/plugin-k8s/src/lib/controller/helm/get.ts
+++ b/plugins/plugin-k8s/src/lib/controller/helm/get.ts
@@ -58,7 +58,7 @@ function getBasicInfo(releaseName: string): Promise<Models.ResourceWithMetadata>
   })
 }
 
-export default async function helmGet(args: Commands.Arguments): Promise<Commands.Response> {
+export default async function helmGet(args: Commands.Arguments): Promise<Commands.KResponse> {
   const idx = args.argvNoOptions.indexOf('get')
 
   const maybeVerb = args.argvNoOptions[idx + 1]

--- a/plugins/plugin-tutorials/src/lib/cmds/get.ts
+++ b/plugins/plugin-tutorials/src/lib/cmds/get.ts
@@ -147,7 +147,7 @@ const fetchProjectData = () => info => {
  * module get command
  *
  */
-const doGet = async (command: Commands.Arguments): Promise<Commands.Response> => {
+const doGet = async (command: Commands.Arguments): Promise<Commands.KResponse> => {
   debug(`tutorial get impl`)
 
   const args: string[] = command.argvNoOptions


### PR DESCRIPTION
also remove `type` from the Table type definition, as it is no longer supported, and may lead to erroneous type inference

Fixes #3279

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
