### PR TITLE
fix: avoid using kui-custom command for switching kubectl namespace

### DIFF
--- a/plugins/plugin-kubectl/src/test/k8s1/namespace.ts
+++ b/plugins/plugin-kubectl/src/test/k8s1/namespace.ts
@@ -62,7 +62,7 @@ describe(`kubectl namespace ${process.env.MOCHA_RUN_TARGET || ''}`, function(thi
     /** switch to default context via command */
     const switchToDefault = () => {
       it('should switch back to default via command', () => {
-        return CLI.command(`namespace switch default`, this.app)
+        return CLI.command(`kubectl config set-context --current --namespace=default`, this.app)
           .then(ReplExpect.okWithAny)
           .catch(Common.oops(this, true))
       })


### PR DESCRIPTION
Fixes #4806

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
