### PR TITLE
fix(packages/webpack): store generated webpack bundles under contextRoot

### DIFF
--- a/packages/webpack/webpack.config.js
+++ b/packages/webpack/webpack.config.js
@@ -93,6 +93,10 @@ const buildDir =
   path.join(stageDir, 'dist/webpack')
 console.log('buildDir', buildDir)
 
+/** this is the full path in which will be serving up bundles; it includes contextRoot */
+const outputPath = contextRoot ? path.join(buildDir, contextRoot) : buildDir
+console.log('outputPath', outputPath)
+
 const builderHome =
   process.env.KUI_BUILDER_HOME ||
   (process.env.KUI_MONO_HOME
@@ -219,7 +223,7 @@ plugins.push({
           }
 
           if (!inBrowser || isWatching) {
-            overrides.build.buildDir = buildDir
+            overrides.build.buildDir = outputPath
             overrides.build.configDir = path.join(path.dirname(buildDir), 'settings')
           }
 
@@ -429,6 +433,6 @@ module.exports = {
     globalObject: 'self', // for monaco
     filename: '[name].[hash].bundle.js',
     publicPath: contextRoot || (inBrowser ? '/' : mode === 'production' ? '' : `${buildDir}/`),
-    path: buildDir
+    path: outputPath
   }
 }


### PR DESCRIPTION
Fixes #3418

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
