### PR TITLE
fix: kubectl edit in sidecar doesn't show success message when a resource is applied

### DIFF
--- a/packages/core/src/webapp/views/toolbar-text.ts
+++ b/packages/core/src/webapp/views/toolbar-text.ts
@@ -19,7 +19,7 @@
  *
  */
 
-type ToolbarTextType = 'info' | 'warning' | 'error'
+type ToolbarTextType = 'info' | 'success' | 'warning' | 'error'
 
 type ToolbarTextValue = string | Element
 

--- a/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
@@ -38,7 +38,7 @@ interface WithOptions {
     clearable?: boolean
     save?: {
       label: string
-      onSave: (data: string) => Promise<void>
+      onSave: (data: string) => Promise<void | ToolbarText>
     }
     revert?: {
       label: string
@@ -166,8 +166,11 @@ export default class Editor extends React.PureComponent<Props, State> {
           kind: 'view' as const,
           command: async () => {
             try {
-              await onSave(editor.getValue())
-              props.willUpdateToolbar(this.allClean(props), !clearable ? undefined : [ClearButton(editor)])
+              const onSavedText = await onSave(editor.getValue())
+              props.willUpdateToolbar(
+                onSavedText || this.allClean(props),
+                !clearable ? undefined : [ClearButton(editor)]
+              )
             } catch (err) {
               props.willUpdateToolbar(this.error(props, 'errorSavingWithMessage', err.message))
             }

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/Toolbar.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/Toolbar.tsx
@@ -45,6 +45,8 @@ export default class Toolbar extends React.PureComponent<Props> {
       switch (type) {
         case 'info':
           return <Icons icon="Info" />
+        case 'success':
+          return <Icons icon="Checkmark" />
         case 'warning':
           return <Icons icon="Warning" />
         case 'error':

--- a/plugins/plugin-kubectl/i18n/resources_en_US.json
+++ b/plugins/plugin-kubectl/i18n/resources_en_US.json
@@ -1,5 +1,6 @@
 {
   "Apply Changes": "Apply Changes",
+  "Successfully Applied": "Successfully Applied",
   "This API Resource is deprecated": "This API Resource is deprecated.",
   "Namespace": "Namespace",
   "Usage": "Usage",

--- a/plugins/plugin-kubectl/src/controller/kubectl/edit.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/edit.ts
@@ -94,6 +94,11 @@ export function doEdit(cmd: string) {
                 }
               }
             })
+
+            return {
+              type: 'success' as const,
+              text: strings('Successfully Applied')
+            }
           }
         },
         revert: {

--- a/plugins/plugin-kubectl/src/test/k8s1/edit.ts
+++ b/plugins/plugin-kubectl/src/test/k8s1/edit.ts
@@ -120,6 +120,7 @@ commands.forEach(command => {
           await this.app.client.keys(`${Keys.End}${Keys.ENTER}foo: bar${Keys.ENTER}`)
           await new Promise(resolve => setTimeout(resolve, 2000))
           await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON('Save'))
+          await SidecarExpect.toolbarText({ type: 'success', text: 'Successfully Applied', exact: true })(this.app)
           await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON('Save'), 10000, true)
         } catch (err) {
           await Common.oops(this, true)(err)


### PR DESCRIPTION
Fixes #4691

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
