### PR TITLE
fix: clicking on container name in details sidecar should add -c to logs command

### DIFF
--- a/plugins/plugin-kubectl/logs/src/controller/kubectl/logs.ts
+++ b/plugins/plugin-kubectl/logs/src/controller/kubectl/logs.ts
@@ -93,7 +93,7 @@ function decorateLogLines(lines: string): string {
  * some ANSI control codes for coloring.
  *
  */
-async function doLogs(args: Arguments<LogOptions>) {
+export async function doLogs(args: Arguments<LogOptions>) {
   if (isUsage(args)) {
     // special case: get --help/-h
     return doHelp('kubectl', args)

--- a/plugins/plugin-kubectl/logs/src/index.ts
+++ b/plugins/plugin-kubectl/logs/src/index.ts
@@ -15,3 +15,4 @@
  */
 
 // this file defines the external API
+export { doLogs } from './controller/kubectl/logs'

--- a/plugins/plugin-kubectl/oc/src/controller/kubectl/delegates.ts
+++ b/plugins/plugin-kubectl/oc/src/controller/kubectl/delegates.ts
@@ -26,6 +26,7 @@ import {
   doEdit,
   doRun
 } from '@kui-shell/plugin-kubectl'
+import { doLogs } from '@kui-shell/plugin-kubectl/logs'
 
 const command = 'oc'
 
@@ -34,6 +35,7 @@ export default (registrar: Registrar) => {
   registrar.listen(`/${commandPrefix}/${command}/create`, doCreate('create', command), crudFlags)
   registrar.listen(`/${commandPrefix}/${command}/delete`, doDelete(command), crudFlags)
   registrar.listen(`/${commandPrefix}/${command}/edit`, doEdit(command), defaultFlags)
+  registrar.listen(`/${commandPrefix}/${command}/logs`, doLogs, defaultFlags)
   registrar.listen(`/${commandPrefix}/${command}/run`, doRun(command), crudFlags)
 
   getter(registrar, command)

--- a/plugins/plugin-kubectl/src/lib/view/modes/containers.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/containers.ts
@@ -59,7 +59,7 @@ const showLogs = (tab: Tab, { pod, container }, args: { argvNoOptions: string[] 
   const containerName = encodeComponent(container.name)
   const ns = encodeComponent(pod.metadata.namespace)
 
-  return `${getCommandFromArgs(args)} logs ${podName} ${containerName} -n ${ns}`
+  return `${getCommandFromArgs(args)} logs ${podName} -c ${containerName} -n ${ns}`
 }
 
 /**


### PR DESCRIPTION
Also delegates oc logs to kubectl

Fixes #4498

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
