### PR TITLE
fix: headless build script has outdated use of jq

### DIFF
--- a/packages/builder/dist/headless/build.sh
+++ b/packages/builder/dist/headless/build.sh
@@ -126,33 +126,6 @@ function tarCopy {
                 --exclude "node_modules/**/docs/**/*.png" \
                 --exclude "node_modules/**/docs/**/*.js" . \
              | "$TAR" -C kui -xf -)
-
-    # check to see if the client wants to use an alternate readme
-    set +e
-    ALT="$(cat "$STAGING"/kui/package.json | jq --raw-output -e .kui.readme)"
-    if [ $? == 0 ]; then
-        if [ ! -e "$ALT" ]; then
-            # maybe ALT is specified relative to CLIENT_HOME, which
-            # would be understandable
-            ALT="$CLIENT_HOME"/"$ALT"
-        fi
-        if [ -f "$ALT" ]; then
-            echo "Copying in alternate README: $ALT"
-            cp "$ALT" "$STAGING"/kui/README.md
-        else
-            if [ -e "$ALT" ]; then
-                # so it exists, but the -f check failed
-                echo "ERROR: Specified alternate README not a file: $ALT"
-            else
-                # otherwise, it does not exist
-                echo "ERROR: Specified alternate README not found: $ALT"
-            fi
-            exit 1
-        fi
-    else
-        echo "Not using alternate README"
-    fi
-    set -e
 }
 
 function configure {


### PR DESCRIPTION
cherry-pick 4921ff5cf84831da5e704fa28f63cc4c024a972b
[jq bacaae6a1] fix: headless build script has outdated use of jq

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
