### PR TITLE
feat: target kubectl logs and kubectl exec to Logs and Terminal tabs

### DIFF
--- a/packages/core/src/models/mmr/content-types.ts
+++ b/packages/core/src/models/mmr/content-types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ParsedOptions } from '../command'
+import { EvaluatorArgs as Arguments, ParsedOptions } from '../command'
 import { ReactElement } from 'react'
 import { Tab } from '../../webapp/tab'
 import { Table, isTable } from '../../webapp/models/table'
@@ -113,6 +113,7 @@ export type FunctionThatProducesContent<T extends MetadataBearing = MetadataBear
   tab: Tab,
   entity: T,
   args: {
+    argsForMode?: Arguments
     argvNoOptions: string[]
     parsedOptions: ParsedOptions
   }

--- a/packages/core/src/models/mmr/types.ts
+++ b/packages/core/src/models/mmr/types.ts
@@ -19,7 +19,7 @@ import { ReactElement } from 'react'
 import { Tab } from '../../webapp/tab'
 import { Content } from './content-types'
 import { MetadataBearing } from '../entity'
-import { ParsedOptions } from '../command'
+import { EvaluatorArgs as Arguments, ParsedOptions } from '../command'
 // import { SelectionController } from '../../webapp/bottom-stripe'
 
 /**
@@ -46,7 +46,7 @@ export type MultiModalResponse<Resource = MetadataBearing> = Resource & View<Res
  * multi-modal view.
  *
  */
-interface View<Resource extends MetadataBearing> {
+export interface View<Resource extends MetadataBearing> {
   /**
    * Each `Mode` is a different way to view the resource
    */
@@ -63,6 +63,9 @@ interface View<Resource extends MetadataBearing> {
    *
    */
   defaultMode?: string
+
+  /** Arguments to pass through to the default mode? */
+  argsForMode?: Arguments
 }
 
 export type ModeOrButton<T = MetadataBearing> = Mode<T> | Button<T>

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -377,10 +377,15 @@ class InProcessExecutor implements Executor {
       }
 
       if (evaluator.options.viewTransformer && execType !== ExecType.Nested) {
-        response = await Promise.resolve(response).then(async _ => {
-          const maybeAView = await evaluator.options.viewTransformer(args, _)
-          return maybeAView || _
-        })
+        response = await Promise.resolve(response)
+          .then(async _ => {
+            const maybeAView = await evaluator.options.viewTransformer(args, _)
+            return maybeAView || _
+          })
+          .catch(err => {
+            // view transformer failed; treat this as the response to the user
+            return err
+          })
       }
 
       // the || true part is a safeguard for cases where typescript

--- a/packages/test/src/api/common.ts
+++ b/packages/test/src/api/common.ts
@@ -450,8 +450,12 @@ export const oops = (ctx: ISuite, wait = false) => async (err: Error) => {
   }
 
   // swap these two if you want to debug failures locally
-  // return new Promise((resolve, reject) => setTimeout(() => { reject(err) }, 100000))
-  throw err
+  return new Promise((resolve, reject) =>
+    setTimeout(() => {
+      reject(err)
+    }, 100000)
+  )
+  // throw err
 }
 
 /** restart the app */
@@ -512,3 +516,19 @@ export const pit = (msg: string, func: Func) => {
 
 /** non-headless targets in travis use the clients/default version */
 export const expectedVersion = version
+
+/**
+ * This helps with webpack/browser-based tests, where we can't rely
+ * on env vars to transit "in debug mode". E.g. see ExecIntoPod
+ *
+ */
+declare let __KUI_RUNNING_KUI_TEST: boolean
+export function setDebugMode(this: ISuite) {
+  it('should inject RUNNING_KUI_TEST', () => {
+    return this.app.client
+      .execute(() => {
+        __KUI_RUNNING_KUI_TEST = true
+      })
+      .catch(oops(this, true))
+  })
+}

--- a/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
+++ b/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
@@ -18,6 +18,7 @@ import * as React from 'react'
 import { isFile } from '@kui-shell/plugin-bash-like/fs'
 
 import {
+  Arguments,
   ParsedOptions,
   Tab as KuiTab,
   Content,
@@ -47,6 +48,7 @@ export type KuiMMRProps = ToolbarProps & {
   isActive: boolean
   response: MultiModalResponse
   args: {
+    argsForMode?: Arguments
     argvNoOptions: string[]
     parsedOptions: ParsedOptions
   }

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/TopNavSidecar.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/TopNavSidecar.tsx
@@ -68,11 +68,11 @@ export function getStateFromMMR(
 
   // consult the view registrar for registered view modes
   // relevant to this resource
-  const command = ''
+  const cmd = ''
   if (isResourceWithMetadata(response)) {
-    addRelevantModes(tab, allModes, command, { resource: response })
+    addRelevantModes(tab, allModes, cmd, { resource: response })
   } else if (isResourceByReference(response)) {
-    addRelevantModes(tab, allModes, command, response)
+    addRelevantModes(tab, allModes, cmd, response)
   }
 
   // obey the `order` constraints of the modes
@@ -228,12 +228,18 @@ export default class TopNavSidecar extends BaseSidecar<MultiModalResponse, Histo
   }
 
   protected bodyContent(idx: number) {
+    const mode = this.current.tabs[idx]
+
     return (
       <KuiContent
         tab={this.state.tab}
-        mode={this.current.tabs[idx]}
+        mode={mode}
         isActive={idx === this.current.currentTabIndex}
-        args={{ argvNoOptions: this.state.current.argvNoOptions, parsedOptions: this.state.current.parsedOptions }}
+        args={{
+          argsForMode: this.current.response.argsForMode,
+          argvNoOptions: this.state.current.argvNoOptions,
+          parsedOptions: this.state.current.parsedOptions
+        }}
         response={this.current.response}
       />
     )

--- a/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-c-via-table.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-c-via-table.ts
@@ -42,9 +42,12 @@ function sleep(N: number) {
 
 const wdescribe = !process.env.USE_WATCH_PANE ? describe : xdescribe
 
-wdescribe(`kubectl logs follow via table ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+wdescribe(`kubectl logs dashC follow via table ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
   before(Common.before(this))
   after(Common.after(this))
+
+  // needed to force the dom renderer for webpack/browser-based tests; see ExecIntoPod
+  Common.setDebugMode.bind(this)()
 
   const ns: string = createNS()
   allocateNS(this, ns)
@@ -66,9 +69,9 @@ wdescribe(`kubectl logs follow via table ${process.env.MOCHA_RUN_TARGET || ''}`,
 
   it(`should follow the logs`, async () => {
     try {
-      const res = await CLI.command(`kubectl logs ${podName} ${containerName} -n ${ns} -f`, this.app)
+      await CLI.command(`kubectl logs ${podName} ${containerName} -n ${ns} -f`, this.app).then(ReplExpect.justOK)
 
-      const rows = Selectors.OUTPUT_N_STREAMING(res.count)
+      const rows = `${Selectors.SIDECAR_TAB_CONTENT} .xterm-rows`
 
       await sleep(sleepTime)
       const text1 = await getTextContent(this.app, rows)

--- a/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-c.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-c.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert'
-
 import { Common, CLI, ReplExpect, Selectors, SidecarExpect } from '@kui-shell/test'
 import {
   createNS,
@@ -23,7 +21,6 @@ import {
   deleteNS,
   waitForGreen,
   waitForRed,
-  getTerminalText,
   waitForTerminalText,
   defaultModeForGet
 } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
@@ -47,7 +44,6 @@ wdescribe(`kubectl Logs tab ${process.env.MOCHA_RUN_TARGET || ''}`, function(thi
   before(Common.before(this))
   after(Common.after(this))
 
-  const getLogText = getTerminalText.bind(this)
   const waitForLogText = waitForTerminalText.bind(this)
 
   const ns: string = createNS()
@@ -251,20 +247,13 @@ wdescribe(`kubectl Logs tab ${process.env.MOCHA_RUN_TARGET || ''}`, function(thi
     return CLI.command(`kubectl delete pod ${podName} -n ${ns}`, this.app)
       .then(ReplExpect.okWithCustom({ selector: Selectors.BY_NAME(podName) }))
       .then(selector => waitForRed(this.app, selector))
-      .catch(Common.oops(this))
+      .catch(Common.oops(this, true))
   })
 
   it('should see log streaming stopped', async () => {
     try {
       await sleep(sleepTime)
-
       await SidecarExpect.toolbarText({ type: 'warning', text: 'Log streaming stopped', exact: false })(this.app)
-
-      const text1 = await getLogText()
-      await sleep(sleepTime)
-      const text2 = await getLogText()
-
-      assert.ok(text1.length === text2.length, `logs streaming should be stopped`)
     } catch (err) {
       return Common.oops(this, true)(err)
     }

--- a/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-f.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-f.ts
@@ -46,6 +46,9 @@ wdescribe(`kubectl logs follow via watch pane ${process.env.MOCHA_RUN_TARGET || 
   before(Common.before(this))
   after(Common.after(this))
 
+  // needed to force the dom renderer for webpack/browser-based tests; see ExecIntoPod
+  Common.setDebugMode.bind(this)()
+
   const ns: string = createNS()
   allocateNS(this, ns)
 
@@ -68,9 +71,9 @@ wdescribe(`kubectl logs follow via watch pane ${process.env.MOCHA_RUN_TARGET || 
 
   it(`should follow the logs`, async () => {
     try {
-      const res = await CLI.command(`kubectl logs ${podName} ${containerName} -n ${ns} -f`, this.app)
+      await CLI.command(`kubectl logs ${podName} ${containerName} -n ${ns} -f`, this.app).then(ReplExpect.justOK)
 
-      const rows = Selectors.OUTPUT_N_STREAMING(res.count)
+      const rows = `${Selectors.SIDECAR_TAB_CONTENT} .xterm-rows`
 
       await sleep(sleepTime)
       const text1 = await getTextContent(this.app, rows)

--- a/plugins/plugin-kubectl/logs/src/test/logs/logs-multi.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/logs-multi.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI, ReplExpect, Selectors, SidecarExpect } from '@kui-shell/test'
+import {
+  createNS,
+  allocateNS,
+  deleteNS,
+  waitForGreen,
+  waitForTerminalText
+} from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
+
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+const ROOT = dirname(require.resolve('@kui-shell/plugin-kubectl/tests/package.json'))
+const inputBuffer = readFileSync(join(ROOT, 'data/k8s/kubectl-logs-two-containers.yaml'))
+const inputEncoded = inputBuffer.toString('base64')
+
+const inputBuffer2 = readFileSync(join(ROOT, 'data/k8s/kubectl-exec.yaml'))
+const inputEncoded2 = inputBuffer2.toString('base64')
+
+const sleepTime = 3
+
+/** sleep for N seconds */
+function sleep(N: number) {
+  return new Promise(resolve => setTimeout(resolve, N * 1000))
+}
+
+interface PodDesc {
+  input: string
+  podName: string
+  containers: string[]
+}
+
+describe(`kubectl Logs multiple pods via selector ${process.env.MOCHA_RUN_TARGET ||
+  ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  const waitForLogText = waitForTerminalText.bind(this)
+
+  const ns: string = createNS()
+  allocateNS(this, ns)
+
+  const allContainers = 'All Containers'
+
+  const pods: PodDesc[] = [
+    { input: inputEncoded, podName: 'kui-two-containers', containers: ['nginx', 'vim'] },
+    { input: inputEncoded2, podName: 'vim', containers: ['alpine'] }
+  ]
+
+  const fqn1 = `${pods[0].podName}:${pods[0].containers[0]}`
+  const fqn2 = `${pods[0].podName}:${pods[0].containers[1]}`
+  const containerName1 = pods[0].containers[0]
+  const containerName2 = pods[0].containers[1]
+
+  // this is the name we expect to represent all of the pods, when
+  // queried by the label we will add in `addLabel()` below
+  const allPods = pods.map(_ => _.podName).join(', ')
+
+  const createPodWithoutWaiting = ({ input, podName }: PodDesc) => {
+    it(`should create sample pod from URL`, () => {
+      return CLI.command(`echo ${input} | base64 --decode | kubectl create -f - -n ${ns}`, this.app)
+        .then(ReplExpect.okWithPtyOutput(podName))
+        .catch(Common.oops(this, true))
+    })
+  }
+
+  const waitForPod = ({ podName }: PodDesc) => {
+    it(`should wait for the pod to come up`, () => {
+      return CLI.command(`kubectl get pod ${podName} -n ${ns} -w`, this.app)
+        .then(ReplExpect.okWithCustom({ selector: Selectors.BY_NAME(podName) }))
+        .then(selector => waitForGreen(this.app, selector))
+        .catch(Common.oops(this, true))
+    })
+  }
+
+  const addLabel = ({ podName }: PodDesc) => {
+    it(`should add a label to pod ${podName}`, () => {
+      return CLI.command(`kubectl label pod ${podName} -n ${ns} foo=bar`, this.app)
+        .then(ReplExpect.okWithPtyOutput('labeled'))
+        .catch(Common.oops(this, true))
+    })
+  }
+
+  const getLogsViaLabel = (containers: string) => {
+    it(`should show the Logs tab via k logs -lfoo=bar`, async () => {
+      return CLI.command(`kubectl logs -lfoo=bar -n ${ns} ${containers}`, this.app)
+        .then(ReplExpect.justOK)
+        .then(SidecarExpect.open)
+        .then(SidecarExpect.showing(allPods))
+        .then(SidecarExpect.mode('logs'))
+        .catch(Common.oops(this, true))
+    })
+  }
+
+  const testLogsContent = (show: string[], notShow?: string[]) => {
+    if (show) {
+      show.forEach(showInLog => {
+        it(`should show ${showInLog} in log output`, async () => {
+          try {
+            await sleep(sleepTime)
+            await waitForLogText((text: string) => text.indexOf(showInLog) !== -1)
+          } catch (err) {
+            return Common.oops(this, true)(err)
+          }
+        })
+      })
+    }
+
+    if (notShow) {
+      notShow.forEach(notShowInLog => {
+        it(`should not show ${notShowInLog} in log output`, async () => {
+          try {
+            await sleep(sleepTime)
+            await waitForLogText((text: string) => text.indexOf(notShowInLog) === -1)
+          } catch (err) {
+            return Common.oops(this, true)(err)
+          }
+        })
+      })
+    }
+  }
+
+  const switchContainer = (container: string, showInLog: string[], notShowInLog: string[]) => {
+    it(`should switch to container ${container}`, async () => {
+      try {
+        await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON('container-list'))
+        await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON('container-list'))
+        await this.app.client.waitForVisible(`.bx--overflow-menu-options button[data-mode="${container}"]`)
+        await this.app.client.click(`.bx--overflow-menu-options button[data-mode="${container}"]`)
+      } catch (err) {
+        return Common.oops(this, true)(err)
+      }
+    })
+
+    testLogsContent(showInLog, notShowInLog)
+  }
+
+  /* Here comes the test */
+
+  // create and label the pods
+  pods.forEach(pod => {
+    createPodWithoutWaiting(pod)
+    waitForPod(pod)
+    addLabel(pod)
+  })
+
+  // use k get -lfoo=bar to show the Logs tab, all containers across all pods
+  getLogsViaLabel('--all-containers')
+
+  // expect the log messages for all containers across all pods
+  // note how pod 0 uses the container names as the log messages
+  // whereas pod 1 uses "hi"
+  testLogsContent([containerName1, containerName2, 'hi'])
+
+  // testing various combination here
+  switchContainer(fqn1, [containerName1], [containerName2, 'hi'])
+  switchContainer(fqn2, [containerName2], [containerName1, 'hi'])
+  switchContainer(allContainers, [containerName1, containerName2, 'hi'], [])
+
+  // use k get -lfoo=bar to show the Logs tab, the first container of the first pod
+  getLogsViaLabel(`-c ${containerName1}`)
+  testLogsContent([containerName1])
+
+  // use k get -lfoo=bar to show the Logs tab, the second container of the first pod
+  getLogsViaLabel(`-c ${containerName2}`)
+  testLogsContent([containerName2])
+
+  deleteNS(this, ns)
+})

--- a/plugins/plugin-kubectl/logs/src/test/logs/logs-via-table.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/logs-via-table.ts
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert'
 import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
-import { waitForGreen, createNS, allocateNS, deleteNS } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
+import {
+  waitForGreen,
+  waitForTerminalText,
+  createNS,
+  allocateNS,
+  deleteNS
+} from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
 
 import { readFileSync } from 'fs'
 import { dirname, join } from 'path'
@@ -75,15 +80,13 @@ wdescribe(`kubectl logs getty via table ${process.env.MOCHA_RUN_TARGET || ''}`, 
     })
   }
 
+  const waitForLogText = waitForTerminalText.bind(this)
+
   const showLogs = (podName: string, containerName: string, label: string, hasLogs: boolean) => {
     const checkLogs = async (res: ReplExpect.AppAndCount) => {
+      await Promise.resolve(res).then(ReplExpect.justOK)
       if (hasLogs) {
-        await Promise.resolve(res)
-          .then(ReplExpect.okWithCustom({ passthrough: true }))
-          .then(N => this.app.client.getText(Selectors.OUTPUT_N_STREAMING(N)))
-          .then(txt => assert.ok(txt.length > 0))
-      } else {
-        await Promise.resolve(res).then(ReplExpect.justOK)
+        await waitForLogText('hi')
       }
     }
 

--- a/plugins/plugin-kubectl/logs/src/test/logs/logs.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/logs.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert'
 import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
-import { createNS, allocateNS, deleteNS } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
+import { waitForTerminalText, createNS, allocateNS, deleteNS } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
 
 import { readFileSync } from 'fs'
 import { dirname, join } from 'path'
@@ -77,15 +76,13 @@ wdescribe(`kubectl logs getty via watch pane ${process.env.MOCHA_RUN_TARGET || '
     })
   }
 
+  const waitForLogText = waitForTerminalText.bind(this)
+
   const showLogs = (podName: string, containerName: string, label: string, hasLogs: boolean) => {
     const checkLogs = async (res: ReplExpect.AppAndCount) => {
+      await Promise.resolve(res).then(ReplExpect.justOK)
       if (hasLogs) {
-        await Promise.resolve(res)
-          .then(ReplExpect.okWithCustom({ passthrough: true }))
-          .then(N => this.app.client.getText(Selectors.OUTPUT_N_STREAMING(N)))
-          .then(txt => assert.ok(txt.length > 0))
-      } else {
-        await Promise.resolve(res).then(ReplExpect.justOK)
+        await waitForLogText('hi')
       }
     }
 

--- a/plugins/plugin-kubectl/src/controller/kubectl/flags.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/flags.ts
@@ -24,8 +24,18 @@ const defaultBooleans = [
   'all-namespaces',
   'ignore-not-found',
   'no-headers',
+
+  'i',
+  'it',
+  'ti',
+  'stdin',
+
+  't',
+  'tty',
+
   'R',
   'recursive',
+
   'server-print',
   'show-kind',
   'show-labels'

--- a/plugins/plugin-kubectl/src/index.ts
+++ b/plugins/plugin-kubectl/src/index.ts
@@ -32,6 +32,7 @@ export {
   isDeployment,
   KubeItems,
   isKubeItems,
+  isKubeItemsOfKind,
   KubeContext,
   Job,
   isJob,
@@ -67,6 +68,7 @@ export {
   getLabel,
   getLabelForArgv,
   isHelpRequest,
+  getContainer,
   getNamespace,
   getNamespaceForArgv,
   isForAllNamespaces
@@ -95,3 +97,5 @@ export { doRun } from './controller/kubectl/run'
 export { doCreate } from './controller/kubectl/create'
 export { doDelete } from './controller/kubectl/delete'
 export { describer } from './controller/kubectl/describe'
+
+export { viewTransformer as getTransformer } from './controller/kubectl/get'

--- a/plugins/plugin-kubectl/src/lib/model/resource.ts
+++ b/plugins/plugin-kubectl/src/lib/model/resource.ts
@@ -151,6 +151,7 @@ export function isNamespaced(resource: KubeResource) {
 export function isKubeResource(entity: KResponse | ResourceWithMetadata): entity is KubeResource {
   const kube = entity as KubeResource
   return (
+    kube !== undefined &&
     kube.isKubeResource === true &&
     kube.apiVersion !== undefined &&
     kube.apiVersion !== kubeuiApiVersion &&
@@ -418,6 +419,13 @@ export interface KubeItems<Item extends KubeResource = KubeResource> extends Kub
 
 export function isKubeItems(resource: KubeResource): resource is KubeItems {
   return isKubeResource(resource) && resource.apiVersion === 'v1' && resource.kind === 'List'
+}
+
+export function isKubeItemsOfKind<Item extends KubeResource = KubeResource>(
+  resource: KubeResource,
+  isOfKind: (item: KubeResource) => item is Item
+): resource is KubeItems<Item> {
+  return isKubeItems(resource) && resource.items.length > 0 && isOfKind(resource.items[0])
 }
 
 /** Scope */

--- a/plugins/plugin-kubectl/src/lib/view/modes/ContainerCommon.tsx
+++ b/plugins/plugin-kubectl/src/lib/view/modes/ContainerCommon.tsx
@@ -16,10 +16,19 @@
 
 import * as React from 'react'
 import { DropDown, Icons } from '@kui-shell/plugin-client-common'
-import { Abortable, Arguments, Button, FlowControllable, Tab, ToolbarProps, ToolbarText, i18n } from '@kui-shell/core'
+import {
+  Abortable,
+  Arguments,
+  Button,
+  FlowControllable,
+  ParsedOptions,
+  Tab,
+  ToolbarProps,
+  ToolbarText,
+  i18n
+} from '@kui-shell/core'
 
 import { Pod } from '../../model/resource'
-import { KubeOptions } from '../../../controller/kubectl/options'
 
 const strings = i18n('plugin-kubectl')
 
@@ -35,7 +44,11 @@ export type Job = Abortable & FlowControllable
 export type StreamingStatus = 'Live' | 'Paused' | 'Stopped' | 'Error' | 'Idle'
 
 export interface ContainerProps {
-  args: Arguments<KubeOptions>
+  args: {
+    argsForMode?: Arguments
+    argvNoOptions: string[]
+    parsedOptions: ParsedOptions
+  }
   tab: Tab
   pod: Pod
   toolbarController: ToolbarProps

--- a/plugins/plugin-kubectl/src/lib/view/modes/last-applied.ts
+++ b/plugins/plugin-kubectl/src/lib/view/modes/last-applied.ts
@@ -34,7 +34,7 @@ function getLastAppliedRaw(resource: KubeResource): string {
  *
  */
 function hasLastApplied(resource: KubeResource): boolean {
-  return getLastAppliedRaw(resource) !== undefined
+  return !resource.isSimulacrum && getLastAppliedRaw(resource) !== undefined
 }
 
 /**

--- a/plugins/plugin-kubectl/src/test/k8s2/kubectl-exec-via-table.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/kubectl-exec-via-table.ts
@@ -45,13 +45,13 @@ wdescribe(`kubectl exec basic stuff via table ${process.env.MOCHA_RUN_TARGET || 
 
   it('should exec ls through pty', () => {
     return CLI.command(`kubectl exec ${podName} -n ${ns} -- ls`, this.app)
-      .then(ReplExpect.okWithPtyOutput('bin'))
+      .then(ReplExpect.okWithString('bin'))
       .catch(Common.oops(this, true))
   })
 
   it('should exec pwd through pty', () => {
     return CLI.command(`kubectl exec ${podName} -n ${ns} -- pwd`, this.app)
-      .then(ReplExpect.okWithPtyOutput('/'))
+      .then(ReplExpect.okWithString('/'))
       .catch(Common.oops(this, true))
   })
 

--- a/plugins/plugin-kubectl/src/test/k8s2/kubectl-exec.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/kubectl-exec.ts
@@ -49,13 +49,13 @@ wdescribe(`kubectl exec basic stuff via watch pane ${process.env.MOCHA_RUN_TARGE
 
   it('should exec ls through pty', () => {
     return CLI.command(`kubectl exec ${podName} -n ${ns} -- ls`, this.app)
-      .then(ReplExpect.okWithPtyOutput('bin'))
+      .then(ReplExpect.okWithString('bin'))
       .catch(Common.oops(this, true))
   })
 
   it('should exec pwd through pty', () => {
     return CLI.command(`kubectl exec ${podName} -n ${ns} -- pwd`, this.app)
-      .then(ReplExpect.okWithPtyOutput('/'))
+      .then(ReplExpect.okWithString('/'))
       .catch(Common.oops(this, true))
   })
 

--- a/plugins/plugin-kubectl/src/test/k8s2/terminal-tab.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/terminal-tab.ts
@@ -36,8 +36,6 @@ const ECHO_TEXT = `hello ${uuid()}`
 const ECHO_FILE_1 = '/tmp/kui-terminal-tab-test-1'
 const ECHO_FILE_2 = '/tmp/kui-terminal-tab-test-2'
 
-declare let __KUI_RUNNING_KUI_TEST: boolean
-
 describe(`${command} Terminal tab ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
   before(Common.before(this))
   after(Common.after(this))
@@ -144,14 +142,8 @@ describe(`${command} Terminal tab ${process.env.MOCHA_RUN_TARGET || ''}`, functi
     })
   }
 
-  /* Here comes the tests */
-  it('should inject RUNNING_KUI_TEST', () => {
-    return this.app.client
-      .execute(() => {
-        __KUI_RUNNING_KUI_TEST = true
-      })
-      .catch(Common.oops(this, true))
-  })
+  // needed to force the dom renderer for webpack/browser-based tests; see ExecIntoPod
+  Common.setDebugMode.bind(this)()
 
   it(`should create sample pod from URL via ${command}`, () => {
     return CLI.command(


### PR DESCRIPTION
this adds plumbing to allow a command respond to pass through an argv

Fixes #4762

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
