### PR TITLE
fix(plugins/plugin-kubectl): ImagePullBackoff should be considered a …

### DIFF
--- a/plugins/plugin-kubectl/src/lib/view/css-for-value.ts
+++ b/plugins/plugin-kubectl/src/lib/view/css-for-value.ts
@@ -38,7 +38,7 @@ export default {
   PodInitializing: TrafficLight.Yellow,
   Initialized: TrafficLight.Yellow,
   Terminating: TrafficLight.Yellow,
-  ImagePullBackOff: TrafficLight.Yellow,
+  ImagePullBackOff: TrafficLight.Red,
   ErrImagePull: TrafficLight.Red,
   Error: TrafficLight.Red,
 


### PR DESCRIPTION
…"red" state

Fixes #4734

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
