### PR TITLE
feat: add support for <Kui noPromptContext/> and <Kui prompt=">"/>

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/KuiConfiguration.tsx
+++ b/plugins/plugin-client-common/src/components/Client/KuiConfiguration.tsx
@@ -14,22 +14,11 @@
  * limitations under the License.
  */
 
-import * as React from 'react'
-import { REPL, ThemeProperties } from '@kui-shell/core'
+import InputProps from './props/Input'
+import SessionProps from './props/Session'
+import BrandingProps from './props/Branding'
+import { ThemeProperties } from '@kui-shell/core'
 
-type KuiConfiguration = Partial<ThemeProperties> & {
-  /** This will be displayed in the upper left of the TopTabStripe */
-  productName?: string
-
-  /** [Optional] session init started view */
-  loading?: React.ReactNode
-
-  /** [Optional] session was severed; reinit started view */
-  reinit?: React.ReactNode
-
-  loadingError?: (err: Error) => React.ReactNode
-
-  loadingDone?: (repl: REPL) => React.ReactNode
-}
+type KuiConfiguration = Partial<ThemeProperties> & Partial<InputProps> & Partial<SessionProps> & Partial<BrandingProps>
 
 export default KuiConfiguration

--- a/plugins/plugin-client-common/src/components/Client/props/Branding.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/Branding.ts
@@ -14,16 +14,9 @@
  * limitations under the License.
  */
 
-import * as React from 'react'
-import { Kui, KuiProps } from '@kui-shell/plugin-client-common'
-
-import '../web/scss/components/TopTabStripe/Carbon.scss'
-
-/**
- * Use DefaultClient configured to run in bottomInput mode.
- *
- */
-export default function BottomInputClient(props: KuiProps) {
-  // prompt is unicode for "heavy right-pointing angle quotation mark ornament"
-  return <Kui {...props} bottomInput noPromptContext prompt="&#x276f;" />
+type BrandingProps = {
+  /** [Optional] This will be displayed in the upper left of the TopTabStripe. Default: "Kui" */
+  productName?: string
 }
+
+export default BrandingProps

--- a/plugins/plugin-client-common/src/components/Client/props/Input.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/Input.ts
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-import * as React from 'react'
-import { Kui, KuiProps } from '@kui-shell/plugin-client-common'
+type InputProps = {
+  /** [Optional] do not display any extra information beside the > prompt. Default: false */
+  noPromptContext?: boolean
 
-import '../web/scss/components/TopTabStripe/Carbon.scss'
-
-/**
- * Use DefaultClient configured to run in bottomInput mode.
- *
- */
-export default function BottomInputClient(props: KuiProps) {
-  // prompt is unicode for "heavy right-pointing angle quotation mark ornament"
-  return <Kui {...props} bottomInput noPromptContext prompt="&#x276f;" />
+  /** [Optional] characters to display before every <input>. Default: "/" */
+  prompt?: string
 }
+
+export default InputProps

--- a/plugins/plugin-client-common/src/components/Client/props/Session.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/Session.ts
@@ -14,16 +14,21 @@
  * limitations under the License.
  */
 
-import * as React from 'react'
-import { Kui, KuiProps } from '@kui-shell/plugin-client-common'
+import { ReactNode } from 'react'
+import { REPL } from '@kui-shell/core'
 
-import '../web/scss/components/TopTabStripe/Carbon.scss'
+type SessionProps = {
+  /** [Optional] session init started view */
+  loading?: ReactNode
 
-/**
- * Use DefaultClient configured to run in bottomInput mode.
- *
- */
-export default function BottomInputClient(props: KuiProps) {
-  // prompt is unicode for "heavy right-pointing angle quotation mark ornament"
-  return <Kui {...props} bottomInput noPromptContext prompt="&#x276f;" />
+  /** [Optional] session was severed; reinit started view */
+  reinit?: ReactNode
+
+  /** [Optional] session could not be established; error view */
+  loadingError?: (err: Error) => ReactNode
+
+  /** [Optional] session established! welcome to your session view */
+  loadingDone?: (repl: REPL) => ReactNode
 }
+
+export default SessionProps

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -21,6 +21,7 @@ import { dots as spinnerFrames } from 'cli-spinners'
 import onPaste from './OnPaste'
 import onKeyDown from './OnKeyDown'
 import onKeyPress from './OnKeyPress'
+import KuiContext from '../../../Client/context'
 import { TabCompletionState } from './TabCompletion'
 import ActiveISearch, { onKeyUp } from './ActiveISearch'
 import { BlockModel, isActive, isProcessing, isFinished, hasCommand, isEmpty, hasUUID, hasValue } from './BlockModel'
@@ -169,14 +170,24 @@ export default class Input extends React.PureComponent<Props, State> {
 
   /** the "xxx" part of "xxx >" of the prompt */
   private promptLeft() {
-    return !this.props.noPromptContext && <span className="repl-context">{this.props.model.cwd}</span>
+    return (
+      !this.props.noPromptContext && (
+        <KuiContext.Consumer>
+          {config => !config.noPromptContext && <span className="repl-context">{this.props.model.cwd}</span>}
+        </KuiContext.Consumer>
+      )
+    )
   }
 
   /** the ">" part of "xxx >" of the prompt */
   private promptRight() {
     // &#x2771; "heavy right-pointing angle bracket ornament"
     // another option: &#x276f; "heavy right-pointing angle quotation mark ornament"
-    return <span className="repl-prompt-righty">/</span>
+    return (
+      <KuiContext.Consumer>
+        {config => <span className="repl-prompt-righty">{config.prompt || '/'}</span>}
+      </KuiContext.Consumer>
+    )
   }
 
   private isearchPrompt() {


### PR DESCRIPTION
Fixes #4653

This PR also exercises these features plugins/plugin-client-alternate/src/index.tsx

You can try it via 
```sh
./bin/switch-client alternate
npm run watch
```


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
