### PR TITLE
feat: allow <Kui/> users to provide custom views for session init

### DIFF
--- a/packages/core/src/session/init.ts
+++ b/packages/core/src/session/init.ts
@@ -34,4 +34,7 @@ export async function initializeSession(tab: Tab): Promise<void> {
   await promise
 
   tab.state.ready = true
+
+  // to test the session init error handling:
+  // throw new Error('artificial failure')
 }

--- a/plugins/plugin-bash-like/web/css/static/xterm.css
+++ b/plugins/plugin-bash-like/web/css/static/xterm.css
@@ -46,6 +46,10 @@ disabled see https://github.com/IBM/kui/issues/3939
       color: var(--color-base00);
     }
 
+    .kui--session-init-done {
+      display: none;
+    }
+
     .repl-inner {
       overflow: hidden;
       display: flex;

--- a/plugins/plugin-carbon-themes/web/scss/kui--alternate.scss
+++ b/plugins/plugin-carbon-themes/web/scss/kui--alternate.scss
@@ -1,7 +1,7 @@
 /* Alternate look for carbon themes */
 
 body.kui--alternate {
-  .repl:not(.kui--input-stripe) .repl-block {
+  .repl-block {
     padding-left: calc(1em * 0.875);
     padding-right: calc(1em * 0.875 - 0.1875em - 6px);
   }

--- a/plugins/plugin-client-common/src/components/Client/KuiConfiguration.tsx
+++ b/plugins/plugin-client-common/src/components/Client/KuiConfiguration.tsx
@@ -14,11 +14,22 @@
  * limitations under the License.
  */
 
-import { ThemeProperties } from '@kui-shell/core'
+import * as React from 'react'
+import { REPL, ThemeProperties } from '@kui-shell/core'
 
 type KuiConfiguration = Partial<ThemeProperties> & {
   /** This will be displayed in the upper left of the TopTabStripe */
   productName?: string
+
+  /** [Optional] session init started view */
+  loading?: React.ReactNode
+
+  /** [Optional] session was severed; reinit started view */
+  reinit?: React.ReactNode
+
+  loadingError?: (err: Error) => React.ReactNode
+
+  loadingDone?: (repl: REPL) => React.ReactNode
 }
 
 export default KuiConfiguration

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -41,6 +41,9 @@ type Props = TerminalOptions & {
   /** tab model */
   tab: KuiTab
 
+  /** handler for terminal clear */
+  onClear?: () => void
+
   sidecarIsVisible?: boolean
   closeSidecar: () => void
 }
@@ -68,6 +71,10 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
 
   /** Clear Terminal; TODO: also clear persisted state, when we have it */
   private clear() {
+    if (this.props.onClear) {
+      this.props.onClear()
+    }
+
     this.setState(() => {
       // capture the value of the last input
       const capturedValue = this._activeBlock ? this._activeBlock.inputValue() : ''

--- a/plugins/plugin-client-common/web/css/static/Popup.scss
+++ b/plugins/plugin-client-common/web/css/static/Popup.scss
@@ -94,7 +94,7 @@ body.subwindow .sidecar-full-screen sidecar:not(.minimized) .sidecar-bottom-stri
       margin-right: 0.1875em;
       .repl-context {
         /* e.g. cwd displayed in prompt */
-        display: none;
+        /* display: none; */
       }
     }
   }

--- a/plugins/plugin-client-common/web/css/static/repl.scss
+++ b/plugins/plugin-client-common/web/css/static/repl.scss
@@ -199,6 +199,10 @@
   flex: 4;
   background-color: var(--color-repl-background);
 }
+.kui--repl-message {
+  padding-top: 0.5rem;
+  background-color: var(--color-repl-background);
+}
 .repl-inner {
   overflow-y: auto;
   flex: 1;

--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -28,7 +28,7 @@ import { productName } from '@kui-shell/client/config.d/name.json'
 /**
  * Format our body, with extra status stripe widgets
  *   - <CurrentGitBranch />
-     - <ProxyOfflineIndicator />
+ *   - <ProxyOfflineIndicator />
  *
  */
 export default function renderMain(props: KuiProps) {

--- a/plugins/plugin-patternfly4-themes/web/scss/common.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/common.scss
@@ -1,7 +1,7 @@
 @import './fonts';
 
 body.kui--patternfly4[kui-theme-style] {
-  .repl:not(.kui--input-stripe) .repl-block {
+  .repl-block {
     padding-left: calc(1em * 0.875);
     padding-right: calc(1em * 0.875 - 0.1875em - 6px);
   }


### PR DESCRIPTION
Fixes #4596

Notes on Session Initialization: to provide custom views for
session initialization (only relevant for browser-based hosted
Kui), you can instantiate <Kui/> with these properties (defined in
KuiConfiguration):
 - `loading={<div className="kui--hero-text">Hold on...</div>}`
 - `reinit={<div className="kui--hero-text">Connection broken...</div>}`
 - `loadingError={err => <div className="kui--hero-text">{err.toString()}</div>}`

Here, we have provided some rough examples of uses of the three. You would then instantiate via: 

```react
<Kui loading=... etc./>
```


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
