### PR TITLE
fix(plugins/plugin-kubectl): we shouldn't render namespace widget when the namespace is empty in kube config

### DIFF
--- a/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
@@ -52,10 +52,12 @@ export default class CurrentNamespace extends React.PureComponent<{}, State> {
       const currentContext = await getCurrentContext(tab)
       eventChannelUnsafe.emit('/kubeui/context/current', currentContext)
 
-      this.setState({
-        text: currentContext === undefined ? '' : this.renderNamespace(currentContext),
-        viewLevel: 'normal' // only show normally if we succeed; see https://github.com/IBM/kui/issues/3537
-      })
+      if (currentContext.metadata.namespace) {
+        this.setState({
+          text: currentContext === undefined ? '' : this.renderNamespace(currentContext),
+          viewLevel: 'normal' // only show normally if we succeed; see https://github.com/IBM/kui/issues/3537
+        })
+      }
     } catch (err) {
       console.error(err)
 


### PR DESCRIPTION
Fixes #4274

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
