### PR TITLE
fix: ibmcloud plugin list does not list unofficial plugins

### DIFF
--- a/plugins/plugin-ibmcloud/plugin/src/controller/list.ts
+++ b/plugins/plugin-ibmcloud/plugin/src/controller/list.ts
@@ -42,7 +42,7 @@ async function doLs(args: Arguments<ListOptions>): Promise<Table> {
   // Notes: the filter reduces allInstalled down to those installed in
   // the specified repo
   const rowData = Object.keys(allInstalled)
-    .filter(installedName => available.find(({ name: availableName }) => availableName === installedName))
+    //    .filter(installedName => available.find(({ name: availableName }) => availableName === installedName))
     .map(key => {
       const { Name: name, Aliases, Version } = allInstalled[key]
 

--- a/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
+++ b/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
@@ -91,7 +91,7 @@ async function needle({ qexec }: REPL, method: 'get', url: string): Promise<{ st
         })
 
         response.on('data', chunk => {
-          debug('got chunk', chunk.toString())
+          // debug('got chunk', chunk.toString())
           body += chunk.toString()
         })
       })


### PR DESCRIPTION
Fixes #4339

also removes superfluous debug output from kubectl fetch-file

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
