### PR TITLE
doc: improved documentation for component development

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -1,22 +1,61 @@
 # Colors, Icons, Component Libraries in Kui
 
-Kui divides theming into three aspects: colors, icons, and components.
-FOr the latter two, Kui currently supports [Carbon Component
-Library](https://www.carbondesignsystem.com) and (partially)
-PatternFly v4, via React.
+Kui divides theming into three aspects:
 
-## Colors
+- [Components](#components), such as breadcrumbs and tables.
+- [Icons](#icons), such as a trash can icon.
+- [Colors](#colors) of the component UI.
 
-TODO
+Kui strives to make these three orthogonal choices.
 
 ## Components
 
-## Carbon Components
+Kui employs a combination of home-grown React components and
+components from third-party open source component frameworks. A
+selection of the latter components are currently hosted by an SPI,
+with support for [Carbon Components](https://www.carbondesignsystem.com) and (partially)
+[PatternFly v4](https://www.patternfly.org/v4/). The remaining
+third-party components in use are not yet SPI'd.
 
-The are fully supported in Kui for the following components:
+### How to Choose a Component Provider
+
+Kui uses a [React Context](https://reactjs.org/docs/context.html) to
+allow for a choice of component provider. Currently, Carbon Component
+Library is the default choice. To inspect or modify this default,
+consult
+[DefaultKuiConfiguration](../plugins/plugin-client-common/src/components/Client/DefaultKuiConfiguration.ts).
+
+To use Patternfly 4 Library in your client, either modify the default
+in your fork, or add `components="patternfly"` to your use of the
+`<Kui/>` client component. For example, the following code will set
+Kui default client to use Patternfly 4 Library.
+
+```typescript
+import { Kui, KuiProps } from '@kui-shell/plugin-client-common'
+
+export default function MyKui(props: KuiProps) {
+  return (
+    <Kui productName={productName} components="patternfly" {...props}>
+      {children}
+    </Kui>
+  )
+}
+```
+
+### SPI for Third Party Components
+
+#### Breadcrumb
+
+- [SPI Interface](../plugins/plugin-client-common/src/components/spi/Breadcrumb/model.ts)
+- [Carbon Components impl](../plugins/plugin-client-common/src/components/spi/Breadcrumb/impl/Carbon.tsx)
+- [PatternFly4 impl](../plugins/plugin-client-common/src/components/spi/Breadcrumb/impl/PatternFly.tsx)
+
+## Work In Progress: Third Party Components Not Yet under an SPI
+
+The following is a comprehensive list of the third party components
+that are currently hard-wired to use Carbon Components:
 
 - [Badge](https://github.com/IBM/kui/blob/master/plugins/plugin-client-common/src/components/Views/Sidecar/Badge.tsx)
-- [Breadcrumb](https://github.com/IBM/kui/blob/master/plugins/plugin-client-common/src/components/Views/Breadcrumb/Carbon.tsx)
 - [Code Snippet](https://github.com/IBM/kui/blob/master/plugins/plugin-client-common/src/components/Content/Markdown.tsx)
 - [Confirm](https://github.com/IBM/kui/blob/master/plugins/plugin-client-common/src/components/Views/Confirm.tsx)
 - [LeftNavSidecar Content](https://github.com/IBM/kui/blob/master/plugins/plugin-client-common/src/components/Views/Sidecar/LeftNavSidecar.tsx)
@@ -31,23 +70,11 @@ The are fully supported in Kui for the following components:
 - [TopNavSidecar Tabs](https://github.com/IBM/kui/blob/master/plugins/plugin-client-common/src/components/Views/Sidecar/TopNavSidecar.tsx)
 - [TopTabStribe](https://github.com/IBM/kui/blob/master/plugins/plugin-client-common/src/components/Client/TopTabStripe/Tab.tsx)
 
-Kui also prototypically supports [Patternfly 4 Libray](https://www.patternfly.org/v4/) for [Breadcrumb](https://github.com/IBM/kui/blob/master/plugins/plugin-client-common/src/components/Views/Breadcrumb/Patternfly.tsx) and [Navigation](https://github.com/IBM/kui/blob/master/plugins/plugin-client-common/src/components/Views/Sidecar/Navigation/Patternfly.tsx) components.
+The Navigation component currently also supports PatternFly v4
+([here](https://github.com/IBM/kui/blob/master/plugins/plugin-client-common/src/components/Views/Sidecar/Navigation/Patternfly.tsx)),
+though is not yet structured under an SPI.
 
-Kui uses [React Context](https://reactjs.org/docs/context.html) for choosing between the component libraries to use. Currently, Carbon Component Library is the default choice. To use Patternfly 4 Library in your client, you can add `components="patternfly"` to the `<Kui/>` client component. For example, the following code will set Kui default client to use Patternfly 4 Library.
-
-plugins/plugin-client-default/src/index.tsx
-
-```typescript
-export default function renderMain(props: KuiProps) {
-  return (
-    <Kui productName={productName} components="patternfly" {...props}>
-      {children}
-    </Kui>
-  )
-}
-```
-
-## Icon SPI
+## Icons
 
 Kui has an SPI for icons. You may add new icons or add support for a
 new icon library by extending either the interface or the
@@ -58,3 +85,7 @@ the
 subdirectory, you will find the current implementations. The SPI
 delegate currently ties the choice of icon provider to the choice of
 component provider.
+
+## Colors
+
+Coming soon.

--- a/plugins/plugin-bash-like/src/test/bash-like/pty-copy-paste.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/pty-copy-paste.ts
@@ -126,16 +126,16 @@ describe(`xterm copy paste ${process.env.MOCHA_RUN_TARGET || ''}`, function(this
       await this.app.client.execute(() => document.execCommand('paste'))
 
       // escape then :wq
-      console.error('CP12')
-      await this.app.client.keys(Keys.ESCAPE)
-      console.error('CP13')
       let idx = 0
       await this.app.client.waitUntil(async () => {
+        console.error(`CP12.${idx}`)
+        await this.app.client.keys(Keys.ESCAPE)
+        console.error(`CP13.${idx}`)
         const txt = await this.app.client.getText(lastRow(res.count))
         if (++idx > 5) {
           console.error(`still waiting for text actualValue=${txt} whereas length should be zero`)
         }
-        return txt.length === 0
+        return !/INSERT/i.test(txt)
       }, CLI.waitTimeout)
 
       console.error('CP14')

--- a/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
@@ -23,7 +23,6 @@ import sortRow from './sort'
 import renderBody from './TableBody'
 import renderHeader from './TableHeader'
 import Toolbar, { Props as ToolbarProps } from './Toolbar'
-import { BreadcrumbView } from '../../spi/Breadcrumb'
 import Grid from './Grid'
 import kui2carbon, { NamedDataTableRow } from './kui2carbon'
 
@@ -106,7 +105,7 @@ export default class PaginatedTable<P extends Props, S extends State> extends Re
 
   private topToolbar() {
     if (this.props.toolbars) {
-      const titleBreadcrumb: BreadcrumbView[] = this.props.response.title
+      const titleBreadcrumb = this.props.response.title
         ? [{ label: this.props.response.title, className: 'kui--data-table-title' }]
         : []
       const breadcrumbs = titleBreadcrumb.concat(

--- a/plugins/plugin-client-common/src/components/spi/Breadcrumb/impl/Carbon.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Breadcrumb/impl/Carbon.tsx
@@ -17,7 +17,8 @@
 import * as React from 'react'
 import { Breadcrumb, BreadcrumbItem } from 'carbon-components-react'
 
-import { Props, getCurrentPageIdx } from '..'
+import Props from '../model'
+import { getCurrentPageIdx } from '..'
 
 import '../../../../../web/scss/components/Breadcrumb/Carbon.scss'
 

--- a/plugins/plugin-client-common/src/components/spi/Breadcrumb/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Breadcrumb/impl/PatternFly.tsx
@@ -17,7 +17,8 @@
 import * as React from 'react'
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core'
 
-import { Props, getCurrentPageIdx } from '..'
+import Props from '../model'
+import { getCurrentPageIdx } from '..'
 
 import '../../../../../web/scss/components/Breadcrumb/Patternfly.scss'
 

--- a/plugins/plugin-client-common/src/components/spi/Breadcrumb/index.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Breadcrumb/index.tsx
@@ -15,29 +15,25 @@
  */
 
 import * as React from 'react'
-import { REPL, Breadcrumb as BreadcrumbModel } from '@kui-shell/core'
 
 import Carbon from './impl/Carbon'
 import PatternFly4 from './impl/PatternFly'
 import KuiContext from '../../Client/context'
 
-export type BreadcrumbView = BreadcrumbModel & { deemphasize?: boolean; isCurrentPage?: boolean; className?: string }
+import Props, { BreadcrumbView } from './model'
+export { Props, BreadcrumbView }
 
-export interface Props {
-  repl: REPL
-  breadcrumbs: BreadcrumbView[]
-}
-
-function currentPageIdxAsSpecified(props: Props) {
-  return props.breadcrumbs && props.breadcrumbs.findIndex(_ => _.isCurrentPage)
-}
-
+/**
+ * Kui allows for one of the breadcrumbs to be distinguished. We term
+ * this the "current page".
+ *
+ */
 export function getCurrentPageIdx(props: Props) {
-  const asSpecified = currentPageIdxAsSpecified(props)
+  const asSpecified = props.breadcrumbs && props.breadcrumbs.findIndex(_ => _.isCurrentPage)
   return asSpecified < 0 ? props.breadcrumbs.length - 1 : asSpecified
 }
 
-export default function iconImpl(props: Props): React.ReactElement {
+export default function BreadcrumbSpi(props: Props): React.ReactElement {
   return (
     <KuiContext.Consumer>
       {config => (config.components === 'patternfly' ? <PatternFly4 {...props} /> : <Carbon {...props} />)}

--- a/plugins/plugin-client-common/src/components/spi/Breadcrumb/model.ts
+++ b/plugins/plugin-client-common/src/components/spi/Breadcrumb/model.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { REPL, Breadcrumb as BreadcrumbModel } from '@kui-shell/core'
+
+/**
+ * The View extends the core BreadcrumbModel with a handful of
+ * properties to aid in rendering the UI.
+ *
+ */
+export type BreadcrumbView = BreadcrumbModel & { deemphasize?: boolean; isCurrentPage?: boolean; className?: string }
+
+interface Props {
+  repl: REPL
+  breadcrumbs: BreadcrumbView[]
+}
+
+export default Props


### PR DESCRIPTION
Fixes #4445

this PR got jammed up in #4447 also; the fix for that is, after hitting ESCAPE, to look for the absence of "INSERT", rather than (as we did prior to this PR) looking for an empty string in the vim status line.
Fixes #4447


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
