### PR TITLE
fix: improve handling of narrower windows

### DIFF
--- a/plugins/plugin-client-common/src/components/StatusStripe/TextWithIconWidget.tsx
+++ b/plugins/plugin-client-common/src/components/StatusStripe/TextWithIconWidget.tsx
@@ -24,6 +24,7 @@ interface Props {
   text: string
   viewLevel: ViewLevel
 
+  className?: string
   iconIsNarrow?: boolean
   iconOnclick?: string
   textOnclick?: string
@@ -64,7 +65,11 @@ export default class TextWithIconWidget extends React.PureComponent<Props> {
 
     return (
       <div
-        className={'kui--status-stripe-element' + (!this.props.id ? '' : ' ' + this.props.id)}
+        className={
+          'kui--status-stripe-element' +
+          (!this.props.id ? '' : ' ' + this.props.id) +
+          (this.props.className ? ' ' + this.props.className : '')
+        }
         data-view={this.props.viewLevel}
       >
         {iconPart}

--- a/plugins/plugin-client-common/web/scss/components/Table/badges.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/badges.scss
@@ -59,25 +59,45 @@
   }
 }
 
-.repl.sidecar-visible .bx--data-table-container .bx--data-table {
-  th[data-key='STATUS'],
-  td.kui--status-cell {
-    padding-left: 0;
+@mixin narrow-window {
+  @media (max-width: 44rem) {
+    @content;
   }
-  [data-tag='badge'] {
-    justify-content: center;
+}
 
-    [data-tag='badge-circle'] {
-      margin: 0;
-      width: 1em;
-      height: 1em;
-      border-radius: 0;
+@mixin badge-only {
+  .bx--data-table-container .bx--data-table {
+    th[data-key='STATUS'],
+    td.kui--status-cell {
+      padding-left: 0;
     }
+    [data-tag='badge'] {
+      justify-content: center;
 
-    .kui--cell-inner-text {
-      /* show only the badge-circle when the sidecar is open */
-      display: none;
+      [data-tag='badge-circle'] {
+        margin: 0;
+        width: 1em;
+        height: 1em;
+        border-radius: 0;
+      }
+
+      .kui--cell-inner-text {
+        /* show only the badge-circle when the sidecar is open */
+        display: none;
+      }
     }
+  }
+}
+
+/* fine-tune the STATUS/badge presentation of tables when the sidecar is open, or with narrower windows */
+.repl.sidecar-visible {
+  @include badge-only;
+}
+@include narrow-window {
+  @include badge-only;
+
+  .kui--hide-in-narrower-windows {
+    display: none !important;
   }
 }
 

--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -33,7 +33,7 @@ export default function renderMain(props: KuiProps) {
   return (
     <Kui isPopup={props.isPopup} commandLine={props.commandLine}>
       <ContextWidgets>
-        <CurrentGitBranch />
+        <CurrentGitBranch className="kui--hide-in-narrower-windows" />
         <CurrentContext />
         <CurrentNamespace />
       </ContextWidgets>

--- a/plugins/plugin-git/src/CurrentGitBranch.tsx
+++ b/plugins/plugin-git/src/CurrentGitBranch.tsx
@@ -22,13 +22,17 @@ import { ViewLevel, TextWithIconWidget } from '@kui-shell/plugin-client-common'
 
 const strings = i18n('plugin-bash-like')
 
+interface Props {
+  className?: string
+}
+
 interface State {
   text: string
   viewLevel: ViewLevel
 }
 
-export default class CurrentGitBranch extends React.PureComponent<{}, State> {
-  public constructor(props = {}) {
+export default class CurrentGitBranch extends React.PureComponent<Props, State> {
+  public constructor(props: Props) {
     super(props)
 
     this.state = {
@@ -91,6 +95,7 @@ export default class CurrentGitBranch extends React.PureComponent<{}, State> {
   public render() {
     return (
       <TextWithIconWidget
+        className={this.props.className}
         text={this.state.text}
         viewLevel={this.state.viewLevel}
         id="kui--plugin-git--current-git-branch"


### PR DESCRIPTION
1) hide CurrentGitBranch in narrower windows
2) don't show the status text (only status badge) in narrower windows

Fixes #4181

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
