### PR TITLE
fix: kui session is noop in electron mode

### DIFF
--- a/plugins/plugin-bash-like/src/pty/session.ts
+++ b/plugins/plugin-bash-like/src/pty/session.ts
@@ -20,7 +20,7 @@ import { setStatus, Status } from '@kui-shell/core/webapp/status'
 import { getPrompt, getCurrentProcessingBlock } from '@kui-shell/core/webapp/cli'
 import { Capabilities, Commands, Errors, i18n, Settings, UI } from '@kui-shell/core'
 
-import { Channel } from './channel'
+import { Channel, InProcessChannel } from './channel'
 import { setOnline, setOffline } from './ui'
 
 const strings = i18n('plugin-bash-like')
@@ -38,8 +38,16 @@ export function getChannelForTab(tab: UI.Tab): Channel {
  * Return the session for the given tab
  *
  */
-export function getSessionForTab(tab: UI.Tab): Promise<Channel> {
-  return tab['_kui_session'] as Promise<Channel>
+export async function getSessionForTab(tab: UI.Tab): Promise<Channel> {
+  if (tab['_kui_session'] === undefined && Capabilities.inElectron()) {
+    const channel = new InProcessChannel()
+    await channel.init()
+    tab['_kui_session'] = channel
+
+    return tab['_kui_session']
+  } else {
+    return tab['_kui_session'] as Promise<Channel>
+  }
 }
 
 /**


### PR DESCRIPTION
Fixed by initializing the session as electron channel factory in electron mode

Fixes #3330

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
