### PR TITLE
fix: the Logs/Terminal retry button should be visible on any exit code

### DIFF
--- a/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-c.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/logs-dash-c.ts
@@ -20,9 +20,9 @@ import {
   allocateNS,
   deleteNS,
   waitForGreen,
-  waitForRed,
   waitForTerminalText,
-  defaultModeForGet
+  defaultModeForGet,
+  deletePodByName
 } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
 
 import { readFileSync } from 'fs'
@@ -243,12 +243,7 @@ wdescribe(`kubectl Logs tab ${process.env.MOCHA_RUN_TARGET || ''}`, function(thi
     type: 'info'
   })
 
-  it(`should delete the pod ${podName} by name via kubectl`, () => {
-    return CLI.command(`kubectl delete pod ${podName} -n ${ns}`, this.app)
-      .then(ReplExpect.okWithCustom({ selector: Selectors.BY_NAME(podName) }))
-      .then(selector => waitForRed(this.app, selector))
-      .catch(Common.oops(this, true))
-  })
+  deletePodByName(this, podName, ns)
 
   it('should see log streaming stopped', async () => {
     try {
@@ -260,6 +255,12 @@ wdescribe(`kubectl Logs tab ${process.env.MOCHA_RUN_TARGET || ''}`, function(thi
   })
 
   const showError = 'Log streaming stopped abnormally.'
+
+  doRetry(['not found'], {
+    text: showError,
+    type: 'error'
+  })
+
   switchContainer(containerName1, ['not found'], [], {
     text: showError,
     type: 'error'

--- a/plugins/plugin-kubectl/logs/src/test/logs/logs-via-table.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/logs-via-table.ts
@@ -105,6 +105,21 @@ wdescribe(`kubectl logs getty via table ${process.env.MOCHA_RUN_TARGET || ''}`, 
     }
   }
 
+  const doRetry = (hasLogs: boolean) => {
+    it('should click retry button', async () => {
+      try {
+        await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON('retry-streaming'))
+        await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON('retry-streaming'))
+
+        if (hasLogs) {
+          await waitForLogText('hi')
+        }
+      } catch (err) {
+        return Common.oops(this, true)(err)
+      }
+    })
+  }
+
   allocateNS(this, ns)
   inputs.forEach(_ => {
     if (_.expectString) {
@@ -114,6 +129,7 @@ wdescribe(`kubectl logs getty via table ${process.env.MOCHA_RUN_TARGET || ''}`, 
     }
     waitForPod(_.podName)
     showLogs(_.podName, _.containerName, _.label, _.hasLogs)
+    doRetry(_.hasLogs)
   })
   inputs.forEach(_ => {
     showLogs(_.podName, _.containerName, _.label, _.hasLogs)

--- a/plugins/plugin-kubectl/src/lib/view/modes/ContainerCommon.tsx
+++ b/plugins/plugin-kubectl/src/lib/view/modes/ContainerCommon.tsx
@@ -77,7 +77,7 @@ export abstract class ContainerComponent<State extends ContainerState> extends R
   protected abstract toolbarText(status: StreamingStatus): ToolbarText
 
   protected toolbarButtonsForError(status: StreamingStatus): Button[] {
-    if (status === 'Error') {
+    if (status === 'Stopped' || status === 'Error') {
       return [
         {
           mode: 'retry-streaming',

--- a/plugins/plugin-kubectl/src/test/k8s2/terminal-tab.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/terminal-tab.ts
@@ -21,6 +21,7 @@ import {
   createNS,
   allocateNS,
   deleteNS,
+  deletePodByName,
   waitForGreen,
   getTerminalText,
   waitForTerminalText,
@@ -103,6 +104,18 @@ describe(`${command} Terminal tab ${process.env.MOCHA_RUN_TARGET || ''}`, functi
     })
   }
 
+  const doRetry = (toolbar: { type: string; text: string; exact: boolean }) => {
+    it('should click retry button', async () => {
+      try {
+        await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON('retry-streaming'))
+        await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON('retry-streaming'))
+        await SidecarExpect.toolbarText(toolbar)(this.app)
+      } catch (err) {
+        return Common.oops(this, true)(err)
+      }
+    })
+  }
+
   /** switch to terminal tab, exit with 1, see error in toolbar and click retry button */
   const exitTerminalTabAndRetry = () => {
     it('should show terminal tab and exit with error', async () => {
@@ -127,18 +140,10 @@ describe(`${command} Terminal tab ${process.env.MOCHA_RUN_TARGET || ''}`, functi
       }
     })
 
-    it('should click retry button', async () => {
-      try {
-        await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON('retry-streaming'))
-        await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON('retry-streaming'))
-        await SidecarExpect.toolbarText({
-          type: 'info',
-          text: `Connected to container ${containerName}`,
-          exact: false
-        })(this.app)
-      } catch (err) {
-        return Common.oops(this, true)(err)
-      }
+    doRetry({
+      type: 'info',
+      text: `Connected to container ${containerName}`,
+      exact: false
     })
   }
 
@@ -211,6 +216,10 @@ describe(`${command} Terminal tab ${process.env.MOCHA_RUN_TARGET || ''}`, functi
       await Common.oops(this, true)(err)
     }
   })
+
+  deletePodByName(this, podName, ns)
+
+  doRetry({ type: 'error', text: 'has closed', exact: false })
 
   deleteNS(this, ns)
 })

--- a/plugins/plugin-kubectl/tests/lib/k8s/utils.d.ts
+++ b/plugins/plugin-kubectl/tests/lib/k8s/utils.d.ts
@@ -57,6 +57,13 @@ declare function allocateNS (ctx: Common.ISuite, ns: string, command?: string, t
 declare function deleteNS (ctx: Common.ISuite, ns: string, command?: string, theCli?: headless): void
 
 /**
+ * Install a mocha test to delete the given pod by name `pod`
+ *
+ */
+declare function deletePodByName (ctx: Common.ISuite, pod: string, ns: string, command?: string, theCli?: headless): void
+
+
+/**
  * Keep poking the given kind till no more such entities exist
  *
  */

--- a/plugins/plugin-kubectl/tests/lib/k8s/utils.js
+++ b/plugins/plugin-kubectl/tests/lib/k8s/utils.js
@@ -113,6 +113,16 @@ exports.deleteNS = (ctx, ns, command = 'kubectl', theCli = CLI) => {
   }
 }
 
+exports.deletePodByName = (ctx, pod, ns, command = 'kubectl', theCli = CLI) => {
+  it(`should delete the pod ${pod} by name via ${command}`, () => {
+    return theCli
+      .command(`kubectl delete pod ${pod} -n ${ns}`, ctx.app)
+      .then(ReplExpect.okWithCustom({ selector: Selectors.BY_NAME(pod) }))
+      .then(selector => exports.waitForRed(ctx.app, selector))
+      .catch(Common.oops(ctx, true))
+  })
+}
+
 /**
  * Keep poking the given kind till no more such entities exist
  *


### PR DESCRIPTION
Fixes #4769

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
