### PR TITLE
fix: use 30/70 split for LeftNavSidecar

### DIFF
--- a/plugins/plugin-bash-like/fs/src/lib/ls.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/ls.ts
@@ -131,6 +131,9 @@ function nameOf(glob: GlobStats): string {
 const outerCSSSecondary = 'hide-with-sidecar'
 const cssSecondary = 'slightly-deemphasize'
 
+const outerCSSLesser = 'hide-with-narrow-window'
+const cssLesser = 'elide-with-narrow-window'
+
 function formatPermissions({ dirent }: GlobStats) {
   return dirent.permissions
 }
@@ -147,13 +150,19 @@ function attrs(entry: GlobStats, args: Arguments<LsOptions>) {
 
   const wide = args.parsedOptions.l
   const perms = wide ? [{ value: formatPermissions(entry), outerCSS: outerCSSSecondary }] : []
-  const uid = wide ? [{ value: formatUid(entry), outerCSS: '', css: cssSecondary }] : []
-  const gid = wide ? [{ value: formatGid(entry), outerCSS: '', css: cssSecondary }] : []
+  const uid = wide ? [{ value: formatUid(entry), outerCSS: outerCSSSecondary, css: cssSecondary }] : []
+  const gid = wide ? [{ value: formatGid(entry), outerCSS: outerCSSSecondary, css: cssSecondary }] : []
   const size = wide
     ? [{ value: prettyBytes(entry.stats.size).replace(/\s/g, ''), outerCSS: `${outerCSSSecondary} text-right` }]
     : []
   const lastMod = wide
-    ? [{ value: prettyTime(entry.stats.mtimeMs), outerCSS: 'badge-width', css: `${cssSecondary} pre-wrap` }]
+    ? [
+        {
+          value: prettyTime(entry.stats.mtimeMs),
+          outerCSS: outerCSSLesser,
+          css: `${cssLesser} ${cssSecondary} pre-wrap`
+        }
+      ]
     : []
 
   return perms
@@ -198,12 +207,11 @@ function toTable(entries: GlobStats[], args: Arguments<LsOptions>): HTMLElement 
     container.appendChild(frag)
     return container
   } else {
-    const wide = args.parsedOptions.l
-    const perms = wide ? [{ value: 'PERMISSIONS', outerCSS: outerCSSSecondary }] : []
-    const uid = wide ? [{ value: 'USER', outerCSS: '' }] : []
-    const gid = wide ? [{ value: 'GROUP', outerCSS: '' }] : []
-    const size = wide ? [{ value: 'SIZE', outerCSS: `${outerCSSSecondary} text-right` }] : []
-    const lastMod = wide ? [{ value: 'LAST MODIFIED', outerCSS: 'badge-width' }] : []
+    const perms = [{ value: 'PERMISSIONS', outerCSS: outerCSSSecondary }]
+    const uid = [{ value: 'USER', outerCSS: outerCSSSecondary }]
+    const gid = [{ value: 'GROUP', outerCSS: outerCSSSecondary }]
+    const size = [{ value: 'SIZE', outerCSS: `${outerCSSSecondary} text-right` }]
+    const lastMod = [{ value: 'LAST MODIFIED', outerCSS: outerCSSLesser, css: cssLesser }]
 
     const header = {
       name: 'NAME',

--- a/plugins/plugin-client-common/src/components/Content/Table/TableHeader.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableHeader.tsx
@@ -27,19 +27,24 @@ export default function renderHeader(kuiHeader: KuiRow, { getHeaderProps, header
   return (
     <TableHead>
       <TableRow>
-        {headers.map((header, cidx) => (
-          <TableHeader
-            key={header.key}
-            {...getHeaderProps({
-              header,
-              'data-key': header.key,
-              // isSortable: isSortable && (!radio || cidx > 0),
-              className: cidx === 0 ? kuiHeader.outerCSS : kuiHeader.attributes[cidx - 1].outerCSS
-            })}
-          >
-            {header.header}
-          </TableHeader>
-        ))}
+        {headers.map((header, cidx) => {
+          const outerCSS = cidx === 0 ? kuiHeader.outerCSS : kuiHeader.attributes[cidx - 1].outerCSS
+          const css = cidx === 0 ? kuiHeader.css : kuiHeader.attributes[cidx - 1].css
+
+          return (
+            <TableHeader
+              key={header.key}
+              {...getHeaderProps({
+                header,
+                'data-key': header.key,
+                // isSortable: isSortable && (!radio || cidx > 0),
+                className: outerCSS
+              })}
+            >
+              {css ? <span className={css}>{header.header}</span> : header.header}
+            </TableHeader>
+          )
+        })}
       </TableRow>
     </TableHead>
   )

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/LeftNavSidecar.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/LeftNavSidecar.tsx
@@ -91,9 +91,9 @@ export default class LeftNavSidecar extends BaseSidecar<NavResponse, HistoryEntr
     return false
   }
 
-  /** matching the old `flex: 3.5` compared to `flex: 4` for the Terminal */
+  /** 30/70 split between the Terminal and the LeftNavSidecar */
   protected defaultWidth(): Width {
-    return Width.Split45
+    return Width.Split70
   }
 
   /** @return a `HistoryEntry` for the given `Response` */

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/width.ts
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/width.ts
@@ -17,6 +17,7 @@
 const enum Width {
   Split45 = '45%',
   Split60 = '60%',
+  Split70 = '70%',
   Split75 = '75%',
   Maximized = '100%',
   Closed = '0%'

--- a/plugins/plugin-client-common/web/scss/components/common/_narrow-window.scss
+++ b/plugins/plugin-client-common/web/scss/components/common/_narrow-window.scss
@@ -10,4 +10,24 @@
   .page[data-zoom='10'] {
     @content;
   }
+
+  @media (max-width: 58rem) {
+    .sidecar-visible .hide-with-narrow-window {
+      display: none;
+    }
+  }
+
+  @media (max-width: 68rem) {
+    .sidecar-visible .elide-with-narrow-window {
+      display: inline-block;
+      max-width: 6em;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    .sidecar-visible .hide-with-narrow-window {
+      display: none;
+    }
+  }
 }

--- a/plugins/plugin-core-support/src/lib/cmds/theme.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/theme.ts
@@ -79,7 +79,7 @@ const list = async ({ REPL }: Arguments) => {
     outerCSS: 'not-a-name',
     attributes: [
       { value: strings('Theme') },
-      { value: strings('Style') },
+      { value: strings('Style'), outerCSS: 'hide-with-narrow-window' },
       { value: strings('Provider'), outerCSS: 'hide-with-sidecar' }
     ]
   }
@@ -111,7 +111,7 @@ const list = async ({ REPL }: Arguments) => {
                 outerCSS: 'entity-name-group',
                 onclick: undefined
               },
-              { value: strings(theme.style), outerCSS: 'pretty-narrow' },
+              { value: strings(theme.style), outerCSS: 'pretty-narrow hide-with-narrow-window' },
               { value: plugin, css: 'sub-text', outerCSS: 'hide-with-sidecar' }
             ],
             onclick: undefined


### PR DESCRIPTION
Fixes #4454

this also improves ls -l rendering in narrower windows, which are going to happen more often, with a 30/70 split
Fixes #4455

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
