### PR TITLE
fix: multiple tab completion bugs

### DIFF
--- a/plugins/plugin-client-common/web/css/static/repl.scss
+++ b/plugins/plugin-client-common/web/css/static/repl.scss
@@ -239,7 +239,7 @@ body/*:not(.sidecar-full-screen)*/ repl.sidecar-visible .repl-selection, body/*.
 
 .repl-block {
   .repl-input {
-    align-items: center;
+    flex-direction: column;
 
     .kui--input-and-context {
       flex: 1;

--- a/plugins/plugin-client-common/web/css/static/status-stripe.css
+++ b/plugins/plugin-client-common/web/css/static/status-stripe.css
@@ -7,91 +7,104 @@
 
   z-index: 10;
   box-shadow: 0 -3px 10px 0 rgba(175, 175, 175, 0.1);
-}
 
-.kui--status-stripe .kui--status-stripe-element a.clickable {
-  /* wrappers around clickable svgs */
-  display: flex;
-  align-items: center;
-}
+  .kui--status-stripe-element a.clickable {
+    /* wrappers around clickable svgs */
+    display: flex;
+    align-items: center;
+  }
 
-.kui--status-stripe .kui--status-stripe-element {
-  color: var(--color-fg);
-}
-.kui--status-stripe .kui--status-stripe-element svg {
-  fill: var(--color-fg);
-}
-.kui--status-stripe .kui--status-stripe-element[data-view="obscured"] {
-  color: var(--color-text-02);
-}
-.kui--status-stripe .kui--status-stripe-element[data-view="obscured"] svg {
-  fill: var(--color-text-02);
-}
-.kui--status-stripe .kui--status-stripe-element[data-view="ok"] svg {
-  fill: var(--color-green);
-}
-.kui--status-stripe .kui--status-stripe-element[data-view="warn"] svg {
-  fill: var(--color-yellow-sidecar);
-}
-.kui--status-stripe .kui--status-stripe-element[data-view="error"] svg {
-  fill: var(--color-error);
-}
-.kui--status-stripe .kui--status-stripe-element[data-view="hidden"] {
-  display: none;
-}
+  .kui--status-stripe-element {
+    color: var(--color-fg);
+  }
+  .kui--status-stripe-element svg {
+    fill: var(--color-fg);
+  }
+  .kui--status-stripe-element[data-view="obscured"] {
+    color: var(--color-text-02);
+  }
+  .kui--status-stripe-element[data-view="obscured"] svg {
+    fill: var(--color-text-02);
+  }
+  .kui--status-stripe-element[data-view="ok"] svg {
+    fill: var(--color-green);
+  }
+  .kui--status-stripe-element[data-view="warn"] svg {
+    fill: var(--color-yellow-sidecar);
+  }
+  .kui--status-stripe-element[data-view="error"] svg {
+    fill: var(--color-error);
+  }
+  .kui--status-stripe-element[data-view="hidden"] {
+    display: none;
+  }
 
-.kui--status-stripe > div {
-  display: flex;
-}
-.kui--status-stripe .kui--status-stripe-context {
-  flex: 1;
-  font-size: 0.6875em;
-  padding-left: calc(1em * 0.875 / 0.6875);
-}
-.kui--status-stripe .kui--status-stripe-meter {
-  font-size: 0.6875em;
-  padding-left: 1em;
-}
+  & > div {
+    display: flex;
+  }
+  .kui--status-stripe-context {
+    flex: 1;
+    font-size: 0.6875em;
+    padding-left: calc(1em * 0.875 / 0.6875);
+  }
+  .kui--status-stripe-meter {
+    font-size: 0.6875em;
+    padding-left: 1em;
+  }
 
-.kui--status-stripe .kui--status-stripe-right {
-  justify-content: flex-end;
-}
+  .kui--status-stripe-right {
+    justify-content: flex-end;
+  }
 
-.kui--status-stripe .kui--status-stripe-element {
-  display: flex;
-  align-items: center;
-  font-weight: bold;
-  margin-right: calc(1em * 0.875);
-}
+  .kui--status-stripe-element {
+    display: flex;
+    align-items: center;
+    font-weight: bold;
+    margin-right: calc(1em * 0.875);
+  }
 
-.kui--status-stripe-element > a {
-  /* see https://github.com/IBM/kui/issues/3489 */
-  display: flex;
-  align-items: center;
-}
+  .kui--status-stripe-element > a {
+    /* see https://github.com/IBM/kui/issues/3489 */
+    display: flex;
+    align-items: center;
+  }
 
-.kui--status-stripe .clickable {
-  color: var(--color-fg);
-  text-decoration: none;
-}
+  .clickable {
+    color: var(--color-fg);
+    text-decoration: none;
+  }
 
-.kui--status-stripe .kui--status-stripe-element .clickable:hover {
-  color: var(--color-brand-01);
-  text-decoration: none;
-}
+  .kui--status-stripe-element .clickable:hover {
+    color: var(--color-brand-01);
+    text-decoration: none;
+  }
 
-.kui--status-stripe .kui--status-stripe-button .kui--status-stripe-element {
-  padding: 3px;
-  margin-right: calc(1em * 0.875 - 2 * 3px);
+  .kui--status-stripe-button .kui--status-stripe-element {
+    padding: 3px;
+    margin-right: calc(1em * 0.875 - 2 * 3px);
 
-  &:hover {
-    background-color: var(--color-table-border1);
-    svg {
-      fill: var(--color-text-01) !important;
+    &:hover {
+      background-color: var(--color-table-border1);
+      svg {
+        fill: var(--color-text-01) !important;
+      }
     }
   }
-}
 
-.kui--status-stripe-icon {
-  opacity: 0.875;
+  .kui--status-stripe-icon {
+    opacity: 0.875;
+  }
+
+  /* tab completions in status stripe input element */
+  .kui--input-stripe .repl-block .kui--tab-completions {
+    bottom: 1.875rem;
+    left: 0;
+    background-color: var(--color-sidecar-background-01);
+    border-bottom: 1px solid var(--color-table-border3);
+    z-index: 100;
+
+    .kui--tab-completions--option .bx--btn--primary:focus {
+      border-radius: 4px 4px 0px 0px;
+    }
+  }
 }

--- a/plugins/plugin-kubectl/src/lib/tab-completion.ts
+++ b/plugins/plugin-kubectl/src/lib/tab-completion.ts
@@ -25,7 +25,7 @@ async function getMatchingStrings(tab: Tab, cmd: string, spec: TabCompletionSpec
   const completions: string = await tab.REPL.qexec(cmd, undefined, undefined, { raw: true })
   const list: string[] = completions.split(/[\n\r]/).map(_ => _.replace(/^\w+\//, ''))
 
-  return list.filter(name => name.startsWith(spec.toBeCompleted))
+  return list.filter(name => name.startsWith(spec.toBeCompleted)).map(name => name.substring(spec.toBeCompleted.length))
 }
 
 /**

--- a/plugins/plugin-kubectl/src/test/k8s1/tab-completion.ts
+++ b/plugins/plugin-kubectl/src/test/k8s1/tab-completion.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
+import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
 import { tabby, tabbyWithOptions } from '@kui-shell/plugin-core-support/tests/lib/core-support/tab-completion-util'
 import { dirname } from 'path'
 import { waitForGreen, createNS, allocateNS, deleteNS } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
@@ -40,11 +40,11 @@ describe(`kubectl get tab completion ${process.env.MOCHA_RUN_TARGET || ''}`, fun
     allocateNS(this, ns3)
 
     it(`should tab complete unique namespace`, () => {
-      return tabby(this.app, `k get pods -n ${uniquePrefix}`, `k get pods -n ${ns3}`, false) // it's ok to have an error, as we don't have any pods, yet
+      return tabby(this, `k get pods -n ${uniquePrefix}`, `k get pods -n ${ns3}`, false) // it's ok to have an error, as we don't have any pods, yet
     })
 
     it(`should tab complete namespaces not unique`, () => {
-      return tabbyWithOptions(this.app, `k get pods -n ${commonPrefix}`, [ns, ns2], `k get pods -n ${ns}`, {
+      return tabbyWithOptions(this, `k get pods -n ${commonPrefix}`, [ns, ns2], `k get pods -n ${ns}`, {
         click: 0,
         expectOK: false, // it's ok to have an error, as we don't have any pods, yet
         expectedPromptAfterTab: `k get pods -n ${commonPrefix}`
@@ -84,12 +84,12 @@ describe(`kubectl get tab completion ${process.env.MOCHA_RUN_TARGET || ''}`, fun
     })
 
     it(`should tab complete pods`, () => {
-      return tabby(this.app, `k get pods -n ${ns} n`, `k get pods -n ${ns} nginx`)
+      return tabby(this, `k get pods -n ${ns} n`, `k get pods -n ${ns} nginx`)
     })
 
     it(`should tab complete pods not unique`, () => {
       return tabbyWithOptions(
-        this.app,
+        this,
         `k get pods -n ${ns} t`,
         [`tab-completion-1`, `tab-completion-2`],
         `k get pods -n ${ns} tab-completion-1`,
@@ -105,4 +105,3 @@ describe(`kubectl get tab completion ${process.env.MOCHA_RUN_TARGET || ''}`, fun
     deleteNS(this, ns3)
   })
 })
-*/


### PR DESCRIPTION
1) kubectl tab completions have repeated prefix text
2) tab completions render side-by-side instead of below Input
3) popup tab completions are not visible
4) kubectl tab completions test was disabled, needs to be revived

Fixes #4281

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
