### PR TITLE
fix(plugins/plugin-kubectl): kubectl explain -h should render as usag…

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/explain.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/explain.ts
@@ -20,6 +20,7 @@ import flags from './flags'
 import { KubeOptions } from './options'
 import { doExecWithStdout } from './exec'
 import commandPrefix from '../command-prefix'
+import { isUsage, doHelp } from '../../lib/util/help'
 
 const strings = i18n('plugin-kubectl')
 
@@ -55,6 +56,11 @@ const kvdf = /^KIND:\s+(\S+)\nVERSION:\s+(\S+)\n\nDESCRIPTION:\n(\s*DEPRECATED -
 
 export const doExplain = (command = 'kubectl') =>
   async function(args: Arguments<KubeOptions>) {
+    if (isUsage(args)) {
+      // special case: get --help/-h
+      return doHelp(command, args)
+    }
+
     // first, we do the raw exec of the given command
     const response = await doExecWithStdout(args, undefined, command)
 

--- a/plugins/plugin-kubectl/src/test/k8s1/explain.ts
+++ b/plugins/plugin-kubectl/src/test/k8s1/explain.ts
@@ -23,6 +23,8 @@ describe('kubectl explain', function(this: Common.ISuite) {
 
   const help = doHelp.bind(this)
 
+  help('kubectl explain -h', ['kubectl', 'explain'], ['Introduction', 'Options'])
+
   help(
     'kubectl explain pod',
     ['API Resources', 'Pod'],


### PR DESCRIPTION
…e in sidecar

Fixes #4211

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
