### PR TITLE
fix: tables should be full-width when sidecar is open

### DIFF
--- a/plugins/plugin-carbon-tables/src/view/PaginatedTable.tsx
+++ b/plugins/plugin-carbon-tables/src/view/PaginatedTable.tsx
@@ -101,7 +101,7 @@ export class PaginatedTable<P extends Props, S extends State> extends React.Pure
     const dataTable = (visibleRows: NamedDataTableRow[]) => (
       // `<form>` prevents the radio button selection reads from the global form of browser.
       // See issue: https://github.com/IBM/kui/issues/3871
-      <form>
+      <form className="kui--data-table-wrapper">
         <DataTable
           rows={visibleRows}
           headers={headers}

--- a/plugins/plugin-carbon-tables/web/css/static/tables.scss
+++ b/plugins/plugin-carbon-tables/web/css/static/tables.scss
@@ -148,6 +148,11 @@ body[kui-theme-style] .repl.sidecar-visible {
   }
 }
 
+.sidecar-visible .kui--data-table-wrapper {
+  /* render tables full-width when sidecar is open https://github.com/IBM/kui/issues/3952 */
+  flex: 1;
+}
+
 .kui--paginated-table {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Fixes #3952

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
