### PR TITLE
Revert "fix(plugins/plugin-carbon-themes): reduce load time burden of ibm-ple…"

### DIFF
--- a/plugins/plugin-carbon-themes/web/css/ibm-plex.css
+++ b/plugins/plugin-carbon-themes/web/css/ibm-plex.css
@@ -1,11 +1,4 @@
-@import ~@ibm / plex/scss/sans/semibold/index;
-@import ~@ibm / plex/scss/sans/italic/index;
-@import ~@ibm / plex/scss/sans/regular/index;
-
-@import ~@ibm / plex/scss/mono/semibold/index;
-@import ~@ibm / plex/scss/mono/italic/index;
-@import ~@ibm / plex/scss/mono/normal/index;
-@import ~@ibm / plex/scss/mono/medium/index;
+@import url(~@ibm/plex/css/ibm-plex.min.css);
 
 body.kui--alternate[kui-theme-style] {
   --font-monospace: "IBM Plex Mono";


### PR DESCRIPTION
Reverts IBM/kui#3832

it turns out that there were two problems;

1) note that eslint messed up the formatting
2) the sass-loader doesn't seem to support scss loading of fonts. once you fix the first issue, you'll see "Can't resolve" errors in the webpack build.