### PR TITLE
fix(plugins/plugin-kubectl): kubectl Show Events query not precise en…

### DIFF
--- a/plugins/plugin-kubectl/src/lib/view/modes/events.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/events.ts
@@ -28,9 +28,11 @@ const strings = i18n('plugin-kubectl')
  *
  */
 function command(tab: Tab, resource: KubeResource, args: { argvNoOptions: string[] }) {
-  const cmdGetPodEvents = `${getCommandFromArgs(args)} get events --field-selector involvedObject.name=${
-    resource.metadata.name
-  },involvedObject.namespace=${resource.metadata.namespace} -n ${resource.metadata.namespace}`
+  const cmdGetPodEvents = `${getCommandFromArgs(args)} get events --field-selector involvedObject.apiVersion=${
+    resource.apiVersion
+  },involvedObject.kind=${resource.kind},involvedObject.name=${resource.metadata.name},involvedObject.namespace=${
+    resource.metadata.namespace
+  } -n ${resource.metadata.namespace}`
 
   // mimic the events table shown in the 'kubectl describe' output
   const customColumns = 'wide'


### PR DESCRIPTION
…ough

added involvedObject.apiVersion and involvedObject.kind to the event query

Fixes #4572

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
