### PR TITLE
8.7.5

### DIFF
--- a/plugins/plugin-kubectl/i18n/resources_en_US.json
+++ b/plugins/plugin-kubectl/i18n/resources_en_US.json
@@ -17,6 +17,7 @@
   "status": "Status",
   "save": "Save",
   "revert": "Revert",
+  "nItems": "{0} items",
   "allTableTitle": "All",
   "keditUsageRequiredDocs": "A kubernetes resource file or kind",
   "keditUsageDocs": "Edit a resource definition file",

--- a/plugins/plugin-kubectl/logs/src/controller/kubectl/logs.ts
+++ b/plugins/plugin-kubectl/logs/src/controller/kubectl/logs.ts
@@ -93,7 +93,7 @@ function decorateLogLines(lines: string): string {
  * some ANSI control codes for coloring.
  *
  */
-async function doLogs(args: Arguments<LogOptions>) {
+export async function doLogs(args: Arguments<LogOptions>) {
   if (isUsage(args)) {
     // special case: get --help/-h
     return doHelp('kubectl', args)

--- a/plugins/plugin-kubectl/logs/src/index.ts
+++ b/plugins/plugin-kubectl/logs/src/index.ts
@@ -15,3 +15,4 @@
  */
 
 // this file defines the external API
+export { doLogs } from './controller/kubectl/logs'

--- a/plugins/plugin-kubectl/oc/src/controller/kubectl/delegates.ts
+++ b/plugins/plugin-kubectl/oc/src/controller/kubectl/delegates.ts
@@ -25,6 +25,7 @@ import {
   doEdit,
   doRun
 } from '@kui-shell/plugin-kubectl'
+import { doLogs } from '@kui-shell/plugin-kubectl/logs'
 
 const command = 'oc'
 
@@ -33,6 +34,7 @@ export default (registrar: Registrar) => {
   registrar.listen(`/${commandPrefix}/${command}/create`, doCreate('create', command), defaultFlags)
   registrar.listen(`/${commandPrefix}/${command}/delete`, doDelete(command), defaultFlags)
   registrar.listen(`/${commandPrefix}/${command}/edit`, doEdit(command), defaultFlags)
+  registrar.listen(`/${commandPrefix}/${command}/logs`, doLogs, defaultFlags)
   registrar.listen(`/${commandPrefix}/${command}/run`, doRun(command), defaultFlags)
 
   getter(registrar, command)

--- a/plugins/plugin-kubectl/src/lib/view/modes/containers.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/containers.ts
@@ -59,7 +59,7 @@ const showLogs = (tab: Tab, { pod, container }, args: { argvNoOptions: string[] 
   const containerName = encodeComponent(container.name)
   const ns = encodeComponent(pod.metadata.namespace)
 
-  return `${getCommandFromArgs(args)} logs ${podName} ${containerName} -n ${ns}`
+  return `${getCommandFromArgs(args)} logs ${podName} -c ${containerName} -n ${ns}`
 }
 
 /**


### PR DESCRIPTION
git cherry-pick f8b6bb7484affb86f87fd2ca524c6d07e541026e
[fix_4498_2 14753af6e] fix(plugins/plugin-kubectl): kubectl edit should support editing a list of resources

git cherry-pick 61c7c08846515d24214ee3914d986c6ef37ede63
[fix_4498 f1c6c3e37] fix: clicking on container name in details sidecar should add -c to logs command