### PR TITLE
fix(plugins/plugin-carbon-themes) a11y - sidecar badge contrast fix

### DIFF
--- a/plugins/plugin-carbon-themes/web/css/carbon-gray90.css
+++ b/plugins/plugin-carbon-themes/web/css/carbon-gray90.css
@@ -126,3 +126,7 @@ body[kui-theme="Carbon Gray90"] .repl {
 body[kui-theme="Carbon Gray90"][kui-theme-style] ::placeholder {
   opacity: 0.875 !important;
 }
+
+body[kui-theme="Carbon Gray90"] sidecar .sidecar-header badge.version {
+  color: var(--color-base06);
+}


### PR DESCRIPTION
Fixes https://github.com/IBM/kui/issues/3151

---

#### Before:

<img width="56" alt="Screen Shot 2020-02-10 at 10 48 19 AM" src="https://user-images.githubusercontent.com/26075187/74165788-9bb9c280-4bf3-11ea-9fbe-91e02d541a42.png">
<img width="579" alt="Screen Shot 2020-02-10 at 10 48 39 AM" src="https://user-images.githubusercontent.com/26075187/74165793-9e1c1c80-4bf3-11ea-8387-f0c52d83ac21.png">

---

#### After:

<img width="54" alt="Screen Shot 2020-02-10 at 10 48 55 AM" src="https://user-images.githubusercontent.com/26075187/74165825-a7a58480-4bf3-11ea-8820-ecc5f9a6fe57.png">
<img width="386" alt="Screen Shot 2020-02-10 at 10 49 18 AM" src="https://user-images.githubusercontent.com/26075187/74165833-ad9b6580-4bf3-11ea-8506-795ed2e56453.png">

**DAP scan no longer flags contrast issue**

---

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
