### PR TITLE
fix(plugins/plugin-carbon-themes): sidecar table contrast issue fix i…

### DIFF
--- a/plugins/plugin-carbon-themes/web/css/carbon-gray10.css
+++ b/plugins/plugin-carbon-themes/web/css/carbon-gray10.css
@@ -83,10 +83,6 @@ body[kui-theme="Carbon Gray10"] {
   --color-latency-13: #d4bbff;
 }
 
-body[kui-theme="Carbon Gray10"] sidecar .bx--data-table td,
-body[kui-theme="Carbon Gray10"] sidecar .bx--data-table th {
-  color: var(--color-text-inverted03);
-}
 body[kui-theme="Carbon Gray10"] sidecar .bx--data-table td .slightly-deemphasize {
   color: var(--color-base02);
 }


### PR DESCRIPTION
…n carbon gray10

Fixes https://github.com/IBM/kui/issues/3540

@starpit I think the reason why you saw some discrepancy is because you are loading other css files like `kui-tables.css` and others that make your tables look different.  I disabled this css rule in the electron dev tools with the kubectl-boilerplate repo and I did not see a negative effect with your version.

#### Before:

<img width="566" alt="Screen Shot 2020-01-29 at 1 49 11 PM" src="https://user-images.githubusercontent.com/26075187/73387356-73020680-429e-11ea-9e8a-b9dd9689dc60.png">
<img width="300" alt="Screen Shot 2020-01-29 at 1 49 22 PM" src="https://user-images.githubusercontent.com/26075187/73387357-73020680-429e-11ea-8928-500e44a248db.png">

---

#### After:

<img width="565" alt="Screen Shot 2020-01-29 at 1 49 29 PM" src="https://user-images.githubusercontent.com/26075187/73387359-73020680-429e-11ea-98c9-698df888c47a.png">
<img width="311" alt="Screen Shot 2020-01-29 at 1 49 33 PM" src="https://user-images.githubusercontent.com/26075187/73387360-73020680-429e-11ea-9cc8-819e8571f9c9.png">





<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
