### PR TITLE
fix(plugins/plugin-kubectl): kubectl describe -h has old bold text

### DIFF
--- a/plugins/plugin-kubectl/src/lib/util/help.ts
+++ b/plugins/plugin-kubectl/src/lib/util/help.ts
@@ -248,7 +248,7 @@ const renderHelpUnsafe = (
       content: header
         .replace(/\n\s*(IMPORTANT:)([^\n]+)/, `\n> **$1**$2`)
         .replace(/(\s)(NOT)(\s)/g, '$1**$2**$3')
-        .replace(/^(.*):$/gm, '##### $1\n')
+        .replace(/^(.{1-15}):$/gm, '##### $1\n')
         .replace(
           /(:\n\n\s*)((([^,\n])+,)+[^,\n]+)/g,
           (_, m1, m2) =>


### PR DESCRIPTION
Fixes #4568

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
