### PR TITLE
fix: sidecar toolbar can't due justice to longer error messages

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -174,7 +174,7 @@ export {
   isFunctionContent,
   FunctionThatProducesContent
 } from './models/mmr/content-types'
-export { ToolbarText } from './webapp/views/toolbar-text'
+export { ToolbarText, ToolbarAlert } from './webapp/views/toolbar-text'
 
 // low-level UI
 export { default as doCancel } from './webapp/cancel'

--- a/packages/core/src/models/mmr/content-types.ts
+++ b/packages/core/src/models/mmr/content-types.ts
@@ -21,7 +21,7 @@ import { Table, isTable } from '../../webapp/models/table'
 import { Entity, MetadataBearing } from '../entity'
 import { isHTML } from '../../util/types'
 import { ModeOrButton, Button } from './types'
-import { ToolbarText } from '../../webapp/views/toolbar-text'
+import { ToolbarText, ToolbarAlert } from '../../webapp/views/toolbar-text'
 
 /**
  * A `ScalarResource` is Any kind of resource that is directly
@@ -35,7 +35,12 @@ export interface ScalarContent<T = ScalarResource> {
 }
 
 export type ToolbarProps = {
-  willUpdateToolbar?: (toolbarText: ToolbarText, extraButtons?: Button[], extraButtonsOverride?: boolean) => void
+  willUpdateToolbar?: (
+    toolbarText: ToolbarText,
+    extraButtons?: Button[],
+    extraButtonsOverride?: boolean,
+    alerts?: ToolbarAlert[]
+  ) => void
 }
 export type ReactProvider = { react: (props: ToolbarProps) => ReactElement<any> }
 export function isReactProvider(entity: ScalarLike<MetadataBearing>): entity is ReactProvider {

--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -49,6 +49,10 @@ export const SIDECAR_TOOLBAR_TEXT = (type: string) =>
 export const SIDECAR_TOOLBAR_BUTTON = (mode: string) =>
   `${SIDECAR_TOOLBAR} .sidecar-bottom-stripe-mode-bits .sidecar-bottom-stripe-button[data-mode="${mode}"] [role="tab"]`
 
+// sidecar alert
+export const SIDECAR_ALERT = (type: string) =>
+  `${SIDECAR} .bx--tab-content[aria-hidden="false"] .kui--toolbar-alert[data-type="${type}"]`
+
 // sidecar tab content, for visible tab
 export const SIDECAR_TAB_CONTENT = `${SIDECAR} .bx--tab-content[aria-hidden="false"] .custom-content`
 export const SIDECAR_CUSTOM_CONTENT = `${SIDECAR_TAB_CONTENT} .code-highlighting`

--- a/packages/test/src/api/sidecar-expect.ts
+++ b/packages/test/src/api/sidecar-expect.ts
@@ -138,6 +138,11 @@ export const toolbarText = (expect: { type: string; text: string; exact?: boolea
   return app
 }
 
+export const toolbarAlert = (expect: { type: string; text: string; exact?: boolean }) => async (app: Application) => {
+  await expectText(app, expect.text, expect.exact)(Selectors.SIDECAR_ALERT(expect.type))
+  return app
+}
+
 const show = (expected: string, selector: string) => async (app: Application) => {
   await app.client.waitUntil(async () => {
     return app.client

--- a/plugins/plugin-client-common/i18n/editor_en_US.json
+++ b/plugins/plugin-client-common/i18n/editor_en_US.json
@@ -9,6 +9,7 @@
   "errorSaving": "Error saving file",
   "errorSavingWithMessage": "Error saving file: **{0}**",
   "errorReverting": "Error reverting file",
+  "errorApplying": "Error applying changes",
   "Unable to validate your edits": "Unable to validate your edits",
   "isNew": "You are in edit mode, viewing **undeployed code**",
   "isNewReadOnly": "You are in readonly mode, viewing **undeployed code**",

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/ToolbarContainer.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/ToolbarContainer.tsx
@@ -15,8 +15,9 @@
  */
 
 import * as React from 'react'
-import { ToolbarText, Button } from '@kui-shell/core'
+import { ToolbarText, ToolbarAlert, Button } from '@kui-shell/core'
 
+import Alert from '../../spi/Alert'
 import Toolbar, { Props as ToolbarProps } from './Toolbar'
 export { Props as ToolbarContainerProps }
 
@@ -26,6 +27,7 @@ interface State {
   toolbarText: ToolbarText
   extraButtons?: Button[]
   extraButtonsOverride?: boolean
+  alerts?: ToolbarAlert[]
 }
 
 export default class ToolbarContainer extends React.PureComponent<Props, State> {
@@ -38,8 +40,13 @@ export default class ToolbarContainer extends React.PureComponent<Props, State> 
   }
 
   /** Called by children if they desire an update to the Toolbar */
-  private onToolbarUpdate(toolbarText: ToolbarText, extraButtons?: Button[], extraButtonsOverride?: boolean) {
-    this.setState({ toolbarText, extraButtons, extraButtonsOverride })
+  private onToolbarUpdate(
+    toolbarText: ToolbarText,
+    extraButtons?: Button[],
+    extraButtonsOverride?: boolean,
+    alerts?: ToolbarAlert[]
+  ) {
+    this.setState({ toolbarText, extraButtons, extraButtonsOverride, alerts })
   }
 
   /** Graft on the toolbar event management */
@@ -70,6 +77,7 @@ export default class ToolbarContainer extends React.PureComponent<Props, State> 
             buttons={toolbarButtons}
           />
         )}
+        {this.state.alerts && this.state.alerts.map((alert, id) => <Alert key={id} alert={alert} />)}
         <React.Suspense fallback={<div />}>{this.children()}</React.Suspense>
       </div>
     )

--- a/plugins/plugin-client-common/src/components/spi/Alert/impl/Carbon.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Alert/impl/Carbon.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react'
+import { i18n } from '@kui-shell/core'
+import { ToastNotification } from 'carbon-components-react'
+import { Props } from '..'
+
+const strings = i18n('plugin-client-common', 'editor')
+
+export default class Alert extends React.PureComponent<Props> {
+  public render() {
+    return (
+      <ToastNotification
+        className="kui--toolbar-alert"
+        data-type={this.props.alert.type}
+        caption=""
+        hideCloseButton={false}
+        iconDescription={strings('closeAlert')}
+        kind={this.props.alert.type}
+        role="alert"
+        statusIconDescription={strings(`${this.props.alert.type} alert`)}
+        subtitle={this.props.alert.body || ''}
+        timeout={0}
+        title={this.props.alert.title}
+      />
+    )
+  }
+}

--- a/plugins/plugin-client-common/src/components/spi/Alert/index.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Alert/index.tsx
@@ -14,22 +14,13 @@
  * limitations under the License.
  */
 
-/**
- * Text to be displayed in the sidecar toolbar
- *
- */
+import * as React from 'react'
 
-type ToolbarTextType = 'info' | 'success' | 'warning' | 'error'
+import Carbon from './impl/Carbon'
 
-type ToolbarTextValue = string | Element
+import Props from './model'
+export { Props }
 
-export interface ToolbarText {
-  type: ToolbarTextType
-  text: ToolbarTextValue
-}
-
-export interface ToolbarAlert {
-  type: ToolbarTextType
-  title: string
-  body?: string
+export default function AlertSpi(props: Props): React.ReactElement {
+  return <Carbon {...props} />
 }

--- a/plugins/plugin-client-common/src/components/spi/Alert/model.ts
+++ b/plugins/plugin-client-common/src/components/spi/Alert/model.ts
@@ -13,23 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ToolbarAlert } from '@kui-shell/core'
 
-/**
- * Text to be displayed in the sidecar toolbar
- *
- */
-
-type ToolbarTextType = 'info' | 'success' | 'warning' | 'error'
-
-type ToolbarTextValue = string | Element
-
-export interface ToolbarText {
-  type: ToolbarTextType
-  text: ToolbarTextValue
+interface Props {
+  alert: ToolbarAlert
 }
 
-export interface ToolbarAlert {
-  type: ToolbarTextType
-  title: string
-  body?: string
-}
+export default Props

--- a/plugins/plugin-client-common/web/scss/components/Table/Toolbar.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/Toolbar.scss
@@ -25,6 +25,17 @@ $toolbar-height: 1.875em;
   }
 }
 
+body[kui-theme-style] .kui--toolbar-alert.bx--toast-notification {
+  position: unset;
+  width: inherit;
+  margin-right: 0.5rem;
+  margin-left: 0.5rem;
+
+  &.bx--toast-notification__subtitle > p {
+    font-size: 14px;
+  }
+}
+
 body[kui-theme-style] .kui--data-table-toolbar {
   display: flex;
 

--- a/plugins/plugin-kubectl/src/test/k8s1/edit.ts
+++ b/plugins/plugin-kubectl/src/test/k8s1/edit.ts
@@ -90,7 +90,7 @@ commands.forEach(command => {
           await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON('Save'))
 
           // an error state and the garbage text had better appear in the toolbar text
-          await SidecarExpect.toolbarText({ type: 'error', text: expectedError || garbage, exact: false })(this.app)
+          await SidecarExpect.toolbarAlert({ type: 'error', text: expectedError || garbage, exact: false })(this.app)
         } catch (err) {
           await Common.oops(this, true)(err)
         }
@@ -121,7 +121,7 @@ commands.forEach(command => {
           await this.app.client.keys(`${Keys.End}${Keys.ENTER}${key}: ${value}${Keys.ENTER}`)
           await new Promise(resolve => setTimeout(resolve, 2000))
           await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON('Save'))
-          await SidecarExpect.toolbarText({ type: 'success', text: 'Successfully Applied', exact: true })(this.app)
+          await SidecarExpect.toolbarAlert({ type: 'success', text: 'Successfully Applied', exact: false })(this.app)
           await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON('Save'), 10000, true)
         } catch (err) {
           await Common.oops(this, true)(err)


### PR DESCRIPTION
Fixes #4789 

![Screen Shot 2020-06-02 at 11 29 08 AM](https://user-images.githubusercontent.com/21212160/83539014-87604500-a4c4-11ea-9425-1b9c13613865.png)
![Screen Shot 2020-06-02 at 11 30 20 AM](https://user-images.githubusercontent.com/21212160/83539018-87f8db80-a4c4-11ea-9c51-17b487aca044.png)



<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
