### PR TITLE
fix: repl scrollbars overlap with repl content

### DIFF
--- a/packages/core/web/css/carbon-overrides-common.css
+++ b/packages/core/web/css/carbon-overrides-common.css
@@ -95,7 +95,7 @@ body[kui-theme-style] .bx--link:hover {
 }
 
 .repl-block.processing .repl-prompt-right-element-status-icon .kui--icon-processing svg circle.bx--loading__stroke-kui {
-  stroke: var(--color-base0C);
+  /* stroke: var(--color-base0C); */
   stroke-dashoffset: 30;
 }
 

--- a/packages/core/web/css/ui.css
+++ b/packages/core/web/css/ui.css
@@ -152,6 +152,7 @@ body.still-loading .repl {
 .repl-inner {
   overflow-y: auto;
   flex: 1;
+  padding-right: 0.375em;
 }
 .repl.sidecar-visible .repl-block {
   background: transparent;
@@ -355,7 +356,7 @@ body:not(.subwindow) .repl .repl-prompt-right-element-status-icon.deemphasize {
   display: block;
 }
 .repl-block.processing .repl-prompt-right-element-status-icon .kui--icon-processing svg circle {
-  stroke: var(--color-brand-03);
+  stroke: var(--color-base0E);
 }
 svg.kui--error-icon path[data-icon-path="inner-path"],
 .repl-block .repl-prompt-right-element-status-icon svg path[data-icon-path="inner-path"] {
@@ -380,6 +381,7 @@ svg.kui--error-icon path:not([data-icon-path="inner-path"]),
 .repl-prompt-right-elements .repl-prompt-right-element-status-icon:hover {
   opacity: 1;
 }
+repl.sidecar-visible .repl-prompt-timestamp,
 repl.sidecar-visible .repl-block:not(.processing) .repl-prompt-right-elements,
 .repl-active .repl-prompt-right-elements {
   display: none; /* see the comment for repl-input re: min-height */


### PR DESCRIPTION
Fixes 3411

this also
- hides the timestamp for processing blocks when the sidecar is open
- modifies spinner color to make it more contrasty

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
