### PR TITLE
fix: kui-watch-webpack should just watch webpack, not build

### DIFF
--- a/packages/webpack/bin/watch.sh
+++ b/packages/webpack/bin/watch.sh
@@ -26,12 +26,9 @@ BUILDER_HOME="$MODULE_HOME"/builder
 
 CONFIG="$MODULE_HOME"/webpack/webpack.config.js
 
-if [ -z "$PORT_OFFSET" ]; then
-    # then the caller will take care of building
-    npx --no-install kui-compile
-
-    KUI_STAGE="$CLIENT_HOME" node "$BUILDER_HOME"/lib/configure.js webpack-watch
-fi
+# let the caller take care of building; see https://github.com/IBM/kui/issues/3377
+# npx --no-install kui-compile
+# KUI_STAGE="$CLIENT_HOME" node "$BUILDER_HOME"/lib/configure.js webpack-watch
 
 pushd "$CLIENT_HOME"
   rm -rf dist/webpack


### PR DESCRIPTION
Fixes #3377

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
