### PR TITLE
feat: allow subclasses of InputProvider to specify their own State

### DIFF
--- a/plugins/plugin-client-alternate/src/CustomInput.tsx
+++ b/plugins/plugin-client-alternate/src/CustomInput.tsx
@@ -15,15 +15,35 @@
  */
 
 import * as React from 'react'
-import { InputProvider, defaultOnKeyDown, defaultOnKeyPress, defaultOnKeyUp } from '@kui-shell/plugin-client-common'
+import {
+  InputProvider,
+  InputProviderProps,
+  InputProviderState,
+  defaultOnKeyDown,
+  defaultOnKeyPress,
+  defaultOnKeyUp
+} from '@kui-shell/plugin-client-common'
 
 import '../web/scss/CustomInput.scss'
+
+/** intentionally empty for now, to get test coverage of the ability to subclass State */
+interface MyState extends InputProviderState {
+  customCount: number
+}
 
 /**
  * Use DefaultClient configured to run in bottomInput mode.
  *
  */
-export default class CustomInput extends InputProvider {
+export default class CustomInput extends InputProvider<MyState> {
+  public constructor(props: InputProviderProps) {
+    super(props)
+
+    this.state = Object.assign(this.state || {}, {
+      customCount: 0
+    })
+  }
+
   /** This is the "input" that we provide */
   protected input() {
     return (

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -89,9 +89,9 @@ type InputProps = {
   model?: BlockModel
 }
 
-type Props = InputOptions & InputProps
+export type Props = InputOptions & InputProps
 
-interface State {
+export interface State {
   /** the execution ID for this prompt, if any */
   execUUID?: string
 
@@ -105,11 +105,11 @@ interface State {
   tabCompletion?: TabCompletionState
 
   /** spinner? */
-  spinner: ReturnType<typeof setInterval>
+  spinner?: ReturnType<typeof setInterval>
   spinnerDom?: HTMLSpanElement
 }
 
-export abstract class InputProvider extends React.PureComponent<Props, State> {
+export abstract class InputProvider<S extends State = State> extends React.PureComponent<Props, S> {
   /** this is what the InputProvider needs to provide, minimially */
   protected abstract input()
 

--- a/plugins/plugin-client-common/src/index.ts
+++ b/plugins/plugin-client-common/src/index.ts
@@ -50,7 +50,11 @@ export { default as TopNavSidecar } from './components/Views/Sidecar/TopNavSidec
 export { default as LeftNavSidecar } from './components/Views/Sidecar/LeftNavSidecar'
 
 // Input components
-export { InputProvider } from './components/Views/Terminal/Block/Input'
+export {
+  InputProvider,
+  State as InputProviderState,
+  Props as InputProviderProps
+} from './components/Views/Terminal/Block/Input'
 export { default as defaultOnKeyDown } from './components/Views/Terminal/Block/OnKeyDown'
 export { default as defaultOnKeyPress } from './components/Views/Terminal/Block/OnKeyPress'
 export { onKeyUp as defaultOnKeyUp } from './components/Views/Terminal/Block/ActiveISearch'


### PR DESCRIPTION
FIxes #4756

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
