### PR TITLE
fix(packages/core): avoid using webview theme preinjection

### DIFF
--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -208,8 +208,8 @@ export function createWindow(
     mainWindow.webContents.on('did-finish-load', async () => {
       if (mainWindow) {
         try {
-          const { switchToPersistedThemeChoice } = await import('../webapp/themes/persistence')
-          await switchToPersistedThemeChoice(mainWindow.webContents /*, Electron.nativeTheme.shouldUseDarkColors */)
+          // const { switchToPersistedThemeChoice } = await import('../webapp/themes/persistence')
+          // await switchToPersistedThemeChoice(mainWindow.webContents /*, Electron.nativeTheme.shouldUseDarkColors */)
         } catch (err) {
           console.error('error initializing themes', err)
         }

--- a/packages/core/src/webapp/themes/default.ts
+++ b/packages/core/src/webapp/themes/default.ts
@@ -16,7 +16,6 @@
 
 import Debug from 'debug'
 
-import findThemeByName from './find'
 import { uiThemes } from '../../core/settings'
 
 const debug = Debug('core/webapp/themes/default')
@@ -25,19 +24,12 @@ const debug = Debug('core/webapp/themes/default')
  * @return the name of the default theme
  *
  */
-export async function getDefault(isDarkMode = false) {
+export async function getDefault() {
   let defaultTheme: string
   try {
     defaultTheme = require('@kui-shell/client/config.d/style.json').defaultTheme
   } catch (err) {
     console.log('using default defaultTheme')
-  }
-
-  if (isDarkMode) {
-    const darkThemeModel = await findThemeByName('Dark')
-    if (darkThemeModel) {
-      defaultTheme = darkThemeModel.theme.name
-    }
   }
 
   if (!defaultTheme) {

--- a/packages/core/src/webapp/themes/init.ts
+++ b/packages/core/src/webapp/themes/init.ts
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-import Debug from 'debug'
-
 import { switchToPersistedThemeChoice } from './persistence'
-import { isHeadless, inBrowser } from '../../core/capabilities'
-
-const debug = Debug('core/webapp/themes/init')
+import { isHeadless } from '../../core/capabilities'
 
 /**
  * Install the persistence theme choice
@@ -27,9 +23,6 @@ const debug = Debug('core/webapp/themes/init')
  */
 export default () => {
   if (!isHeadless()) {
-    if (inBrowser() || !document.body.hasAttribute('kui-theme')) {
-      debug('loading theme')
-      return switchToPersistedThemeChoice()
-    }
+    return switchToPersistedThemeChoice()
   }
 }


### PR DESCRIPTION
this avoids problems stemming from theme content relying on MiniCssExtract functionality -- which apparently does not work for webview preinjection

Fixes #3809

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
