### PR TITLE
fix(packages/builder): kui-compile does not work in external clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "_watch": "npm run kill; CSP_ALLOWED_HOSTS=\"http: https: data: filesystem: about: blob: ws: wss:\" kui-watch-webpack",
     "watch:webpack": "npm run pty:nodejs && (npm run proxy &); npm run _watch",
     "watch:electron": "npm run pty:electron && TARGET=electron-renderer npm run _watch",
-    "watch": "npm run kill; npm run compile && npm run link  && concurrently -n ES6,WEBPACK --kill-others 'npm run watch:source' 'npm run watch:electron'",
+    "watch": "npm run kill; npm run compile && npm run link && concurrently -n ES6,WEBPACK --kill-others 'npm run watch:source' 'npm run watch:electron'",
     "proxy": "npm run pty:nodejs && cd packages/proxy/app && npm install && PORT=8081 KUI_USE_HTTP=true ../../../tools/travis/proxy.sh ..",
     "watch:source": "tsc --build tsconfig.json --watch",
     "compile:prep": "touch node_modules/@kui-shell/prescan.json",

--- a/packages/builder/bin/babel.sh
+++ b/packages/builder/bin/babel.sh
@@ -28,16 +28,20 @@
 #
 PLUGINS=@babel/plugin-transform-modules-commonjs,dynamic-import-node-babel-7,babel-plugin-ignore-html-and-css-imports
 
+function babel {
+    npx babel --plugins $PLUGINS $1/mdist --out-dir $1/$OUT --ignore '**/*.d.ts','**/*.js.map' --no-copy-ignored &
+}
+
 for i in {packages,plugins}/*; do
     if [ -d $i/mdist ]; then
         OUT=dist
         if [ "$i" == "packages/builder" ]; then OUT=build; fi
 
-        npx babel --plugins $PLUGINS $i/mdist --out-dir $i/$OUT &
+        babel $i
 
         for j in $i/*; do
             if [ -d $j/mdist ]; then
-               npx babel --plugins $PLUGINS $j/mdist --out-dir $j/dist &
+                babel $j
             fi
         done
     fi

--- a/packages/builder/bin/compile.sh
+++ b/packages/builder/bin/compile.sh
@@ -52,7 +52,7 @@ else
   # compile the source
   npx tsc -b ${1-.}
 
-  $SCRIPTDIR/babel.sh
+  npx kui-babel
 fi
 
 if [ ! -d node_modules/@kui-shell/build ]; then


### PR DESCRIPTION
update kui-compile to call babel.sh via `npx kui-babel`

Fixes #3993

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
