### PR TITLE
fix(plugin-sidecar): React doesn't re-instantiate PaginatedTable for tabs located in the same LeftNav

### DIFF
--- a/plugins/plugin-client-default/config.d/about.json
+++ b/plugins/plugin-client-default/config.d/about.json
@@ -9,6 +9,14 @@
         },
         { "mode": "version", "contentFrom": "version --full" }
       ]
+    },
+    "Configure": {
+      "modes": [
+        {
+          "mode": "theme",
+          "contentFrom": "themes"
+        }
+      ]
     }
   }
 }

--- a/plugins/plugin-client-default/i18n/about_en_US.json
+++ b/plugins/plugin-client-default/i18n/about_en_US.json
@@ -2,6 +2,7 @@
   "about": "About",
   "about:content": "[![Kui: The CLI with a GUI twist](icons/svg/kui-wide.svg)](http://kui.tools)\n**Kui** is a platform for enhancing the terminal experience with visualizations. It provides users a modern alternative to ASCII terminals and web-based consoles. It provides tool developers an opportunity to unify these experiences.\n\n---\n\n[Home Page](http://kui.tools)\n\n[GitHub](https://github.com/IBM/kui)\n\n[Bugs](https://github.com/IBM/kui/issues/new)",
   "theme": "Themes",
+  "Configure": "Configure",
   "tutorial": "Getting Started",
   "version": "Version"
 }

--- a/plugins/plugin-sidecar/src/view/components/LeftNavSidecar.tsx
+++ b/plugins/plugin-sidecar/src/view/components/LeftNavSidecar.tsx
@@ -32,7 +32,6 @@ const KuiContent = React.lazy(() => import('./KuiContent'))
 
 const strings = i18n('client', 'about')
 // const strings2 = i18n('core-support')
-const strings2 = strings
 
 interface Navigation {
   title: string
@@ -107,7 +106,7 @@ export default class LeftNavSidecar extends BaseSidecar<NavResponse, State> {
       repl: tab.REPL,
       width: Width.Default,
 
-      allNavs: this.addExtraNav(navigations),
+      allNavs: navigations,
       current: { nav: 0, tab: navigations[0].currentTabIndex },
       response
     }
@@ -119,11 +118,6 @@ export default class LeftNavSidecar extends BaseSidecar<NavResponse, State> {
 
   private onResponse(tab: Tab, response: NavResponse) {
     this.setState(this.getState(tab, response))
-  }
-
-  protected addExtraNav(navs: Navigation[]) {
-    const tabs = [{ mode: 'theme', label: 'Theme', contentFrom: 'themes' }]
-    return navs.concat([{ title: strings2('Configure'), tabs, currentTabIndex: 0 }])
   }
 
   /** render menu options specified by client/config.d/about.json */
@@ -173,6 +167,7 @@ export default class LeftNavSidecar extends BaseSidecar<NavResponse, State> {
     return (
       <React.Suspense fallback={<div />}>
         <KuiContent
+          key={`${navIdx}-${tabIdx}`} // helps react distinguish similar KuiContents, see: https://github.com/IBM/kui/issues/3837
           tab={this.state.tab}
           mode={this.state.allNavs[navIdx].tabs[tabIdx]}
           response={Object.values(this.state.response)[navIdx]}


### PR DESCRIPTION
Fixes #3837

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
