### PR TITLE
fix(plugins/plugin-kubectl): showEvents button should issue a non-wide table

### DIFF
--- a/plugins/plugin-kubectl/src/lib/view/formatTable.ts
+++ b/plugins/plugin-kubectl/src/lib/view/formatTable.ts
@@ -39,8 +39,8 @@ const outerCSSForKey = {
   READY: 'a-few-numbers-wide kui--hide-in-narrower-windows',
   KIND: 'max-width-id-like entity-kind',
   NAMESPACE: 'entity-name-group hide-with-sidecar not-a-name', // kubectl get pods --all-namespaces
-  MESSAGE: 'not-too-compact hide-with-sidecar',
-  TYPE: 'hide-with-sidecar',
+  MESSAGE: 'not-too-compact', // k get events
+  TYPE: 'hide-with-sidecar', // k get events
 
   CLUSTER: 'entity-name-group entity-name-group-narrow hide-with-sidecar', // kubectl config get-contexts
   AUTHINFO: 'entity-name-group entity-name-group-narrow hide-with-sidecar', // kubectl config get-contexts

--- a/plugins/plugin-kubectl/src/lib/view/modes/events.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/events.ts
@@ -32,11 +32,7 @@ function command(tab: Tab, resource: KubeResource, args: { argvNoOptions: string
     resource.metadata.name
   },involvedObject.namespace=${resource.metadata.namespace} -n ${resource.metadata.namespace}`
 
-  // mimic the events table shown in the 'kubectl describe' output
-  const customColumns = 'wide'
-  // 'custom-columns=TYPE:type,REASON:reason,LAST SEEN:lastTimestamp,COUNT:count,FIRST SEEN:firstTimestamp,FROM:source.component,MESSAGE:message'
-
-  return `${cmdGetPodEvents} -o "${customColumns}"`
+  return cmdGetPodEvents
 }
 
 /**

--- a/plugins/plugin-kubectl/src/test/k8s2/events.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/events.ts
@@ -70,28 +70,32 @@ commands.forEach(command => {
         const table = `${Selectors.OUTPUT_N(res.count + 1)} .bx--data-table`
 
         // test events table has correct header
-        const header = ['TYPE', 'REASON', 'LAST SEEN', 'FIRST SEEN', 'MESSAGE']
+        const headerWithSidecarOpen = ['REASON', 'MESSAGE']
         await Promise.all(
-          header.map(async _header => {
-            await this.app.client.waitForExist(`${table} thead th[data-key="${_header}"]`)
+          headerWithSidecarOpen.map(async _header => {
+            await this.app.client.waitForVisible(`${table} thead th[data-key="${_header}"]`)
           })
         )
-
-        await this.app.client.click(`${table} tr:first-child .clickable`)
-
-        await SidecarExpect.open(this.app).then(SidecarExpect.kind('Event'))
       } catch (err) {
-        await SidecarExpect.open(this.app).then(SidecarExpect.kind('Event'))
         await Common.oops(this, true)
       }
     })
 
     it('should click on Show Involved Object', async () => {
-      await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON('involvedObject'))
-      await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON('involvedObject'))
-      await SidecarExpect.open(this.app)
-        .then(SidecarExpect.showing(podName))
-        .then(SidecarExpect.kind('Pod'))
+      try {
+        const res = await CLI.command('k get events -o wide', this.app)
+
+        const table = `${Selectors.OUTPUT_N(res.count)} .bx--data-table`
+        await this.app.client.click(`${table} tr:first-child .clickable`)
+
+        await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON('involvedObject'))
+        await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON('involvedObject'))
+        await SidecarExpect.open(this.app)
+          .then(SidecarExpect.showing(podName))
+          .then(SidecarExpect.kind('Pod'))
+      } catch (err) {
+        await Common.oops(this, true)
+      }
     })
 
     deleteNS(this, ns)


### PR DESCRIPTION
Also refines events table to show REASON and MESSAGE columns only when sidecar open

Fixes #4604

The screenshot below captures how events table looks when sidecar open. The two tables are issued by 1. `show events` button, 2. `k get events` command.

![Screen Shot 2020-05-18 at 4 27 52 PM](https://user-images.githubusercontent.com/21212160/82256570-953e9380-9924-11ea-80ee-111f41cf9563.png)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
