### PR TITLE
fix(packages/core): MMR rendering is glitchy

### DIFF
--- a/packages/core/src/webapp/bottom-stripe.ts
+++ b/packages/core/src/webapp/bottom-stripe.ts
@@ -48,6 +48,9 @@ export function isSidecarMode(entity: string | HTMLElement | Table | SidecarMode
 interface BottomStripOptions {
   show?: string
   preserveBackButton?: boolean
+
+  /** only generate model, do not update view? */
+  modelOnly?: boolean
 }
 
 export const rawCSS = {
@@ -351,12 +354,16 @@ export const addModeButtons = (
     addRelevantModes(tab, modesUnsorted, command, entity)
   }
 
-  if (options.show && modesUnsorted.find(_ => _.mode === options.show)) {
+  if (options && options.show && modesUnsorted.find(_ => _.mode === options.show)) {
     modesUnsorted = modesUnsorted.map(_ => Object.assign({}, _))
 
     modesUnsorted.filter(_ => _.defaultMode && _.mode !== options.show).forEach(_ => (_.defaultMode = false))
 
     modesUnsorted.find(_ => _.mode === options.show).defaultMode = true
+  }
+
+  if (options && options.modelOnly) {
+    return modesUnsorted
   }
 
   // obey the `order` constraints of the modes

--- a/packages/test/src/api/mmr.ts
+++ b/packages/test/src/api/mmr.ts
@@ -233,7 +233,7 @@ export class TestMMR {
                 await this.app.client.waitForExist(Selectors.SIDECAR_MODE_BUTTON_SELECTED(expectMode.mode))
               }
             } catch (err) {
-              return Common.oops(this)(err)
+              return Common.oops(this, true)(err)
             }
           })
 
@@ -244,7 +244,7 @@ export class TestMMR {
                   await SidecarExpect.textPlainContent(expectMode.content)(this.app)
                 }
               } catch (err) {
-                return Common.oops(this)(err)
+                return Common.oops(this, true)(err)
               }
             })
           } else if (expectMode.contentType === 'table') {
@@ -255,7 +255,7 @@ export class TestMMR {
                   assert.strictEqual(rows.value.length, expectMode.nRows)
                 }
               } catch (err) {
-                return Common.oops(this)(err)
+                return Common.oops(this, true)(err)
               }
             })
             it(`should show ${expectMode.nCells} table cells in the ${expectMode.mode} tab`, async () => {
@@ -265,7 +265,7 @@ export class TestMMR {
                   assert.strictEqual(cells.value.length, expectMode.nCells)
                 }
               } catch (err) {
-                return Common.oops(this)(err)
+                return Common.oops(this, true)(err)
               }
             })
           } else if (expectMode.contentType === 'yaml') {
@@ -276,7 +276,7 @@ export class TestMMR {
                     await SidecarExpect.yaml(expectMode.content)(this.app)
                   }
                 } catch (err) {
-                  return Common.oops(this)(err)
+                  return Common.oops(this, true)(err)
                 }
               })
             } else {
@@ -286,7 +286,7 @@ export class TestMMR {
                     await SidecarExpect.textPlainContent(expectMode.content)(this.app)
                   }
                 } catch (err) {
-                  return Common.oops(this)(err)
+                  return Common.oops(this, true)(err)
                 }
               })
             }

--- a/packages/test/src/api/util.ts
+++ b/packages/test/src/api/util.ts
@@ -195,8 +195,12 @@ export const waitForXtermInput = (app: Application, N: number) => {
 }
 
 export const expectText = (app: Application, expectedText: string) => async (selector: string) => {
+  let idx = 0
   await app.client.waitUntil(async () => {
     const actualText = await app.client.getText(selector)
+    if (++idx > 5) {
+      console.error(`still waiting for text; actualText=${actualText} expectedText=${expectedText}`)
+    }
     return actualText === expectedText
   })
   return app


### PR DESCRIPTION
we update the bottom stripe, then fetch the content for the first tab, then update the Presentation (e.g. from Slim to Normal). since the middle one is asynchronous, this introduces a glitchy UI effect

Fixes #3589

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
