### PR TITLE
feat(plugins/plugin-kubectl): Terminal tab for Pod kubernetes resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -466,7 +466,8 @@
         "shelljs": "0.8.3",
         "speed-date": "1.0.0",
         "ws": "7.2.3",
-        "xterm": "4.4.0"
+        "xterm": "4.4.0",
+        "xterm-addon-fit": "^0.4.0"
       }
     },
     "@kui-shell/plugin-carbon-themes": {
@@ -15472,6 +15473,11 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/xterm/-/xterm-4.4.0.tgz",
       "integrity": "sha512-JGIpigWM3EBWvnS3rtBuefkiToIILSK1HYMXy4BCsUpO+O4UeeV+/U1AdAXgCB6qJrnPNb7yLgBsVCQUNMteig=="
+    },
+    "xterm-addon-fit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.4.0.tgz",
+      "integrity": "sha512-p4BESuV/g2L6pZzFHpeNLLnep9mp/DkF3qrPglMiucSFtD8iJxtMufEoEJbN8LZwB4i+8PFpFvVuFrGOSpW05w=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/packages/core/src/core/jobs/job.ts
+++ b/packages/core/src/core/jobs/job.ts
@@ -21,6 +21,7 @@ export interface Abortable {
 export interface FlowControllable {
   xon(): void
   xoff(): void
+  write(data: string): void
 }
 
 /** in the future, a WatchableJob may be more than Abortable, e.g. Suspendable */

--- a/plugins/plugin-bash-like/package.json
+++ b/plugins/plugin-bash-like/package.json
@@ -32,7 +32,8 @@
     "shelljs": "0.8.3",
     "speed-date": "1.0.0",
     "ws": "7.2.3",
-    "xterm": "4.4.0"
+    "xterm": "4.4.0",
+    "xterm-addon-fit": "^0.4.0"
   },
   "kui": {
     "exclude": {

--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -932,6 +932,7 @@ export const doExec = (
         // command against the websocket/channel
         const init = async (ws: Channel) => {
           const job = {
+            write: (data: string) => ws.send(JSON.stringify({ type: 'data', data, uuid: ourUUID })),
             xon: () => {
               debug('xon requested')
               ws.send(JSON.stringify({ type: 'xon', uuid: ourUUID }))

--- a/plugins/plugin-kubectl/i18n/exec_en_US.json
+++ b/plugins/plugin-kubectl/i18n/exec_en_US.json
@@ -1,0 +1,5 @@
+{
+  "The terminal connection has closed.": "The terminal connection has closed.",
+  "Connecting to container X.": "Please wait. Connecting to container **{0}**.",
+  "Connected to container X.": "Connected to container **{0}**."
+}

--- a/plugins/plugin-kubectl/logs/src/controller/kubectl/logs.ts
+++ b/plugins/plugin-kubectl/logs/src/controller/kubectl/logs.ts
@@ -65,9 +65,6 @@ export async function doLogs(args: Arguments<LogOptions>) {
   // a bit of plumbing: tell the PTY that we will be handling everything
   const myExecOptions = Object.assign({}, args.execOptions, {
     rethrowErrors: true, // we want to handle errors
-    quiet: true, // don't ever emit anything on your own
-    replSilence: true, // repl: same thing
-    echo: false, // do not even echo "ok"
 
     // the PTY will call this when the PTY process is ready; in
     // return, we send it back a consumer of streaming output

--- a/plugins/plugin-kubectl/src/controller/kubectl/exec.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/exec.ts
@@ -109,6 +109,13 @@ export async function doExecWithPty<
     // Otherwise, execute the given command using a pty
     //
     const commandToPTY = args.command.replace(/^k(\s)/, 'kubectl$1')
+
+    if (args.execOptions.onInit) {
+      args.execOptions.quiet = true // don't ever emit anything on your own
+      args.execOptions.replSilence = true // repl: same thing
+      args.execOptions.echo = false // do not even echo "ok"
+    }
+
     return args.REPL.qexec<string | Response>(
       `sendtopty ${commandToPTY}`,
       args.block,

--- a/plugins/plugin-kubectl/src/lib/view/modes/ExecIntoPod.tsx
+++ b/plugins/plugin-kubectl/src/lib/view/modes/ExecIntoPod.tsx
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react'
+import { v4 as uuid } from 'uuid'
+import {
+  Abortable,
+  Arguments,
+  FlowControllable,
+  ModeRegistration,
+  Streamable,
+  Tab,
+  ToolbarProps,
+  ToolbarText,
+  i18n
+} from '@kui-shell/core'
+
+import { Terminal as XTerminal } from 'xterm'
+import { FitAddon } from 'xterm-addon-fit'
+
+import { getCommandFromArgs } from '../../util/util'
+import { KubeOptions } from '../../../controller/kubectl/options'
+import { KubeResource, Pod, isPod } from '../../model/resource'
+
+import { ContainerProps, ContainerState, ContainerComponent } from './logs'
+
+import '@kui-shell/plugin-bash-like/web/css/static/xterm.css'
+
+const strings = i18n('plugin-kubectl', 'exec')
+
+type Job = Abortable & FlowControllable
+
+interface State extends ContainerState {
+  isTerminated: boolean
+
+  dom: HTMLDivElement
+  xterm: XTerminal
+  doResize: () => void
+}
+
+class Terminal extends ContainerComponent<State> {
+  private readonly resizeListener: () => void
+
+  public constructor(props: ContainerProps) {
+    super(props)
+
+    this.state = {
+      container: props.pod.spec.containers[0].name,
+
+      dom: undefined,
+      xterm: undefined,
+      doResize: undefined,
+
+      isTerminated: false,
+      job: undefined,
+      streamUUID: undefined
+    }
+
+    this.updateToolbar('Paused')
+
+    this.resizeListener = this.onResize.bind(this)
+    window.addEventListener('resize', this.resizeListener)
+  }
+
+  private onResize() {
+    if (this.state.xterm) {
+      this.state.doResize()
+    }
+  }
+
+  /** When we are going away, make sure to abort the streaming job. */
+  public componentWillUnmount() {
+    super.componentWillUnmount()
+    this.state.xterm.dispose()
+
+    window.removeEventListener('resize', this.resizeListener)
+  }
+
+  /** Finish up the initialization of the stream */
+  public componentDidUpdate() {
+    this.updateToolbar('Live')
+
+    if (!this.state.job && !this.state.isTerminated) {
+      this.initStream()
+    }
+  }
+
+  protected showContainer(container: string) {
+    super.showContainer(container)
+
+    this.setState(curState => {
+      if (curState.job) {
+        curState.job.abort()
+      }
+
+      return {
+        job: undefined,
+        streamUUID: undefined,
+        isTerminated: false
+      }
+    })
+  }
+
+  public static getDerivedStateFromProps(props: ContainerProps, state: State) {
+    if (state.dom && !state.xterm) {
+      return Terminal.initTerminal(state.dom)
+    } else {
+      return state
+    }
+  }
+
+  protected toolbarText(): ToolbarText {
+    if (this.state.isTerminated) {
+      return {
+        type: 'error',
+        text: strings('The terminal connection has closed.')
+      }
+    } else if (!this.state.job) {
+      return {
+        type: 'warning',
+        text: strings('Please wait. Connecting to container X.', this.state.container)
+      }
+    } else {
+      return {
+        type: 'info',
+        text: strings('Connected to container X.', this.state.container)
+      }
+    }
+  }
+
+  private initStream() {
+    const streamUUID = uuid()
+    const { pod, repl } = this.props
+    const { container, xterm } = this.state
+    const cmd = `${getCommandFromArgs(this.props.args)} exec -it ${pod.metadata.name} -c ${container} -n ${
+      pod.metadata.namespace
+    } sh`
+
+    xterm.clear()
+
+    repl.qexec(cmd, undefined, undefined, {
+      onInit: () => {
+        return (_: Streamable) => {
+          if (typeof _ === 'string') {
+            xterm.write(_)
+          }
+        }
+      },
+
+      onReady: (job: Job) => {
+        xterm.onData((data: string) => {
+          if (this.state.streamUUID === streamUUID) {
+            job.write(data)
+          }
+        })
+
+        xterm.focus()
+
+        this.setState({
+          job,
+          streamUUID
+        })
+      },
+
+      onExit: (exitCode: number) => {
+        this.setState(curState => {
+          if (curState.streamUUID === streamUUID) {
+            this.updateToolbar(exitCode === 0 ? 'Stopped' : 'Error')
+            return {
+              job: undefined,
+              streamUUID: undefined,
+              isTerminated: true
+            }
+          }
+        })
+      }
+    }) /* .catch(err => {
+      console.error(err)
+      this.updateToolbar('Error')
+    }) */
+  }
+
+  private static initTerminal(dom: HTMLElement) {
+    const xterm = new XTerminal({ fontFamily: 'IBM Plex Mono' })
+    const fitAddon = new FitAddon()
+    xterm.loadAddon(fitAddon)
+    xterm.open(dom)
+
+    const doResize = () => {
+      fitAddon.fit()
+    }
+
+    // resize once on init
+    doResize()
+
+    return {
+      xterm,
+      doResize
+    }
+  }
+
+  public render() {
+    if (this.state.dom && !this.state.xterm) {
+      return <React.Fragment />
+    } else {
+      return <div className="kui--full-height" ref={dom => this.setState({ dom })} />
+    }
+  }
+}
+
+/**
+ * The content renderer for the summary tab
+ *
+ */
+async function content({ REPL }: Tab, pod: Pod, args: Arguments<KubeOptions>) {
+  return {
+    react: function TerminalProvider(toolbarController: ToolbarProps) {
+      return <Terminal repl={REPL} pod={pod} args={args} toolbarController={toolbarController} />
+    }
+  }
+}
+
+/**
+ * Add a Pods mode button to the given modes model, if called for by
+ * the given resource.
+ *
+ */
+export const terminalMode: ModeRegistration<KubeResource> = {
+  when: isPod,
+  mode: {
+    mode: 'terminal',
+    label: 'Terminal',
+    content
+  }
+}
+
+export default terminalMode

--- a/plugins/plugin-kubectl/src/lib/view/modes/yaml.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/yaml.ts
@@ -18,6 +18,9 @@ import { ModeRegistration } from '@kui-shell/core'
 
 import { WithRawData, hasRawData } from '../../model/resource'
 
+/** we want this to be placed as the last tab */
+export const order = 999
+
 /**
  * The YAML mode applies to all KubeResources, and simply extracts the
  * raw `data` field from the resource; note how we indicate that this
@@ -36,7 +39,7 @@ const yamlMode: ModeRegistration<WithRawData> = {
     }),
 
     // traits:
-    order: 999 // we want this to be placed as the last tab
+    order
   }
 }
 

--- a/plugins/plugin-kubectl/src/non-headless-preload.ts
+++ b/plugins/plugin-kubectl/src/non-headless-preload.ts
@@ -24,6 +24,7 @@ import crdSummaryMode from './lib/view/modes/crd-summary'
 import configmapSummaryMode from './lib/view/modes/configmap-summary'
 import namespaceSummaryMode from './lib/view/modes/namespace-summary'
 import logsMode from './lib/view/modes/logs'
+import ExecIntoPad from './lib/view/modes/ExecIntoPod'
 import lastAppliedMode from './lib/view/modes/last-applied'
 import showOwnerButton from './lib/view/modes/ShowOwnerButton'
 import showNodeButton from './lib/view/modes/ShowNodeOfPodButton'
@@ -45,6 +46,7 @@ export default async (registrar: PreloadRegistrar) => {
     configmapSummaryMode,
     namespaceSummaryMode,
     logsMode,
+    ExecIntoPad,
     lastAppliedMode,
     showCRDResources,
     showOwnerButton,

--- a/plugins/plugin-kubectl/src/test/k8s2/terminal-tab.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/terminal-tab.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { v4 as uuid } from 'uuid'
+import { Common, CLI, Keys, ReplExpect, Selectors, SidecarExpect } from '@kui-shell/test'
+import {
+  createNS,
+  allocateNS,
+  deleteNS,
+  waitForGreen,
+  defaultModeForGet
+} from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
+
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+const ROOT = dirname(require.resolve('@kui-shell/plugin-kubectl/tests/package.json'))
+const inputBuffer = readFileSync(join(ROOT, 'data/k8s/kubectl-logs-two-containers.yaml'))
+const inputEncoded = inputBuffer.toString('base64')
+const podName = 'kui-two-containers'
+const containerName = 'nginx'
+
+// we will echo this text to this file
+const ECHO_TEXT = `hello ${uuid()}`
+const ECHO_FILE = '/tmp/kui-terminal-tab-test'
+
+describe(`kubectl Terminal tab ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  const ns: string = createNS()
+  allocateNS(this, ns)
+
+  it(`should create sample pod from URL`, () => {
+    return CLI.command(`echo ${inputEncoded} | base64 --decode | kubectl create -f - -n ${ns}`, this.app)
+      .then(ReplExpect.okWithPtyOutput(podName))
+      .catch(Common.oops(this, true))
+  })
+
+  if (process.env.USE_WATCH_PANE) {
+    it(`should wait for the pod to come up`, () => {
+      return CLI.command(`kubectl get pod ${podName} -n ${ns} -w`, this.app)
+        .then(async () => {
+          await this.app.client.waitForExist(Selectors.WATCHER_N(1))
+          await this.app.client.waitForExist(Selectors.WATCHER_N_GRID_CELL_ONLINE(1, podName))
+        })
+        .catch(Common.oops(this, true))
+    })
+  } else {
+    it(`should wait for the pod to come up`, () => {
+      return CLI.command(`kubectl get pod ${podName} -n ${ns} -w`, this.app)
+        .then(ReplExpect.okWithCustom({ selector: Selectors.BY_NAME(podName) }))
+        .then(selector => waitForGreen(this.app, selector))
+        .catch(Common.oops(this, true))
+    })
+  }
+
+  it(`should get pods via kubectl then click`, async () => {
+    try {
+      const selector: string = await CLI.command(`kubectl get pods ${podName} -n ${ns}`, this.app).then(
+        ReplExpect.okWithCustom({ selector: Selectors.BY_NAME(podName) })
+      )
+
+      // wait for the badge to become green
+      await waitForGreen(this.app, selector)
+
+      // now click on the table row
+      await this.app.client.click(`${selector} .clickable`)
+      await SidecarExpect.open(this.app)
+        .then(SidecarExpect.mode(defaultModeForGet))
+        .then(SidecarExpect.showing(podName))
+    } catch (err) {
+      return Common.oops(this, true)(err)
+    }
+  })
+
+  it('should show terminal tab', async () => {
+    try {
+      await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON('terminal'))
+      await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON('terminal'))
+      await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON_SELECTED('terminal'))
+
+      await SidecarExpect.toolbarText({ type: 'info', text: `Connected to container ${containerName}`, exact: false })(
+        this.app
+      )
+
+      await new Promise(resolve => setTimeout(resolve, 5000))
+
+      this.app.client.keys(`echo ${ECHO_TEXT} > ${ECHO_FILE}${Keys.ENTER}`)
+      this.app.client.keys(`exit${Keys.ENTER}`)
+
+      await SidecarExpect.toolbarText({ type: 'error', text: 'has closed', exact: false })(this.app)
+    } catch (err) {
+      return Common.oops(this, true)(err)
+    }
+  })
+
+  it('should confirm echoed text via kubectl exec', async () => {
+    await CLI.command(`kubectl exec ${podName} -c ${containerName} -n ${ns} cat ${ECHO_FILE}`, this.app)
+      .then(ReplExpect.okWithPtyOutput(ECHO_TEXT))
+      .catch(Common.oops(this, true))
+  })
+
+  deleteNS(this, ns)
+})


### PR DESCRIPTION
covers "exec into pod" use case

Fixes #4639

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
