### PR TITLE
fix(plugins/plugin-kubectl): k edit -h does not open in sidecar

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/edit.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/edit.ts
@@ -20,6 +20,7 @@ import { Arguments, Registrar, i18n } from '@kui-shell/core'
 import flags from './flags'
 import { doExecWithStdout } from './exec'
 import commandPrefix from '../command-prefix'
+import { isUsage, doHelp } from '../../lib/util/help'
 import { KubeOptions, getNamespace, getNamespaceForArgv } from './options'
 import { KubeResource, KubeItems, isKubeItems } from '../../lib/model/resource'
 
@@ -28,6 +29,11 @@ const strings2 = i18n('plugin-client-common', 'editor')
 
 export function doEdit(cmd: string) {
   return async (args: Arguments<KubeOptions>) => {
+    if (isUsage(args)) {
+      // special case: get --help/-h
+      return doHelp(cmd, args)
+    }
+
     const idx = args.argvNoOptions.indexOf('edit')
     const kindForQuery = args.argvNoOptions[idx + 1] || ''
     const nameForQuery = args.argvNoOptions[idx + 2] || ''


### PR DESCRIPTION
Fixes #4661

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
