### PR TITLE
chore: add alternative Top Tab styles in plugin-client-alternate

### DIFF
--- a/plugins/plugin-client-alternate/src/index.tsx
+++ b/plugins/plugin-client-alternate/src/index.tsx
@@ -17,6 +17,8 @@
 import * as React from 'react'
 import { Kui, KuiProps } from '@kui-shell/plugin-client-common'
 
+import '../web/scss/components/TopTabStripe/Carbon.scss'
+
 /**
  * Use DefaultClient configured to run in bottomInput mode.
  *

--- a/plugins/plugin-client-alternate/web/scss/components/TopTabStripe/Carbon.scss
+++ b/plugins/plugin-client-alternate/web/scss/components/TopTabStripe/Carbon.scss
@@ -1,0 +1,39 @@
+.bx--header .kui--tab.kui--tab--active {
+  box-shadow: none;
+}
+
+.bx--header {
+  background-color: var(--color-stripe-02);
+  height: 48px;
+  flex-basis: 48px;
+  display: flex;
+  font-weight: 600;
+  box-shadow: 0 1px 10px 0 rgba(21, 41, 53, 0.1);
+  z-index: 1;
+}
+
+.kui--tab--label {
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.kui--tab--active {
+  color: var(--active-tab-color);
+}
+
+.kui--tab::after {
+  display: block;
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 2px;
+  background-color: transparent;
+  bottom: 0;
+  transition: all 0.2s;
+  pointer-events: none;
+}
+
+.kui--tab:hover:after,
+.kui--tab--active:after {
+  background-color: currentColor;
+}


### PR DESCRIPTION
Fixes #4608

The screenshots below captured how the alternate TopTabStripe looks: 

Carbon Gray 10:
![Screen Shot 2020-05-15 at 5 38 22 PM](https://user-images.githubusercontent.com/21212160/82098391-e1929500-96d2-11ea-969f-f2bcce679496.png)

Carbon Gray 90:
![Screen Shot 2020-05-15 at 5 39 21 PM](https://user-images.githubusercontent.com/21212160/82098481-04bd4480-96d3-11ea-9b3b-7650ff016568.png)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
