### PR TITLE
fix: table model should not allow raw HTML Node

### DIFF
--- a/packages/core/src/models/mmr/content-types.ts
+++ b/packages/core/src/models/mmr/content-types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from 'react'
+import { ReactElement } from 'react'
 import { Tab } from '../../webapp/tab'
 import { Table, isTable } from '../../webapp/models/table'
 import { Entity, MetadataBearing } from '../entity'
@@ -34,7 +34,7 @@ export interface ScalarContent<T = ScalarResource> {
 }
 
 export type ToolbarProps = { willUpdateToolbar?: (toolbarText: ToolbarText, buttons?: Button[]) => void }
-type ReactProvider = { react: (props: ToolbarProps) => React.ReactElement<any> }
+type ReactProvider = { react: (props: ToolbarProps) => ReactElement<any> }
 export function isReactProvider(entity: ScalarLike<MetadataBearing>): entity is ReactProvider {
   const provider = entity as ReactProvider
   return typeof provider.react === 'function'

--- a/packages/core/src/webapp/models/table.ts
+++ b/packages/core/src/webapp/models/table.ts
@@ -16,6 +16,7 @@
 
 /* eslint-disable @typescript-eslint/explicit-member-accessibility */
 
+import { ReactElement } from 'react'
 import { MetadataBearing, Entity } from '../../models/entity'
 
 export class Row {
@@ -84,7 +85,7 @@ export class Row {
 export class Cell {
   value: string
 
-  valueDom?: Node[] | Node
+  valueDom?: ReactElement
 
   css?: string
 

--- a/plugins/plugin-carbon-tables/src/view/TableCell.tsx
+++ b/plugins/plugin-carbon-tables/src/view/TableCell.tsx
@@ -93,7 +93,7 @@ export default function renderCell(
                 : (kuiRow.attributes[cidx - 1].css || '') + (kuiRow.attributes[cidx - 1].onclick ? ' clickable' : ''))
             }
           >
-            {cell.value}
+            {(kuiRow.attributes[cidx - 1] && kuiRow.attributes[cidx - 1].valueDom) || cell.value}
           </span>
         </TableCell>
       )

--- a/plugins/plugin-client-common/src/components/StatusStripe/TextWithIconWidget.tsx
+++ b/plugins/plugin-client-common/src/components/StatusStripe/TextWithIconWidget.tsx
@@ -37,14 +37,17 @@ export default class TextWithIconWidget extends React.PureComponent<Props> {
       (this.props.iconIsNarrow ? 'tiny-right-pad' : 'small-right-pad') +
       (this.props.iconOnclick ? ' clickable' : '')
 
-    const iconPart = (
+    const iconPart = this.props.iconOnclick ? (
       <a
         href="#"
         className={iconClassName}
+        onMouseDown={evt => evt.preventDefault()}
         onClick={this.props.iconOnclick ? () => getCurrentTab().REPL.pexec(this.props.iconOnclick) : undefined}
       >
         {this.props.children}
       </a>
+    ) : (
+      <span className={iconClassName}>{this.props.children}</span>
     )
 
     const textPart = this.props.textOnclick ? (


### PR DESCRIPTION
instead, allow for a ReactElement

BREAKING CHANGE: table models will no longer allow for the previously supported `Node | Node[]` data type. you must instead pass a ReactElement if you want to inject custom cell content.

Fixes #3785

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
