### PR TITLE
fix: webpack build tarCopy falsefully excludes a theme directory

### DIFF
--- a/packages/webpack/build.sh
+++ b/packages/webpack/build.sh
@@ -80,7 +80,6 @@ function tarCopy {
     # to come before the --exclude rules!
     "$TAR" -C "$CLIENT_HOME" -cf - \
            --exclude "./npm-packs" \
-           --exclude "./theme" \
            --exclude "./dist" \
            --exclude "./kui" \
            --exclude "./kui-*-tmp" \


### PR DESCRIPTION
Fixes #3516

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
