### PR TITLE
fix(plugins/plugin-client-common): sidecar does not resopnd to Escape…

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/TabContent.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContent.tsx
@@ -341,6 +341,7 @@ export default class TabContent extends React.PureComponent<Props, State> {
       return React.cloneElement(node, {
         key,
         uuid: this.props.uuid,
+        active: this.props.active,
         width: this.state.sidecarWidth,
         willChangeSize: this.onWillChangeSize.bind(this),
         willLoseFocus: this.onWillLoseFocus.bind(this)

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/BaseSidecar.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/BaseSidecar.tsx
@@ -52,6 +52,7 @@ export interface SidecarOptions {
 export type Props = SidecarOptions & {
   uuid?: string
   tab?: KuiTab
+  active?: boolean
 }
 
 export interface SidecarHistoryEntry extends BaseHistoryEntry {
@@ -88,13 +89,11 @@ export abstract class BaseSidecar<
     super(props)
 
     // Interpret Escape key as a toggle of the view's width
-    if (!this.isFixedWidth()) {
-      const onEscape = this.onEscape.bind(this)
-      document.addEventListener('keydown', onEscape)
-      this.cleaners.push(() => document.removeEventListener('keydown', onEscape))
-      // ^^^ Note! keydown versus keyup is important (for now at
-      // least; @starpit 20200408); see https://github.com/IBM/kui/issues/4215
-    }
+    const onEscape = this.onEscape.bind(this)
+    document.addEventListener('keydown', onEscape)
+    this.cleaners.push(() => document.removeEventListener('keydown', onEscape))
+    // ^^^ Note! keydown versus keyup is important (for now at
+    // least; @starpit 20200408); see https://github.com/IBM/kui/issues/4215
   }
 
   public componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
@@ -189,7 +188,13 @@ export abstract class BaseSidecar<
 
   /** Escape key toggles sidecar visibility */
   private onEscape(evt: KeyboardEvent) {
-    if (evt.key === 'Escape' && !document.getElementById('confirm-dialog') && !isPopup() && this.current) {
+    if (
+      evt.key === 'Escape' &&
+      this.props.active &&
+      !document.getElementById('confirm-dialog') &&
+      !isPopup() &&
+      this.current
+    ) {
       if (this.props.willChangeSize) {
         this.props.willChangeSize(this.props.width === Width.Closed ? this.defaultWidth() : Width.Closed)
       }


### PR DESCRIPTION
… reliably

1) escape does not close LeftNavSidecar reliably; this is due to an incorrect guard of isFixedWidth() around the onEscape registration
Fixes #4774

2) escape closes sidecars in all tabs; we need to pay attention to whether the sidecar is part of the active KuiTab
Fixes #4804

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
