### PR TITLE
fix(plugins/plugin-client-common): top tab buttons should be owned by…

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react'
 import { inElectron, Tab, eventBus } from '@kui-shell/core'
 
-import TabModel from './TabModel'
+import TabModel, { TopTabButton } from './TabModel'
 import TabContent, { TabContentOptions } from './TabContent'
 import TopTabStripe, { TopTabStripeConfiguration } from './TopTabStripe'
 
@@ -202,6 +202,20 @@ export default class TabContainer extends React.PureComponent<Props, State> {
     }
   }
 
+  private willUpdateTopTabButtons(uuid: string, buttons: TopTabButton[]) {
+    this.setState(curState => {
+      const idx = curState.tabs.findIndex(_ => _.uuid === uuid)
+      if (idx >= 0) {
+        return {
+          tabs: curState.tabs
+            .slice(0, idx)
+            .concat([curState.tabs[idx].update(buttons)])
+            .concat(curState.tabs.slice(idx + 1))
+        }
+      }
+    })
+  }
+
   public render() {
     return (
       <div className="kui--full-height">
@@ -216,7 +230,14 @@ export default class TabContainer extends React.PureComponent<Props, State> {
         {this.search()}
         <div className="tab-container">
           {this.state.tabs.map((_, idx) => (
-            <TabContent key={idx} uuid={_.uuid} active={idx === this.state.activeIdx} state={_.state} {...this.props}>
+            <TabContent
+              key={idx}
+              uuid={_.uuid}
+              active={idx === this.state.activeIdx}
+              willUpdateTopTabButtons={this.willUpdateTopTabButtons.bind(this, _.uuid)}
+              state={_.state}
+              {...this.props}
+            >
               {this.children(_.uuid)}
             </TabContent>
           ))}

--- a/plugins/plugin-client-common/src/components/Client/TabModel.ts
+++ b/plugins/plugin-client-common/src/components/Client/TabModel.ts
@@ -22,13 +22,16 @@ export function uuid() {
   return (_uuidCounter++).toString()
 }
 
-export default class TabModel {
-  private readonly _uuid: string
-  private readonly _state: TabState
+export interface TopTabButton<P extends { key: string } = { key: string }> {
+  icon: React.ReactElement<P>
+}
 
-  public constructor() {
-    this._uuid = uuid()
-    this._state = new TabState(this._uuid)
+export default class TabModel {
+  public constructor(
+    private readonly _uuid = uuid(),
+    private readonly _state = new TabState(_uuid),
+    private readonly _buttons: TopTabButton[] = []
+  ) {
     this._state.capture()
   }
 
@@ -38,5 +41,13 @@ export default class TabModel {
 
   public get state() {
     return this._state
+  }
+
+  public get buttons() {
+    return this._buttons
+  }
+
+  public update(buttons: TopTabButton[]) {
+    return new TabModel(this.uuid, this.state, buttons)
   }
 }

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/index.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/index.tsx
@@ -163,6 +163,22 @@ export default class TopTabStripe extends React.PureComponent<Props> {
     )
   }
 
+  /** Buttons that appear in the top right */
+  private buttons() {
+    if (this.props.tabs[this.props.activeIdx]) {
+      const { buttons } = this.props.tabs[this.props.activeIdx]
+      return (
+        <div
+          id="kui--custom-top-tab-stripe-button-container"
+          num-button={buttons.length} // helps with css to calculate the right position of the container
+          className="kui--hide-in-narrower-windows" // re: kui--hide-in-narrower-windows, see https://github.com/IBM/kui/issues/4459
+        >
+          {buttons.map(_ => _.icon)}
+        </div>
+      )
+    }
+  }
+
   /**
    * React render handler
    *
@@ -173,6 +189,7 @@ export default class TopTabStripe extends React.PureComponent<Props> {
         {/* this.headerMenu(args) */}
         {this.headerName()}
         {this.tabs()}
+        {this.buttons()}
         {/* this.sidenav(args) */}
       </Header>
     )

--- a/plugins/plugin-client-common/web/css/static/TopTabStripe.scss
+++ b/plugins/plugin-client-common/web/css/static/TopTabStripe.scss
@@ -218,8 +218,7 @@
 #kui--custom-top-tab-stripe-button-container {
   display: flex;
   justify-content: flex-end;
-  position: absolute;
-  z-index: 10000;
+  position: relative;
 
   &[num-button='2'] {
     /* number of buttons in the container */


### PR DESCRIPTION
… the top tab stripe

they had been owned and rendered (with position: absolute) by TabContent. this was ugly. worse, any clients that had their own top stripe would find kui elements rudely interjected.

Fixes #4690

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
