### PR TITLE
fix: with two radio tables open, only one seems to have selection at a time

### DIFF
--- a/plugins/plugin-carbon-tables/src/view/PaginatedTable.tsx
+++ b/plugins/plugin-carbon-tables/src/view/PaginatedTable.tsx
@@ -100,21 +100,25 @@ export class PaginatedTable<P extends Props, S extends State> extends React.Pure
 
     // the view
     const dataTable = (
-      <DataTable
-        rows={visibleRows}
-        headers={headers}
-        radio={radio}
-        isSortable={false} // until we figure out how to handle sort+pagination and TableHeader className
-        sortRow={sortRow}
-        render={renderOpts => (
-          <TableContainer title={response.title} className="kui--screenshotable">
-            <Table size="compact">
-              {response.header && renderHeader(response.header, renderOpts)}
-              {renderBody(response.body, renderOpts, tab, repl)}
-            </Table>
-          </TableContainer>
-        )}
-      />
+      // `<form>` prevents the radio button selection reads from the global form of browser.
+      // See issue: https://github.com/IBM/kui/issues/3871
+      <form>
+        <DataTable
+          rows={visibleRows}
+          headers={headers}
+          radio={radio}
+          isSortable={false} // until we figure out how to handle sort+pagination and TableHeader className
+          sortRow={sortRow}
+          render={renderOpts => (
+            <TableContainer title={response.title} className="kui--screenshotable">
+              <Table size="compact">
+                {response.header && renderHeader(response.header, renderOpts)}
+                {renderBody(response.body, renderOpts, tab, repl)}
+              </Table>
+            </TableContainer>
+          )}
+        />
+      </form>
     )
 
     const pagination = needsPagination && (


### PR DESCRIPTION
Fixes #3871

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
