### PR TITLE
fix(packages/core): in 10.15, SFMono fonts are in a new location

### DIFF
--- a/packages/core/web/css/kui-ui.css
+++ b/packages/core/web/css/kui-ui.css
@@ -8,59 +8,66 @@ body[kui-theme-style] {
   font-family: "SF Mono";
   font-weight: 200;
   font-style: normal;
-  src: url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Light.otf"), local("Menlo"),
+  src: url("file:///System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Light.otf"),
+    url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Light.otf"), local("Menlo"),
     local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"), local("monospace");
 }
 @font-face {
   font-family: "SF Mono";
   font-weight: 200;
   font-style: italic;
-  src: url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-LightItalic.otf"),
-    local("Menlo"), local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"),
-    local("monospace");
+  src: url("file:///System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-LightItalic.otf"),
+    url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-LightItalic.otf"), local("Menlo"),
+    local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"), local("monospace");
 }
 @font-face {
   font-family: "SF Mono";
   font-weight: 400;
   font-style: normal;
-  src: url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Regular.otf"), local("Menlo"),
+  src: url("file:///System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Regular.otf"),
+    url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Regular.otf"), local("Menlo"),
     local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"), local("monospace");
 }
 @font-face {
   font-family: "SF Mono";
   font-weight: 400;
   font-style: italic;
-  src: url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-RegularItalic.otf"),
+  src: url("file:///System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-RegularItalic.otf"),
+    url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-RegularItalic.otf"), local("Menlo"),
+    local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"), local("monospace");
+}
+@font-face {
+  font-family: "SF Mono";
+  font-weight: 500;
+  font-style: normal;
+  src: url("file:///System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Medium.otf"),
+    local("Menlo"), url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Medium.otf"),
     local("Menlo"), local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"),
     local("monospace");
 }
 @font-face {
   font-family: "SF Mono";
   font-weight: 500;
-  font-style: normal;
-  src: url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Medium.otf"), local("Menlo"),
+  font-style: italic;
+  src: url("file:///System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-MediumItalic.otf"),
+    url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-MediumItalic.otf"), local("Menlo"),
     local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"), local("monospace");
 }
 @font-face {
   font-family: "SF Mono";
-  font-weight: 500;
-  font-style: italic;
-  src: url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-MediumItalic.otf"),
+  font-weight: 600;
+  font-style: normal;
+  src: url("file:///System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Semibold.otf"),
+    local("Menlo"), url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Semibold.otf"),
     local("Menlo"), local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"),
     local("monospace");
 }
 @font-face {
   font-family: "SF Mono";
   font-weight: 600;
-  font-style: normal;
-  src: url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Semibold.otf"), local("Menlo"),
-    local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"), local("monospace");
-}
-@font-face {
-  font-family: "SF Mono";
-  font-weight: 600;
   font-style: italic;
-  src: url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-SemiboldItalic.otf"),
+  src: url("file:///System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-SemiboldItalic.otf"),
+    url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-SemiboldItalic.otf"),
     local("Menlo"), local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"),
     local("monospace");
 }
@@ -68,28 +75,34 @@ body[kui-theme-style] {
   font-family: "SF Mono";
   font-weight: 700;
   font-style: normal;
-  src: url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Bold.otf"), local("Menlo"),
-    local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"), local("monospace");
+  src: url("file:///System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Bold.otf"),
+    local("Menlo"), url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Bold.otf"),
+    local("Menlo"), local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"),
+    local("monospace");
 }
 @font-face {
   font-family: "SF Mono";
   font-weight: 700;
   font-style: italic;
-  src: url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-BoldItalic.otf"), local("Menlo"),
-    local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"), local("monospace");
+  src: url("file:///System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-BoldItalic.otf"),
+    local("Menlo"), url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-BoldItalic.otf"),
+    local("Menlo"), local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"),
+    local("monospace");
 }
 @font-face {
   font-family: "SF Mono";
   font-weight: 800;
   font-style: normal;
-  src: url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Heavy.otf"), local("Menlo"),
-    local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"), local("monospace");
+  src: url("file:///System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Heavy.otf"),
+    local("Menlo"), url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Heavy.otf"),
+    local("Menlo"), local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"),
+    local("monospace");
 }
 @font-face {
   font-family: "SF Mono";
   font-weight: 800;
   font-style: italic;
-  src: url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-HeavyItalic.otf"),
-    local("Menlo"), local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"),
-    local("monospace");
+  src: url("file:///System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-HeavyItalic.otf"),
+    url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-HeavyItalic.otf"), local("Menlo"),
+    local("Monaco"), local("Consolas"), local("Liberation Mono"), local("Courier New"), local("monospace");
 }


### PR DESCRIPTION
Fixes #3432

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
