### PR TITLE
fix: hitting escape on initial page load toggles open empty sidecar

### DIFF
--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -4,6 +4,7 @@ export const TAB_SELECTED_N = (N: number) => `${TAB_N(N)}.visible`
 
 export const SIDECAR_BASE = `${CURRENT_TAB} .kui--sidecar`
 export const SIDECAR_FULLSCREEN = `${CURRENT_TAB} .kui--sidecar.visible.maximized:not(.minimized)`
+export const TERMINAL_WITH_SIDECAR_VISIBLE = `${CURRENT_TAB} .repl.sidecar-visible`
 export const PROMPT_BLOCK = `${CURRENT_TAB} .repl .repl-block`
 export const BOTTOM_PROMPT_BLOCK = `${CURRENT_TAB} .kui--input-stripe .repl-block`
 export const BOTTOM_PROMPT = `${BOTTOM_PROMPT_BLOCK} input`

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/BaseSidecar.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/BaseSidecar.tsx
@@ -178,7 +178,7 @@ export abstract class BaseSidecar<
 
   /** Escape key toggles sidecar visibility */
   private onEscape(evt: KeyboardEvent) {
-    if (evt.key === 'Escape' && !document.getElementById('confirm-dialog') && !isPopup()) {
+    if (evt.key === 'Escape' && !document.getElementById('confirm-dialog') && !isPopup() && this.current) {
       if (this.props.willChangeSize) {
         this.props.willChangeSize(this.props.width === Width.Closed ? this.defaultWidth() : Width.Closed)
       }

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/TopNavSidecar.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/TopNavSidecar.tsx
@@ -326,8 +326,9 @@ export default class TopNavSidecar extends BaseSidecar<MultiModalResponse, Histo
 
   public render() {
     if (!this.current || !this.current.response) {
-      return <div>hi</div>
+      return <div />
     }
+
     try {
       const breadcrumbs = [
         this.kindBreadcrumb(),

--- a/plugins/plugin-core-support/src/test/core/basic-functionality.ts
+++ b/plugins/plugin-core-support/src/test/core/basic-functionality.ts
@@ -22,7 +22,7 @@
 import * as assert from 'assert'
 import { Application } from 'spectron'
 
-import { Common, CLI } from '@kui-shell/test'
+import { CLI, Common, Selectors, Keys } from '@kui-shell/test'
 
 const APP_TITLE = process.env.APP_TITLE || 'Kui'
 // const CLI_PLACEHOLDER = process.env.CLI_PLACEHOLDER || 'enter your command'
@@ -56,6 +56,11 @@ Common.localDescribe('Basic Functionality', function(this: Common.ISuite) {
   it('shows an initial window', () => openWindow(this.app).catch(Common.oops(this, true)))
 
   it('has an initial focus on the CLI prompt', () => assert.ok(this.app.client.hasFocus(selectors.PROMPT)))
+
+  it('should do nothing when hitting escape key', async () => {
+    await this.app.client.keys(Keys.ESCAPE)
+    await this.app.client.waitForExist(Selectors.TERMINAL_WITH_SIDECAR_VISIBLE, 2000, true)
+  })
 
   /* it('has the expected placeholder text in the CLI prompt', async () => {
     try {


### PR DESCRIPTION
Fixes #4487

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
