### PR TITLE
fix: incorrect nodejs "engine" spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "start": "node bin/kui shell"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.15.0",
+    "npm": ">=5.7.1"
   },
   "dependencies": {
     "@kui-shell/core": "file:packages/core",


### PR DESCRIPTION
specify npm 5.7.1, because we use npm ci

Fixes #3320

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
