### PR TITLE
fix: font zooming issues

### DIFF
--- a/plugins/plugin-client-common/src/components/Sidecar/ToolbarButton.tsx
+++ b/plugins/plugin-client-common/src/components/Sidecar/ToolbarButton.tsx
@@ -86,7 +86,7 @@ export default class ToolbarButton<T extends ResourceWithMetadata = ResourceWith
       >
         <span role="tab">
           {button.icon ? (
-            <TooltipIcon direction="bottom" align="end" tooltipText={button.label || button.mode}>
+            <TooltipIcon className="zoomable" direction="bottom" align="end" tooltipText={button.label || button.mode}>
               {button.icon}
             </TooltipIcon>
           ) : (

--- a/plugins/plugin-client-common/src/components/Sidecar/TopNavSidecar.tsx
+++ b/plugins/plugin-client-common/src/components/Sidecar/TopNavSidecar.tsx
@@ -223,7 +223,7 @@ export default class TopNavSidecar extends BaseSidecar<MultiModalResponse, Histo
 
     return (
       <div className="sidecar-content-container">
-        <div className="custom-content zoomable">
+        <div className="custom-content">
           <ToolbarContainer
             tab={this.state.tab}
             response={this.current.response}

--- a/plugins/plugin-client-common/web/css/static/Popup.scss
+++ b/plugins/plugin-client-common/web/css/static/Popup.scss
@@ -1,31 +1,3 @@
-body.subwindow {
-  .kui--sidecar {
-    .sidecar-bottom-stripe-button-container.sidecar-bottom-stripe-back-bits .graphical-icon {
-      font-size: 3vmin;
-    }
-    .sidecar-bottom-stripe-toolbar {
-      font-size: 1.5vw;
-    }
-
-    .sidecar-bottom-stripe svg {
-      width: 2.5vmin;
-      height: 2.5vmin;
-    }
-    .sidecar-bottom-stripe-toolbar svg {
-      width: 1.5vmin;
-      height: 1.5vmin;
-    }
-
-    .sidecar-bottom-stripe-toolbar .sidecar-toolbar-text .sidecar-toolbar-text-content {
-      font-size: 1.375vmin;
-    }
-
-    .sidecar-header-name {
-      font-size: 4vh;
-    }
-  }
-}
-
 body.subwindow .kui--sidecar .sidecar-bottom-stripe-close {
   /* no close button if in subwindow/popup mode */
   display: none;
@@ -76,17 +48,10 @@ body.subwindow .kui--sidecar .padding-content {
 body.subwindow .kui--sidecar .sidecar-header-secondary-content {
   font-size: 1em;
 }
-body.subwindow:not([data-presentation='FixedSize']) .custom-content {
-  font-size: 2.5vmin;
-}
 /* Duplicate rule with line 1451 in ui.css */
 body.subwindow .kui--sidecar .repl-input,
 body.subwindow .kui--sidecar .repl-block .ok-line:not(.show-in-popup) .ok {
   display: none;
-}
-body.subwindow .kui--sidecar .sidecar-bottom-stripe {
-  font-size: 2vmin;
-  min-height: unset;
 }
 body.subwindow .kui--sidecar .usage-error-wrapper .page-content {
   display: flex;
@@ -119,13 +84,6 @@ body.subwindow .sidecar-full-screen .kui--sidecar .sidecar-header .action-conten
 body.subwindow .sidecar-full-screen sidecar:not(.minimized) .sidecar-bottom-stripe .sidecar-bottom-stripe-close {
     display: none;
 }*/
-
-body.subwindow .sidecar-bottom-stripe .sidecar-bottom-stripe-button:first-child .graphical-icon {
-  padding-left: 0.875vw;
-}
-body.subwindow .sidecar-bottom-stripe .sidecar-bottom-stripe-button .graphical-icon {
-  padding-right: 0.875vw;
-}
 
 .repl:not(.kui--input-stripe) {
   padding-top: 0;

--- a/plugins/plugin-core-support/web/css/static/zoom.css
+++ b/plugins/plugin-core-support/web/css/static/zoom.css
@@ -44,6 +44,10 @@
 .page[data-zoom="2"] .zoomable {
   font-size: 106.25% !important;
 }
+.page[data-zoom="2"] button.zoomable svg[width="16"] {
+  width: 17px;
+  height: 17px;
+}
 .page[data-zoom="2"] .graphical-icon > svg {
   width: 21.25px;
   height: 21.25px;
@@ -51,6 +55,10 @@
 .page[data-zoom="3"] .zoomable .view-lines > div,
 .page[data-zoom="3"] .zoomable {
   font-size: 112.5% !important;
+}
+.page[data-zoom="3"] button.zoomable svg[width="16"] {
+  width: 18px;
+  height: 18px;
 }
 .page[data-zoom="3"] .graphical-icon > svg {
   width: 22.25px;
@@ -63,6 +71,10 @@
 .page[data-zoom="4"] .zoomable[data-bounded-zoom] {
   font-size: 112.5% !important;
 }
+.page[data-zoom="4"] button.zoomable svg[width="16"] {
+  width: 19px;
+  height: 19px;
+}
 .page[data-zoom="4"] .graphical-icon > svg {
   width: 23.75px;
   height: 23.75px;
@@ -73,6 +85,10 @@
 }
 .page[data-zoom="5"] .zoomable[data-bounded-zoom] {
   font-size: 112.5% !important;
+}
+.page[data-zoom="5"] button.zoomable svg[width="16"] {
+  width: 20px;
+  height: 20px;
 }
 .page[data-zoom="5"] .graphical-icon > svg {
   width: 25px;
@@ -85,6 +101,10 @@
 .page[data-zoom="6"] .zoomable[data-bounded-zoom] {
   font-size: 112.5% !important;
 }
+.page[data-zoom="6"] button.zoomable svg[width="16"] {
+  width: 21px;
+  height: 21px;
+}
 .page[data-zoom="6"] .graphical-icon > svg {
   width: 26.25px;
   height: 26.25px;
@@ -95,6 +115,10 @@
 }
 .page[data-zoom="7"] .zoomable[data-bounded-zoom] {
   font-size: 112.5% !important;
+}
+.page[data-zoom="7"] button.zoomable svg[width="16"] {
+  width: 22px;
+  height: 22px;
 }
 .page[data-zoom="7"] .graphical-icon > svg {
   width: 27.5px;
@@ -107,6 +131,10 @@
 .page[data-zoom="8"] .zoomable[data-bounded-zoom] {
   font-size: 112.5% !important;
 }
+.page[data-zoom="8"] button.zoomable svg[width="16"] {
+  width: 23px;
+  height: 23px;
+}
 .page[data-zoom="8"] .graphical-icon > svg {
   width: 28.75px;
   height: 28.75px;
@@ -118,6 +146,10 @@
 .page[data-zoom="9"] .zoomable[data-bounded-zoom] {
   font-size: 112.5% !important;
 }
+.page[data-zoom="9"] button.zoomable svg[width="16"] {
+  width: 24px;
+  height: 24px;
+}
 .page[data-zoom="9"] .graphical-icon > svg {
   width: 30px;
   height: 30px;
@@ -128,6 +160,10 @@
 }
 .page[data-zoom="10"] .zoomable[data-bounded-zoom] {
   font-size: 112.5% !important;
+}
+.page[data-zoom="10"] button.zoomable svg[width="16"] {
+  width: 25px;
+  height: 25px;
 }
 .page[data-zoom="10"] .graphical-icon > svg {
   width: 31.25px;


### PR DESCRIPTION
1) in popup mode, the sidecar content and other bits still have viewport-relative sizing
2) when font zooming, the sidecar tab content is zoomed twice (two nested zoomables)
3) sidecar ToolbarButtons do not respond to font zooming

Fixes #4176
Fixes #4177

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
