### PR TITLE
fix: proxy still runs http-allocate-cert even if NO_DOCKER is set

### DIFF
--- a/packages/proxy/build.sh
+++ b/packages/proxy/build.sh
@@ -41,7 +41,12 @@ function init {
 # install the proxy-specific build bits
 function initProxy {
     pushd "$STAGING_DIR" > /dev/null
-    cp -a "$PROXY_HOME"/{package.json,build-docker.sh,Dockerfile,Dockerfile.http,.dockerignore} .
+    cp -a "$PROXY_HOME"/package.json .
+
+    if [ -z "$NO_DOCKER" ]; then
+      cp -a "$PROXY_HOME"/{build-docker.sh,Dockerfile,Dockerfile.http,.dockerignore} .
+    fi
+
     mkdir -p kui/packages/proxy
     cp -a "$PROXY_HOME"/app kui/packages/proxy
 
@@ -65,7 +70,7 @@ function headless {
 
 # create the self-signed certificate
 function cert {
-  if [ "$KUI_USE_HTTP" != "true" ] && [ -d "$BUILDER_HOME/../webpack" ]; then
+  if [ -z "${NO_DOCKER}" ] && [ "$KUI_USE_HTTP" != "true" ] && [ -d "$BUILDER_HOME/../webpack" ]; then
     pushd "$BUILDER_HOME/../webpack" > /dev/null
     CLIENT_HOME="$CLIENT_HOME" npm run http-allocate-cert
     cp -a "$CLIENT_HOME"/.keys "$STAGING_DIR"/app/bin

--- a/packages/webpack/build.sh
+++ b/packages/webpack/build.sh
@@ -135,7 +135,12 @@ function init {
 # install the webpackery bits
 function initWebpack {
     pushd "$STAGING_DIR" > /dev/null
-    cp -a "$BUILDER_HOME"/../webpack/{package.json,webpack.config.js,build-docker.sh,Dockerfile,Dockerfile.http,bin,conf.d} .
+    cp -a "$BUILDER_HOME"/../webpack/{package.json,webpack.config.js} .
+
+    if [ -z "$NO_DOCKER" ]; then
+      cp -a "$BUILDER_HOME"/../webpack/{build-docker.sh,Dockerfile,Dockerfile.http,bin,conf.d} .
+    fi
+
     popd > /dev/null
 }
 


### PR DESCRIPTION
Fixes #4137

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
