### PR TITLE
fix: js and ts files do not get syntax coloring

### DIFF
--- a/plugins/plugin-bash-like/fs/src/lib/open.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/open.ts
@@ -25,7 +25,8 @@ import {
   i18n,
   Arguments,
   Registrar,
-  KResponse
+  KResponse,
+  SupportedStringContent
 } from '@kui-shell/core'
 
 import File from './File'
@@ -34,6 +35,23 @@ import { localFilepath } from './usage-helpers'
 
 const strings = i18n('plugin-bash-like')
 const debug = Debug('plugins/bash-like/cmds/open')
+
+/** Important for alignment to the Editor view component */
+function contentTypeOf(suffix: string): SupportedStringContent {
+  switch (suffix) {
+    case 'sh':
+      return 'shell'
+    case 'md':
+      return 'text/markdown'
+    case 'html':
+      return 'text/html'
+    case 'yaml':
+    case 'json':
+      return suffix
+    default:
+      return 'text/plain'
+  }
+}
 
 /**
  * Decide how to display a given filepath
@@ -89,16 +107,7 @@ async function open({ argvNoOptions, REPL }: Arguments): Promise<KResponse> {
           ? {
               mode: 'view',
               label: strings('Edit'),
-              contentType:
-                suffix === 'sh'
-                  ? 'shell'
-                  : suffix === 'md'
-                  ? 'text/markdown'
-                  : suffix === 'html'
-                  ? 'text/html'
-                  : suffix === 'yaml' || suffix === 'json'
-                  ? suffix
-                  : 'text/plain',
+              contentType: contentTypeOf(suffix),
               content: data
             }
           : {

--- a/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
@@ -15,6 +15,7 @@
  */
 
 import * as React from 'react'
+import { extname } from 'path'
 import { IDisposable, editor as Monaco, Range } from 'monaco-editor'
 
 import { File, isFile } from '@kui-shell/plugin-bash-like/fs'
@@ -241,7 +242,13 @@ export default class Editor extends React.PureComponent<Props, State> {
           !isFile(props.response) &&
           (!props.response.spec || props.response.spec.readOnly !== false) &&
           (props.readOnly || !isFile(props.response) || false),
-        language: props.content.contentType ? language(props.content.contentType) : undefined
+        language:
+          props.content.contentType === 'text/plain'
+            ? language(
+                props.content.contentType,
+                isFile(props.response) ? extname(props.response.spec.filepath).slice(1) : undefined
+              )
+            : props.content.contentType || undefined
       }
       const options = Object.assign(defaultMonacoOptions(providedOptions), providedOptions)
       const editor = Monaco.create(state.wrapper, options)

--- a/plugins/plugin-client-common/src/components/Content/Editor/lib/file-types.ts
+++ b/plugins/plugin-client-common/src/components/Content/Editor/lib/file-types.ts
@@ -21,11 +21,13 @@ const debug = Debug('plugins/editor/file-types')
  * What is the monaco "language" for the given kind?
  *    only nodejs and compositions diverge from monaco's notation
  */
-export const language = (kind: string) => {
-  const base = kind.substring(0, kind.indexOf(':')) || kind
-  debug('language', kind, base)
+export const language = (kind: string, extension?: string) => {
+  const base = extension || kind.substring(0, kind.indexOf(':')) || kind
+  debug('language', kind, extension, base)
 
   if (base === 'nodejs' || base === 'app' || base === 'composition' || base === 'sequence') {
+    return 'javascript'
+  } else if (base === 'js') {
     return 'javascript'
   } else if (base === 'ts') {
     return 'typescript'


### PR DESCRIPTION
Fixes #4450

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
