### PR TITLE
fix: TabContent constructor sometimes calls this.setState

### DIFF
--- a/packages/core/src/webapp/bootstrap/boot.ts
+++ b/packages/core/src/webapp/bootstrap/boot.ts
@@ -34,7 +34,7 @@ async function initCommandRegistrar() {
  * @param { ClientRender } clientMain client-provided renderer of main content
  *
  */
-const domReady = (renderMain?: ClientRender) => async () => {
+const domReady = (inSanbox: boolean, renderMain?: ClientRender) => async () => {
   const initializer = import('./init')
   const plugins = import('../../plugins/plugins')
   const events = import('../../core/events')
@@ -59,7 +59,7 @@ const domReady = (renderMain?: ClientRender) => async () => {
         : Promise.resolve()
     )
 
-    waitForThese.push(waitForThese[1].then(() => initializer).then(_ => _.init()))
+    waitForThese.push(waitForThese[1].then(() => initializer).then(_ => _.init(inSanbox)))
 
     // await query.then(_ => _.init())
 
@@ -89,14 +89,14 @@ const domReady = (renderMain?: ClientRender) => async () => {
  *
  */
 export default async (renderMain: ClientRender) => {
-  import('./init').then(_ => _.preinit())
-  window.addEventListener('load', domReady(renderMain), { once: true })
+  import('./init').then(_ => _.preinit(false))
+  window.addEventListener('load', domReady(false, renderMain), { once: true })
 }
 
 /** For booting into an external browser sandbox, such as codesandbox.io */
 export async function bootIntoSandbox() {
   const { setMedia, Media } = await import('../../core/capabilities')
   setMedia(Media.Browser)
-  await import('./init').then(_ => _.preinit())
-  await domReady()
+  await import('./init').then(_ => _.preinit(true))
+  await domReady(true)
 }

--- a/packages/core/src/webapp/bootstrap/init.ts
+++ b/packages/core/src/webapp/bootstrap/init.ts
@@ -59,7 +59,7 @@ function inBrowser() {
   return document.body.classList.contains('not-electron')
 }
 
-export const init = async () => {
+export const init = async (inSandbox: boolean) => {
   // debug('init')
 
   const waitForThese: Promise<void>[] = []
@@ -82,7 +82,7 @@ export const init = async () => {
   //
   // see if we were passed an argv to execute on load
   //
-  if (!inBrowser()) {
+  if (!inSandbox && !inBrowser()) {
     // Notes: sequester the electron bits into their own chunk, to
     // prevent webpack from bunching code that has an
     // `import('electron')` into the main bundle
@@ -92,7 +92,7 @@ export const init = async () => {
   // debug('init done')
 }
 
-export const preinit = async () => {
+export const preinit = async (inSandbox: boolean) => {
   // debug('preinit')
 
   let prefs = {}
@@ -100,7 +100,7 @@ export const preinit = async () => {
   /** add os-xxxx to the body's classname, to allow for os-specific styling, if needed */
   document.body.classList.add(`os-${process.platform}`)
 
-  if (!inBrowser()) {
+  if (!inSandbox && !inBrowser()) {
     // Notes: sequester the electron bits into their own chunk, to
     // prevent webpack from bunching code that has an
     // `import('electron')` into the main bundle

--- a/plugins/plugin-client-common/src/components/TabContent.tsx
+++ b/plugins/plugin-client-common/src/components/TabContent.tsx
@@ -77,17 +77,19 @@ export default class TabContent extends React.PureComponent<Props, State> {
   public constructor(props: Props) {
     super(props)
 
-    eventBus.once(`/tab/new/${props.uuid}`, () => this.setState({ sessionInit: 'Done' }))
-
-    const onOffline = this.onOffline.bind(this)
-    eventBus.on(`/tab/offline/${props.uuid}`, onOffline)
-    this.cleaners.push(() => eventBus.off(`/tab/offline/${props.uuid}`, onOffline))
-
     this.state = {
       tab: undefined,
       sessionInit: 'NotYet',
       secondaryWidth: '0%'
     }
+  }
+
+  public componentDidMount() {
+    eventBus.once(`/tab/new/${this.props.uuid}`, () => this.setState({ sessionInit: 'Done' }))
+
+    const onOffline = this.onOffline.bind(this)
+    eventBus.on(`/tab/offline/${this.props.uuid}`, onOffline)
+    this.cleaners.push(() => eventBus.off(`/tab/offline/${this.props.uuid}`, onOffline))
   }
 
   /* public static getDerivedStateFromProps(props: Props, state: State) {


### PR DESCRIPTION
Fixes #3844

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
