### PR TITLE
fix: return an NavResponse without links results in blank page

### DIFF
--- a/clients/test/plugins/plugin-test/src/lib/cmds/NavResponse.ts
+++ b/clients/test/plugins/plugin-test/src/lib/cmds/NavResponse.ts
@@ -26,9 +26,28 @@ import { tableMode } from './content/modes'
 
 interface Options extends ParsedOptions {
   switch?: boolean
+  noLinks?: boolean
 }
 
+const navResponseWithoutLinks = (): NavResponse => ({
+  apiVersion: 'kui-shell/v1',
+  kind: 'NavResponse',
+  menus: [
+    {
+      'Test Nav Without Links': {
+        kind: 'MultiModelResponse',
+        metadata: { name: 'test nav 2' },
+        modes: tableMode
+      }
+    }
+  ]
+})
+
 const doNav = () => (args: Arguments<Options>): NavResponse => {
+  if (args.parsedOptions.noLinks) {
+    return navResponseWithoutLinks()
+  }
+
   if (args.parsedOptions.switch) {
     return {
       apiVersion: 'kui-shell/v1',

--- a/clients/test/plugins/plugin-test/src/test/response/NavResponse.ts
+++ b/clients/test/plugins/plugin-test/src/test/response/NavResponse.ts
@@ -15,7 +15,7 @@
  */
 import { TestNavResponse } from '@kui-shell/test'
 
-const test = new TestNavResponse({
+const testFullNavResponse = new TestNavResponse({
   command: 'test nav',
   showing: 'Test Nav',
   modes: ['table'],
@@ -23,4 +23,12 @@ const test = new TestNavResponse({
   hrefLinks: [{ label: 'Home Page', href: 'http://kui.tools' }]
 })
 
-test.run()
+testFullNavResponse.run()
+
+const testNavResponseWithoutLinks = new TestNavResponse({
+  command: 'test nav --noLinks',
+  showing: 'Test Nav Without Links',
+  modes: ['table']
+})
+
+testNavResponseWithoutLinks.run()

--- a/packages/test/src/api/NavResponse.ts
+++ b/packages/test/src/api/NavResponse.ts
@@ -24,8 +24,8 @@ interface Param {
   command: string
   showing: string
   modes: string[]
-  commandLinks: { label: string; expect: { type: 'NavResponse'; showing: string } }[]
-  hrefLinks: { label: string; href: string }[]
+  commandLinks?: { label: string; expect: { type: 'NavResponse'; showing: string } }[]
+  hrefLinks?: { label: string; href: string }[]
 }
 
 export class TestNavResponse {

--- a/plugins/plugin-sidecar/src/view/components/LeftNavSidecar.tsx
+++ b/plugins/plugin-sidecar/src/view/components/LeftNavSidecar.tsx
@@ -121,7 +121,7 @@ export default class LeftNavSidecar extends BaseSidecar<NavResponse, State> {
       width: Width.Default,
 
       allNavs: navigations,
-      allLinks: response.links,
+      allLinks: response.links || [],
       current: { menuIdx: 0, tabIdx: navigations[0].currentTabIndex },
       response
     }


### PR DESCRIPTION
Fixes #3927

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
