### PR TITLE
fix(plugins/plugin-editor): Editor component should be readOnly for non-files

### DIFF
--- a/plugins/plugin-editor/src/view/components/Editor.tsx
+++ b/plugins/plugin-editor/src/view/components/Editor.tsx
@@ -165,7 +165,7 @@ export default class Editor extends React.PureComponent<Props, State> {
       // here we instantiate an editor widget
       const providedOptions = {
         value: props.content.content,
-        readOnly: props.readOnly || false,
+        readOnly: props.readOnly || !isFile(props.response) || false,
         language: props.content.contentType ? language(props.content.contentType) : undefined
       }
       const options = Object.assign(defaultMonacoOptions(providedOptions), providedOptions)


### PR DESCRIPTION
Fixes #3641

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
