### PR TITLE
feat: add support for command string modes that specify contentType

### DIFF
--- a/clients/test/plugins/plugin-test/src/lib/cmds/content/modes.ts
+++ b/clients/test/plugins/plugin-test/src/lib/cmds/content/modes.ts
@@ -28,8 +28,12 @@ export const plainTextModeAlt: UI.MultiModalMode[] = [{ mode: 'text2', label: 'T
 
 // string directly as content function string
 // this should take the output of the `test string` command and place it in the mode content section
-export const plainTextModeAlt2: UI.MultiModalMode[] = [
-  { mode: 'text3', label: 'T3', content: 'test string', contentType: 'command' }
+export const plainTextModeAlt2: UI.MultiModalMode[] = [{ mode: 'text3', label: 'T3', contentFrom: 'test string' }]
+
+// string directly as content function string, with contentType
+// this should take the output of the `test string` command and place it in the mode content section
+export const plainTextModeAlt3: UI.MultiModalMode[] = [
+  { mode: 'text4', label: 'T4', contentFrom: 'test markdown', contentType: 'text/markdown' }
 ]
 
 // table directly as content
@@ -66,6 +70,7 @@ export const modes1: UI.MultiModalMode[] = [].concat(
   plainTextMode,
   plainTextModeAlt,
   plainTextModeAlt2,
+  plainTextModeAlt3,
   tableMode,
   htmlTextMode,
   markdownTextMode,
@@ -77,6 +82,7 @@ export const modes2: UI.MultiModalMode[] = [].concat(
   tableMode, // swapped to first
   plainTextModeAlt,
   plainTextModeAlt2,
+  plainTextModeAlt3,
   plainTextMode, // swapped with tableMode
   htmlTextMode,
   markdownTextMode,
@@ -88,6 +94,7 @@ export const modes3: UI.MultiModalMode[] = [].concat(
   plainTextModeAlt, // swapped to first
   plainTextMode, // swapped with plainTextModeAlt
   plainTextModeAlt2,
+  plainTextModeAlt3,
   tableMode,
   htmlTextMode,
   markdownTextMode,
@@ -99,6 +106,7 @@ export const modes4: UI.MultiModalMode[] = [].concat(
   plainTextModeAlt2, // swapped to first
   plainTextModeAlt,
   plainTextMode, // swapped with plainTextModeAlt2
+  plainTextModeAlt3,
   tableMode,
   htmlTextMode,
   markdownTextMode,
@@ -110,6 +118,7 @@ export const modes5: UI.MultiModalMode[] = [].concat(
   htmlTextMode, // swapped to first
   plainTextModeAlt,
   plainTextModeAlt2,
+  plainTextModeAlt3,
   tableMode,
   plainTextMode, // swapped with htmlTextMode
   markdownTextMode,

--- a/clients/test/plugins/plugin-test/src/lib/cmds/say-hello.ts
+++ b/clients/test/plugins/plugin-test/src/lib/cmds/say-hello.ts
@@ -24,6 +24,16 @@ const sayHello = ({ parsedOptions }: Arguments<Options>): KResponse => {
   return 'hello world' + (parsedOptions.grumble ? ` ${parsedOptions.grumble}` : '')
 }
 
+const sayMarkdown = (): KResponse => {
+  return `
+# hello world
+- aaa
+- bbbb
+
+## sub
+hi`
+}
+
 const options: CommandOptions = {
   usage: {
     command: 'string',
@@ -35,4 +45,5 @@ const options: CommandOptions = {
 
 export default (commandTree: Registrar) => {
   commandTree.listen('/test/string', sayHello, options)
+  commandTree.listen('/test/markdown', sayMarkdown)
 }

--- a/clients/test/plugins/plugin-test/src/test/response/mmr-mode-via-registration.ts
+++ b/clients/test/plugins/plugin-test/src/test/response/mmr-mode-via-registration.ts
@@ -46,10 +46,17 @@ const testRegistrationWithModes = new TestMMR({
   command: 'test mmr mode-via-registration'
 })
 
+const expectedMarkdownContent = `hello world
+aaa
+bbbb
+sub
+hi`
+
 const modes: MMRExpectMode[] = [
   { mode: 'text', label: 'T1', content: 'test plain text 5', contentType: 'text/plain' },
   { mode: 'text2', label: 'T2', content: 'plain as day', contentType: 'text/plain' },
   { mode: 'text3', label: 'T3', content: 'hello world', contentType: 'text/plain' },
+  { mode: 'text4', label: 'T4', content: expectedMarkdownContent, contentType: 'text/plain' },
   { mode: 'table', label: 'Tbl1', nRows: 2, nCells: 4, contentType: 'table' },
   { mode: 'html', label: 'H', contentType: 'text/html' },
   { mode: 'm', contentType: 'text/markdown' },

--- a/clients/test/plugins/plugin-test/src/test/response/mmr-mode.ts
+++ b/clients/test/plugins/plugin-test/src/test/response/mmr-mode.ts
@@ -29,11 +29,18 @@ import { metadata as _meta } from '../../lib/cmds/mmr-mode'
 
 const { metadata } = _meta
 
+const expectedMarkdownContent = `hello world
+aaa
+bbbb
+sub
+hi`
+
 // this is the expected modes result showing in the sidecar
 const expectModes: MMRExpectMode[] = [
   { mode: 'text', label: 'T1', content: 'test plain text 5', contentType: 'text/plain' },
   { mode: 'text2', label: 'T2', content: 'plain as day', contentType: 'text/plain' },
   { mode: 'text3', label: 'T3', content: 'hello world', contentType: 'text/plain' },
+  { mode: 'text4', label: 'T4', content: expectedMarkdownContent, contentType: 'text/plain' },
   { mode: 'table', label: 'Tbl1', nRows: 2, nCells: 4, contentType: 'table' },
   { mode: 'html', label: 'H', contentType: 'text/html' },
   { mode: 'm', contentType: 'text/markdown' },
@@ -129,4 +136,4 @@ testDefault4.modes(expectModes4, expectModes4[0])
 testDefault5.modes(expectModes5, expectModes5[0])
 testDefault.toolbarText(toolbarText)
 testDefault.toolbarButtons(buttons)
-testOrder.modes(expectModes, expectModes[4])
+testOrder.modes(expectModes, expectModes.find(_ => _.mode === 'html'))

--- a/packages/core/src/models/mmr/show.ts
+++ b/packages/core/src/models/mmr/show.ts
@@ -54,8 +54,15 @@ export async function format<T extends MetadataBearing>(
     // then resource.content is a function that will provide the information
     return format(tab, mmr, await resource.content(tab, mmr))
   } else if (isCommandStringContent(resource)) {
-    const content = await tab.REPL.qexec<ScalarResource | ScalarContent>(resource.content)
-    return format(tab, mmr, content)
+    const content = await tab.REPL.qexec<ScalarResource | ScalarContent>(resource.contentFrom)
+    if (resource.contentType && typeof content === 'string') {
+      return format(tab, mmr, {
+        content,
+        contentType: resource.contentType
+      })
+    } else {
+      return format(tab, mmr, content)
+    }
   } else if (isCustomSpec(resource.content)) {
     return resource.content
   } else if (isTable(resource.content) || isMultiTable(resource.content)) {

--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -1096,7 +1096,7 @@ export const doExec = (
                       contentType,
                       content: stripClean(raw),
                       resource,
-                      modes: [{ mode: 'raw', content: cmdline, contentType: 'command', defaultMode: true }]
+                      modes: [{ mode: 'raw', contentFrom: cmdline, defaultMode: true }]
                     })
                   }
                 } catch (err) {

--- a/plugins/plugin-core-support/src/lib/cmds/about/about.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/about/about.ts
@@ -256,20 +256,18 @@ const aboutWindow = async (args: Commands.Arguments<Options>): Promise<Commands.
   }
 
   const standardModes: UI.Mode[] = [
-    { mode: 'about', label: strings('About'), content: 'about', contentType: 'command' },
+    { mode: 'about', label: strings('About'), contentFrom: 'about' },
     {
       mode: 'gettingStarted',
       label: strings('Getting Started'),
-      content: 'about --mode gettingStarted',
-      contentType: 'command'
+      contentFrom: 'about --mode gettingStarted'
     },
     {
       mode: 'configure',
       label: strings('Configure'),
-      content: 'about --mode configure --content themes',
-      contentType: 'command'
+      contentFrom: 'about --mode configure --content themes'
     },
-    { mode: 'version', label: strings('Version'), content: 'about --mode version', contentType: 'command' }
+    { mode: 'version', label: strings('Version'), contentFrom: 'about --mode version' }
   ]
   const modes: UI.Mode[] = standardModes.concat(Settings.theme.about || [])
 


### PR DESCRIPTION
this changes the schema of CommandStringContent to
```typescript
{
  contentFrom: string
  contentType?: SupportedStringContent
}
```

Fixes #3299

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
