### PR TITLE
fix(packages/core): plugin assembler has a path separator assumption

### DIFF
--- a/packages/core/src/plugins/assembler.ts
+++ b/packages/core/src/plugins/assembler.ts
@@ -15,7 +15,7 @@
  */
 
 import Debug from 'debug'
-import { join, relative } from 'path'
+import { join, relative, sep } from 'path'
 import { ensureFile, writeFile } from 'fs-extra'
 
 import * as plugins from './plugins'
@@ -167,7 +167,8 @@ export const compile = async (
     // NOTE ON relativization: this is important so that webpack can
     // be instructed to pull in the plugins into the build see the
     // corresponding NOTE in ./plugins.ts and ./preloader.ts
-    const fixed = externalOnly ? filepath : relative(pluginRoot, filepath).replace(/^(.*\/)(plugin-.*)$/, '$2')
+    const pattern = new RegExp(`^(.*\\${sep})(plugin-.*)$`)
+    const fixed = externalOnly ? filepath : relative(pluginRoot, filepath).replace(pattern, '$2')
     return fixed
   }
   const fixupPaths = (pluginList: PrescanCommandDefinitions) =>


### PR DESCRIPTION
Fixes #3326

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
