### PR TITLE
fix: pty/client performance tweaks

### DIFF
--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -51,7 +51,6 @@ const exitAltBufferPattern = /\x1b\[\??(47|1047|1049)l/
 
 import copy from './copy'
 
-import 'xterm/css/xterm.css'
 import '../../web/css/static/xterm.css'
 
 interface Size {
@@ -898,8 +897,8 @@ export const doExec = (
           }
 
           // heuristic for hiding empty rows
-          terminal.element.classList.add('xterm-empty-row-heuristic')
-          setTimeout(() => terminal.element.classList.remove('xterm-empty-row-heuristic'), 100)
+          // terminal.element.classList.add('xterm-empty-row-heuristic')
+          // setTimeout(() => terminal.element.classList.remove('xterm-empty-row-heuristic'), 100)
 
           //
           // on exit, remove event handlers and the like

--- a/plugins/plugin-bash-like/web/css/static/xterm.css
+++ b/plugins/plugin-bash-like/web/css/static/xterm.css
@@ -1,3 +1,5 @@
+@import "~xterm/css/xterm.css";
+
 /* Explanation for width hacks:
    see https://github.com/xtermjs/xterm.js/pull/2067
    see https://github.com/IBM/kui/issues/1518
@@ -62,6 +64,7 @@ disabled see https://github.com/IBM/kui/issues/3939
       }
       &.processing {
         padding: 0;
+        margin: 0;
         -webkit-app-region: no-drag; /* but make sure the content of the blocks are not draggable */
 
         .bx--accordion__heading {
@@ -88,9 +91,9 @@ disabled see https://github.com/IBM/kui/issues/3939
   }
 }
 
-.kui--tab-content:not(.xterm-alt-buffer-mode) .xterm.xterm-empty-row-heuristic .xterm-rows > div:empty {
+/* .kui--tab-content:not(.xterm-alt-buffer-mode) .xterm.xterm-empty-row-heuristic .xterm-rows > div:empty {
   display: none;
-}
+} */
 
 .xterm .xterm-rows .xterm-hidden-row {
   display: none;
@@ -119,6 +122,7 @@ disabled see https://github.com/IBM/kui/issues/3939
   transition-delay: 150ms; /* only show the spinner block if the command takes a bit longer */
 }
 .xterm-container .xterm-rows:not(.xterm-focus) .xterm-cursor.xterm-cursor-block {
+  background-color: var(--color-base03) !important;
   outline-color: transparent !important;
 }
 


### PR DESCRIPTION
this also fixes a long-standing minor issue where non-focused xterms had an unthemed cursor color; you will see this usually as a brief low-contrast cursor block when launching certain apps

Fixes #4397

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
