### PR TITLE
fix: electron cross-builds for win32 on linux hosts do not avoid asar

### DIFF
--- a/packages/builder/dist/electron/builders/electron.js
+++ b/packages/builder/dist/electron/builders/electron.js
@@ -103,12 +103,17 @@ async function copyNodePty(buildPath, electronVersion, targetPlatform, arch, cal
   }
 }
 
+// required positional arguments to our main:
+const dir = process.argv[0]
+const name = process.argv[1]
+const platform = process.argv[2]
+const icon = process.argv[3]
+
 const args = {
-  // required positional arguments to our main:
-  dir: process.argv[0],
-  name: process.argv[1],
-  platform: process.argv[2],
-  icon: process.argv[3],
+  dir,
+  name,
+  platform,
+  icon,
 
   // required environmental parameters:
   appVersion: process.env.VERSION,
@@ -121,7 +126,7 @@ const args = {
   ignore: process.env.IGNORE,
 
   // default settings
-  asar: process.platform !== 'win32', // node-pty loading native modules versus asar :(
+  asar: platform !== 'win32', // node-pty loading native modules versus asar :(
   overwrite: true,
 
   // and finally, this is the reason we are here:


### PR DESCRIPTION
Fixes #3336

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
