### PR TITLE
feat: RadioTable and port of the themes table to use it

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -194,7 +194,9 @@ export { default as Store } from './models/store'
 export { default as SymbolTable } from './core/symbol-table'
 
 // Tables
+export { default as CellShould } from './models/CellShould'
 export { Icon, TableStyle, Table, Row, Cell, isTable } from './webapp/models/table'
+export { default as RadioTable, isRadioTable, RadioTableRow, RadioTableCell } from './models/RadioTable'
 
 // Util
 export { findFileWithViewer, findFile, isSpecialDirectory, addPath as augmentModuleLoadPath } from './core/find-file'

--- a/packages/core/src/models/CellShould.ts
+++ b/packages/core/src/models/CellShould.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Hints to improve visualization of table cells
+ *
+ */
+const enum CellShould {
+  HideWithSidecar = 'hide-with-sidecar',
+  HideWhenNarrow = 'hide-with-narrow-window',
+  ElideWhenNarrow = 'elide-with-narrow-window',
+  BeGrayish = 'sub-text'
+}
+
+export default CellShould

--- a/packages/core/src/models/RadioTable.ts
+++ b/packages/core/src/models/RadioTable.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KResponse } from './command'
+import CellShould from './CellShould'
+
+interface RadioTable {
+  apiVersion: 'kui-shell/v1'
+  kind: 'RadioTable'
+
+  title: string
+  header: RadioTableRow
+  body: (RadioTableRow & Selectable)[]
+
+  defaultSelectedIdx: number
+}
+
+export interface RadioTableRow {
+  name?: string
+  cells: RadioTableCell[]
+}
+
+export interface Selectable {
+  onSelect: () => Promise<void>
+}
+
+export type RadioTableCell =
+  | string
+  | {
+      key?: string
+      value: string
+
+      /** optional hints to improve rendering of the cells */
+      hints?: CellShould | CellShould[]
+    }
+
+export function isRadioTable(response: KResponse): response is RadioTable {
+  if (typeof response === 'object') {
+    const table = response as RadioTable
+    return table.apiVersion === 'kui-shell/v1' && table.kind === 'RadioTable'
+  } else {
+    return false
+  }
+}
+
+export default RadioTable

--- a/packages/core/src/models/entity.ts
+++ b/packages/core/src/models/entity.ts
@@ -20,6 +20,7 @@ import { ToolbarText } from '../webapp/views/toolbar-text'
 import { UsageModel } from '../core/usage-error'
 import { MultiModalResponse } from './mmr/types'
 import { NavResponse } from './NavResponse'
+import RadioTable from './RadioTable'
 import Presentation from '../webapp/views/presentation'
 
 export interface MessageBearingEntity {
@@ -160,7 +161,7 @@ export function isRawResponse<Content extends RawContent>(entity: Entity<Content
  */
 export type ScalarResponse<RowType extends Row = Row> = SimpleEntity | Table<RowType> | MixedResponse
 
-export type ViewableResponse = MultiModalResponse | NavResponse
+export type ViewableResponse = MultiModalResponse | NavResponse | RadioTable
 
 export type StructuredResponse<
   Content = void,

--- a/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
+++ b/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
@@ -24,6 +24,7 @@ import {
   Button,
   Content,
   isHTML,
+  isRadioTable,
   isReactProvider,
   isStringWithOptionalContentType,
   isTable,
@@ -40,6 +41,7 @@ import renderTable from './Table'
 import Markdown from './Markdown'
 import HTMLString from './HTMLString'
 import HTMLDom from './Scalar/HTMLDom'
+import RadioTableSpi from '../spi/RadioTable'
 
 interface KuiMMRProps {
   tab: KuiTab
@@ -88,6 +90,8 @@ export default class KuiMMRContent extends React.PureComponent<KuiMMRProps> {
     } else if (isScalarContent(mode)) {
       if (isReactProvider(mode)) {
         return mode.react({ willUpdateToolbar })
+      } else if (isRadioTable(mode.content)) {
+        return <RadioTableSpi table={mode.content} />
       } else if (isTable(mode.content)) {
         return renderTable(tab, tab.REPL, mode.content, false)
         // ^^^ Notes: typescript doesn't like this, and i don't know why:

--- a/plugins/plugin-client-common/src/components/Content/Scalar/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Scalar/index.tsx
@@ -21,6 +21,7 @@ import {
   Tab as KuiTab,
   ScalarResponse,
   isHTML,
+  isRadioTable,
   isTable,
   isMixedResponse,
   isUsageError
@@ -28,6 +29,7 @@ import {
 
 import HTMLDom from './HTMLDom'
 import renderTable from '../Table'
+import RadioTableSpi from '../../spi/RadioTable'
 import { isError } from '../../Views/Terminal/Block/BlockModel'
 
 interface Props {
@@ -73,6 +75,8 @@ export default class Scalar extends React.PureComponent<Props, State> {
     try {
       if (typeof response === 'number' || typeof response === 'string' || typeof response === 'boolean') {
         return <pre>{response}</pre>
+      } else if (isRadioTable(response)) {
+        return <RadioTableSpi table={response} />
       } else if (isTable(response)) {
         return renderTable(tab, tab.REPL, response, undefined, true)
         // ^^^ Notes: typescript doesn't like this, and i don't know why:

--- a/plugins/plugin-client-common/src/components/spi/RadioTable/impl/Carbon.tsx
+++ b/plugins/plugin-client-common/src/components/spi/RadioTable/impl/Carbon.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react'
+import { v4 as uuid } from 'uuid'
+import { RadioTableRow } from '@kui-shell/core'
+
+import { CheckmarkFilled16 as Checkmark } from '@carbon/icons-react'
+import {
+  StructuredListWrapper,
+  StructuredListHead,
+  StructuredListRow,
+  StructuredListCell,
+  StructuredListBody,
+  StructuredListInput
+} from 'carbon-components-react'
+
+import BaseProps from '../model'
+import { State as BaseState } from '../index'
+
+import '../../../../../web/scss/components/StructuredList/Carbon.scss'
+
+type Props = BaseProps &
+  BaseState & {
+    onChange: (selectedIdx: number) => void
+  }
+
+interface State {
+  uuid: string
+}
+
+export default class CarbonRadioTable extends React.PureComponent<Props, State> {
+  public constructor(props: Props) {
+    super(props)
+
+    this.state = {
+      uuid: uuid()
+    }
+  }
+
+  private async onChange(selectedIdx: number, onSelect: () => void) {
+    // wow, carbon components isn't so great; we have to manage unchecking ourselves??
+    ;(document.getElementById(this.id(this.props.selectedIdx)) as HTMLInputElement).checked = false
+
+    if (onSelect) {
+      await onSelect()
+    }
+
+    this.props.onChange(selectedIdx)
+  }
+
+  private id(idx: number): string {
+    return `${this.state.uuid}-${idx}`
+  }
+
+  private row(row: RadioTableRow, idx: number, head: boolean, onSelect?: () => void) {
+    const isSelected = !head && idx === this.props.selectedIdx
+    const name = this.id(idx)
+
+    // notes: label is needed for selection
+    return (
+      <StructuredListRow label head={head} key={idx} data-name={row.name || name}>
+        {!head && (
+          <StructuredListInput
+            defaultChecked={isSelected}
+            id={name}
+            name={name}
+            value={name}
+            onChange={this.onChange.bind(this, idx, onSelect)}
+          />
+        )}
+
+        <StructuredListCell>{isSelected && <Checkmark className="bx--structured-list-svg" />}</StructuredListCell>
+
+        {row.cells.map((_, idx) => (
+          <StructuredListCell head={head} key={idx} data-key={typeof _ !== 'string' && _.key}>
+            {typeof _ === 'string' ? _ : _.value}
+          </StructuredListCell>
+        ))}
+      </StructuredListRow>
+    )
+  }
+
+  private header() {
+    return <StructuredListHead>{this.row(this.props.table.header, 0, true)}</StructuredListHead>
+  }
+
+  private body() {
+    return (
+      <StructuredListBody>
+        {this.props.table.body.map((row, idx) => this.row(row, idx, false, row.onSelect))}
+      </StructuredListBody>
+    )
+  }
+
+  public render() {
+    return (
+      <StructuredListWrapper selection className="kui--radio-table kui--screenshotable">
+        {this.header()}
+        {this.body()}
+      </StructuredListWrapper>
+    )
+  }
+}

--- a/plugins/plugin-client-common/src/components/spi/RadioTable/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/RadioTable/impl/PatternFly.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react'
+import { v4 as uuid } from 'uuid'
+import { RadioTableRow } from '@kui-shell/core'
+
+import {
+  DataList,
+  DataListItem,
+  DataListCell,
+  DataListItemRow,
+  //  DataListCheck,
+  DataListItemCells
+  //  DataListAction
+} from '@patternfly/react-core'
+
+import BaseProps from '../model'
+import { State as BaseState } from '../index'
+
+type Props = BaseProps &
+  BaseState & {
+    onChange: (selectedIdx: number) => void
+  }
+
+import '../../../../../web/scss/components/RadioTable/PatternFly.scss'
+
+interface State {
+  uuid: string
+}
+
+export default class PatternFly4RadioTable extends React.PureComponent<Props, State> {
+  public constructor(props: Props) {
+    super(props)
+
+    const _uuid = uuid()
+    this.state = {
+      uuid: _uuid
+    }
+  }
+
+  /** row id */
+  private static id(uuid: string, idx: number) {
+    return `${uuid}-${idx}`
+  }
+
+  /** row id */
+  private static aria(uuid: string, idx: number) {
+    return `${PatternFly4RadioTable.id(uuid, idx)}-aria`
+  }
+
+  private idxPartOfId(id: string): number {
+    // 37 = uuid.v4 length plus "-"
+    return parseInt(id.slice(37))
+  }
+
+  private async onSelectDataListItem(selectedDataListItemId: string) {
+    const selectedIdx = this.idxPartOfId(selectedDataListItemId)
+    const row = this.props.table.body[selectedIdx]
+    if (row && row.onSelect) {
+      await row.onSelect()
+    }
+
+    this.props.onChange(selectedIdx)
+  }
+
+  private row(row: RadioTableRow, ridx: number) {
+    const id = PatternFly4RadioTable.id(this.state.uuid, ridx)
+    const aria = PatternFly4RadioTable.aria(this.state.uuid, ridx)
+
+    return (
+      <DataListItem key={ridx} aria-labelledby={aria} id={id}>
+        <DataListItemRow>
+          <DataListItemCells
+            dataListCells={row.cells.map((_, cidx) => (
+              <DataListCell key={cidx} data-key={typeof _ !== 'string' && _.key}>
+                <span id={cidx === 0 ? id : undefined}>{typeof _ === 'string' ? _ : _.value}</span>
+              </DataListCell>
+            ))}
+          />
+        </DataListItemRow>
+      </DataListItem>
+    )
+  }
+
+  private header() {
+    /* return (
+      <StructuredListHead>
+        {this.row(this.props.table.header, 0, true)}
+      </StructuredListHead>
+      ) */
+    return <div />
+  }
+
+  private body() {
+    return <React.Fragment>{this.props.table.body.map((row, idx) => this.row(row, idx))}</React.Fragment>
+  }
+
+  public render() {
+    const selectedDataListItemId = PatternFly4RadioTable.id(this.state.uuid, this.props.selectedIdx)
+
+    return (
+      <DataList
+        isCompact
+        aria-label="radio table"
+        className="kui--screenshotable"
+        selectedDataListItemId={selectedDataListItemId}
+        onSelectDataListItem={this.onSelectDataListItem.bind(this)}
+      >
+        {this.header()}
+        {this.body()}
+      </DataList>
+    )
+  }
+}

--- a/plugins/plugin-client-common/src/components/spi/RadioTable/index.tsx
+++ b/plugins/plugin-client-common/src/components/spi/RadioTable/index.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react'
+
+import KuiContext from '../../Client/context'
+
+import Props from './model'
+import Carbon from './impl/Carbon'
+import PatternFly4 from './impl/PatternFly'
+
+export interface State {
+  selectedIdx: number
+}
+
+export default class RadioTableSpi extends React.PureComponent<Props, State> {
+  public constructor(props: Props) {
+    super(props)
+
+    this.state = {
+      selectedIdx: props.table.defaultSelectedIdx
+    }
+  }
+
+  private onChange(selectedIdx: number) {
+    this.setState({ selectedIdx })
+  }
+
+  public render() {
+    const onChange = this.onChange.bind(this)
+
+    return (
+      <KuiContext.Consumer>
+        {config =>
+          config.components === 'patternfly' ? (
+            <PatternFly4 {...this.props} selectedIdx={this.state.selectedIdx} onChange={onChange} />
+          ) : (
+            <Carbon {...this.props} selectedIdx={this.state.selectedIdx} onChange={onChange} />
+          )
+        }
+      </KuiContext.Consumer>
+    )
+  }
+}

--- a/plugins/plugin-client-common/src/components/spi/RadioTable/model.ts
+++ b/plugins/plugin-client-common/src/components/spi/RadioTable/model.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RadioTable } from '@kui-shell/core'
+
+interface Props {
+  table: RadioTable
+}
+
+export default Props

--- a/plugins/plugin-client-common/web/scss/components/RadioTable/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/RadioTable/PatternFly.scss
@@ -1,0 +1,6 @@
+[kui-theme-style] {
+  .pf-c-data-list__item {
+    background-color: transparent;
+    color: var(--color-text-01);
+  }
+}

--- a/plugins/plugin-client-common/web/scss/components/StructuredList/Carbon.scss
+++ b/plugins/plugin-client-common/web/scss/components/StructuredList/Carbon.scss
@@ -17,7 +17,13 @@
 @import '~carbon-components/scss/components/structured-list/_structured-list.scss';
 
 [kui-theme-style] .bx--structured-list {
-  margin-bottom: 5em;
+  font-family: var(--font-sans-serif);
+  color: var(--color-text-01);
+
+  &.kui--radio-table {
+    margin-bottom: 0;
+    width: auto;
+  }
 
   .bx--structured-list-row {
     border-bottom-color: var(--color-base03);
@@ -32,5 +38,27 @@
     padding-left: 1em;
     line-height: 1.3125em;
     max-width: 36em;
+  }
+
+  &.kui--radio-table .bx--structured-list-td {
+    font-size: 1em;
+    line-height: 1.125em;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+  }
+
+  &.bx--structured-list--selection
+    .bx--structured-list-row:hover:not(.bx--structured-list-row--header-row):not(.bx--structured-list-row--selected) {
+    background-color: var(--color-ui-03);
+    border-color: var(--color-table-border1);
+
+    &,
+    .bx--structured-list-td {
+      color: var(--color-text-01);
+    }
+  }
+
+  .bx--structured-list-input:checked + .bx--structured-list-td .bx--structured-list-svg {
+    fill: currentColor;
   }
 }

--- a/plugins/plugin-client-test/src/test/response/theme.ts
+++ b/plugins/plugin-client-test/src/test/response/theme.ts
@@ -24,7 +24,7 @@ describe('theme switching', function(this: Common.ISuite) {
     CLI.command('theme list', this.app)
       .then(
         ReplExpect.okWithCustom({
-          selector: `[data-value="Default Light"]`
+          selector: `[data-name="Light"]`
         })
       )
       .catch(Common.oops(this, true)))
@@ -33,7 +33,7 @@ describe('theme switching', function(this: Common.ISuite) {
     CLI.command('theme list', this.app)
       .then(
         ReplExpect.okWithCustom({
-          selector: `[data-value="Test Theme"]`
+          selector: `[data-name="Test Theme"]`
         })
       )
       .catch(Common.oops(this, true)))

--- a/plugins/plugin-core-support/src/test/core-support/theme.ts
+++ b/plugins/plugin-core-support/src/test/core-support/theme.ts
@@ -33,7 +33,6 @@ const resetTheme = (ctx: Common.ISuite) => {
 
 interface Theme {
   name: string
-  display: string
 }
 
 /**
@@ -97,7 +96,7 @@ const clickOnThemeButtonThenClickOnTheme = (clickOn: Theme) => (ctx: Common.ISui
       await ctx.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON_SELECTED_V2('theme'))
       await new Promise(resolve => setTimeout(resolve, 300))
 
-      const checkMarkCell = `${Selectors.SIDECAR} [data-name="${clickOn.name}"] td.bx--table-column-checkbox.not-a-name`
+      const checkMarkCell = `${Selectors.SIDECAR} [data-name="${clickOn.name}"]`
 
       console.error('A', checkMarkCell)
       await ctx.app.client.waitForVisible(checkMarkCell)
@@ -120,9 +119,9 @@ const clickOnThemeButtonThenClickOnTheme = (clickOn: Theme) => (ctx: Common.ISui
 }
 
 /** some helpers */
-const Default = { name: defaultTheme, display: defaultTheme }
-const Dark = { name: 'Dark', display: 'Default Dark' }
-const Light = { name: 'Light', display: 'Default Light' }
+const Default = { name: defaultTheme }
+const Dark = { name: 'Dark' }
+const Light = { name: 'Light' }
 const goLight = go(Light)
 const goDark = go(Dark)
 const restartAndThenLight = restartAndThen(Light)
@@ -148,7 +147,7 @@ describe('theme switching', function(this: Common.ISuite) {
     CLI.command('theme list', this.app)
       .then(
         ReplExpect.okWithCustom({
-          selector: `.entity-name[data-value="${Light.display}"]`
+          selector: `[data-name="${Light.name}"]`
         })
       )
       .catch(Common.oops(this)))
@@ -157,7 +156,7 @@ describe('theme switching', function(this: Common.ISuite) {
     CLI.command('theme list', this.app)
       .then(
         ReplExpect.okWithCustom({
-          selector: `.entity-name[data-value="${Dark.display}"]`
+          selector: `[data-name="${Dark.name}"]`
         })
       )
       .catch(Common.oops(this)))


### PR DESCRIPTION
Fixes #4507

BREAKING CHANGE: any tests that depend on the old structure of the themes table will need to be updated.

Carbon provider:

![image](https://user-images.githubusercontent.com/4741620/81455468-4e4ee200-915d-11ea-9911-f376446d9cc3.png)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
