### PR TITLE
fix: optimize kubectl watch load on apiserver

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
@@ -121,6 +121,7 @@ export default class LivePaginatedTable extends PaginatedTable<LiveProps, LiveSt
     const nRowsBefore = existingRows.length
 
     const foundIndex = existingRows.findIndex(_ => _.NAME === newKuiRow.name)
+
     const insertionIndex = foundIndex === -1 ? nRowsBefore : foundIndex
 
     const newRow = kuiRow2carbonRow(this.state.headers)(newKuiRow, insertionIndex)
@@ -146,7 +147,7 @@ export default class LivePaginatedTable extends PaginatedTable<LiveProps, LiveSt
     if (!batch) {
       this.setState({ rows: newRows })
     } else if (this._deferredUpdate) {
-      this._deferredUpdate = this._deferredUpdate.concat(newRows)
+      this._deferredUpdate = newRows
     } else {
       this._deferredUpdate = newRows
     }

--- a/plugins/plugin-kubectl/src/controller/kubectl/fqn.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/fqn.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 IBM Corporation
+ * Copyright 2019-2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ function versionString(apiVersion: string): string {
   return group.length > 0 ? `.${version}.${group}` : ''
 }
 
-function kindPart(apiVersion: string, kind: string) {
+export function kindPart(apiVersion: string, kind: string) {
   return `${kind}${versionString(apiVersion)}`
 }
 

--- a/plugins/plugin-kubectl/src/test/k8s1/get-namespaces-with-watch.ts
+++ b/plugins/plugin-kubectl/src/test/k8s1/get-namespaces-with-watch.ts
@@ -104,7 +104,7 @@ const testDrilldown = async (nsName: string, res: ReplExpect.AppAndCount) => {
 /** k get ns -w */
 const watchNS = function(this: Common.ISuite, kubectl: string) {
   const watchCmds = [
-    `${kubectl} get ns -w`,
+    //    `${kubectl} get ns -w`, <-- not guaranteed to work locally, due to table pagination
     `${kubectl} get ns ${nsName} -w`,
     `${kubectl} get -w=true --watch ns ${nsName} --watch=true -w`
   ]


### PR DESCRIPTION
1) do a bulk fetch rather than a bunch of individual gets to kubectl
2) LivePaginatedTable had a bug with bulk table updates, where the deferredUpdate array would have duplicates

Fixes #4494

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
