### PR TITLE
feat: allow themes to dictate Kui client properties

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -120,7 +120,7 @@ export { Tab, getCurrentTab, getTabId, sameTab } from './webapp/tab'
 export { default as TabState } from './models/tab-state'
 
 // Themes
-export { default as Theme } from './webapp/themes/Theme'
+export { default as Theme, ThemeProperties } from './webapp/themes/Theme'
 export { findByName as findThemeByName } from './webapp/themes/find'
 export { getDefault as getDefaultTheme } from './webapp/themes/default'
 export {

--- a/packages/core/src/webapp/themes/Theme.ts
+++ b/packages/core/src/webapp/themes/Theme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 IBM Corporation
+ * Copyright 2019-2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,15 +20,22 @@ export const apiVersion = 'v2'
 /** all known Theme apiVersions */
 export type ThemeApiVersion = 'v1' | 'v2'
 
-export default interface Theme {
+/** Properties that can be associated with <Kui/> component */
+export interface ThemeProperties {
+  components: 'carbon' | 'patternfly'
+  topTabNames: 'command' | 'fixed'
+}
+
+type Theme = ThemeProperties & {
   apiVersion?: ThemeApiVersion
   name: string
   description?: string
   css: string | string[]
   attrs?: string[]
   style: string
-  topTabNames: 'command' | 'fixed'
 }
+
+export default Theme
 
 export interface ThemeSet {
   /** import path prefix for all themes */

--- a/plugins/plugin-client-common/src/components/Client/KuiConfiguration.tsx
+++ b/plugins/plugin-client-common/src/components/Client/KuiConfiguration.tsx
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-interface KuiConfiguration {
+import { ThemeProperties } from '@kui-shell/core'
+
+type KuiConfiguration = Partial<ThemeProperties> & {
   /** This will be displayed in the upper left of the TopTabStripe */
   productName?: string
-
-  /** component library */
-  components?: 'carbon' | 'patternfly'
 }
 
 export default KuiConfiguration

--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -33,7 +33,7 @@ import { productName } from '@kui-shell/client/config.d/name.json'
  */
 export default function renderMain(props: KuiProps) {
   return (
-    <Kui productName={productName} components="carbon" {...props}>
+    <Kui productName={productName} {...props}>
       <ContextWidgets>
         <CurrentGitBranch className="kui--hide-in-narrower-windows" />
         <CurrentContext />

--- a/plugins/plugin-patternfly4-themes/theme.json
+++ b/plugins/plugin-patternfly4-themes/theme.json
@@ -5,7 +5,8 @@
       "css": ["patternfly4-light.scss"],
       "attrs": ["kui--patternfly4", "pf-t-light", "kui--sidecar-inverted"],
       "style": "light",
-      "topTabNames": "fixed"
+      "topTabNames": "fixed",
+      "components": "patternfly"
     }
   ]
 }


### PR DESCRIPTION
Fixes #4409

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
