### PR TITLE
fix: summary tab is not read-only for kubectl edit command

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -146,6 +146,7 @@ export {
   Mode as MultiModalMode,
   MultiModalResponse
 } from './models/mmr/types'
+export { Editable, EditableSpec } from './models/editable'
 export {
   Breadcrumb,
   NavResponse,

--- a/packages/core/src/models/editable.ts
+++ b/packages/core/src/models/editable.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ToolbarText } from '../webapp/views/toolbar-text'
+
+export type Editable = { spec: EditableSpec }
+
+export interface EditableSpec {
+  readOnly: boolean
+  clearable: boolean
+  save: {
+    label: string
+    onSave(data: string): Save | Promise<Save>
+  }
+  revert: {
+    label?: string
+    onRevert(): string | Promise<string>
+  }
+}
+
+type Save = void | { noToolbarUpdate?: boolean; toolbarText?: ToolbarText }

--- a/packages/core/src/models/mmr/content-types.ts
+++ b/packages/core/src/models/mmr/content-types.ts
@@ -22,6 +22,7 @@ import { Entity, MetadataBearing } from '../entity'
 import { isHTML } from '../../util/types'
 import { ModeOrButton, Button } from './types'
 import { ToolbarText } from '../../webapp/views/toolbar-text'
+import { Editable } from '../editable'
 
 /**
  * A `ScalarResource` is Any kind of resource that is directly
@@ -90,7 +91,8 @@ interface WithOptionalContentType<ContentType = SupportedStringContent> {
  *
  */
 export type StringContent<ContentType = SupportedStringContent> = ScalarContent<string> &
-  WithOptionalContentType<ContentType>
+  WithOptionalContentType<ContentType> &
+  Partial<Editable>
 
 export function isStringWithOptionalContentType<T extends MetadataBearing>(
   entity: Entity | Content<T> | MetadataBearing | ModeOrButton<T>

--- a/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
@@ -32,26 +32,11 @@ import '../../../../web/scss/components/Editor/Editor.scss'
 
 const strings = i18n('plugin-client-common', 'editor')
 
-interface WithOptions {
-  spec: {
-    readOnly?: boolean
-    clearable?: boolean
-    save?: {
-      label: string
-      onSave: (data: string) => Promise<void | { noToolbarUpdate?: boolean; toolbarText: ToolbarText }>
-    }
-    revert?: {
-      label: string
-      onRevert: () => Promise<string>
-    }
-  }
-}
-
 type Props = MonacoOptions &
   ToolbarProps & {
     repl: REPL
     content: StringContent
-    response: File | (MultiModalResponse & Partial<WithOptions>)
+    response: File | MultiModalResponse
   }
 
 interface State {
@@ -138,7 +123,7 @@ export default class Editor extends React.PureComponent<Props, State> {
   private static isClearable(props: Props) {
     return (
       (isFile(props.response) && !props.readOnly) ||
-      (!isFile(props.response) && props.response.spec && props.response.spec.clearable !== false)
+      (!isFile(props.response) && props.content.spec && props.content.spec.clearable !== false)
     )
   }
 
@@ -158,11 +143,11 @@ export default class Editor extends React.PureComponent<Props, State> {
           }
         })
         buttons.push(save)
-      } else if (props.response.spec && props.response.spec.save) {
-        const { onSave } = props.response.spec.save
+      } else if (props.content.spec && props.content.spec.save) {
+        const { onSave } = props.content.spec.save
         buttons.push({
           mode: 'Save',
-          label: props.response.spec.save.label || strings('saveLocalFile'),
+          label: props.content.spec.save.label || strings('saveLocalFile'),
           kind: 'view' as const,
           command: async () => {
             try {
@@ -203,11 +188,11 @@ export default class Editor extends React.PureComponent<Props, State> {
           }
         })
         buttons.push(revert)
-      } else if (props.response.spec && props.response.spec.revert) {
-        const { onRevert } = props.response.spec.revert
+      } else if (props.content.spec && props.content.spec.revert) {
+        const { onRevert } = props.content.spec.revert
         buttons.push({
           mode: 'Revert',
-          label: props.response.spec.revert.label || strings('revert'),
+          label: props.content.spec.revert.label || strings('revert'),
           kind: 'view' as const,
           command: async () => {
             try {
@@ -259,7 +244,7 @@ export default class Editor extends React.PureComponent<Props, State> {
         value: props.content.content,
         readOnly:
           !isFile(props.response) &&
-          (!props.response.spec || props.response.spec.readOnly !== false) &&
+          (!props.content.spec || props.content.spec.readOnly !== false) &&
           (props.readOnly || !isFile(props.response) || false),
         language:
           props.content.contentType === 'text/plain'

--- a/plugins/plugin-client-common/src/components/Content/Eval.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Eval.tsx
@@ -26,6 +26,7 @@ import {
   isReactProvider,
   isScalarContent,
   ScalarContent,
+  EditableSpec,
   isStringWithOptionalContentType
 } from '@kui-shell/core'
 
@@ -45,6 +46,7 @@ interface EvalState {
   react: ReactProvider
   content: ScalarResource
   contentType: SupportedStringContent
+  spec?: EditableSpec
 }
 
 /**
@@ -69,6 +71,7 @@ export default class Eval extends React.PureComponent<EvalProps, EvalState> {
       isLoading: true,
       command: props.command,
       react: undefined,
+      spec: undefined,
       content: undefined,
       contentType: props.contentType
     }
@@ -98,7 +101,12 @@ export default class Eval extends React.PureComponent<EvalProps, EvalState> {
           if (isReactProvider(content)) {
             this.setState({ isLoading: false, react: content })
           } else if (isStringWithOptionalContentType(content)) {
-            this.setState({ isLoading: false, content: content.content, contentType: content.contentType })
+            this.setState({
+              isLoading: false,
+              content: content.content,
+              contentType: content.contentType,
+              spec: content.spec
+            })
           } else if (isScalarContent(content)) {
             done(content.content)
           } else {
@@ -116,6 +124,7 @@ export default class Eval extends React.PureComponent<EvalProps, EvalState> {
     const mode = this.state.react
       ? this.state.react
       : {
+          spec: this.state.spec,
           content: this.state.content,
           contentType: this.state.contentType
         }


### PR DESCRIPTION
Fixes #4809

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
