### PR TITLE
fix(plugins/plugin-kubectl): watchable kubectl tables don't show the namespace in the breadcrumb

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -257,7 +257,7 @@ export const doGet = (command: string) =>
         if ((await fullKind) === 'Event' && output !== 'wide') {
           return overrideEventCommand(args, output)
         } else {
-          return doGetWatchTable(args)
+          return doGetWatchTable(args, command)
         }
       }
     }

--- a/plugins/plugin-kubectl/src/test/k8s2/aaa-watch-error-handling-via-table.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/aaa-watch-error-handling-via-table.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as assert from 'assert'
+
 import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
 import { createNS, waitForGreen, waitForRed } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
 
@@ -79,6 +81,13 @@ wdescribe(`kubectl watch error handler via table ${process.env.MOCHA_RUN_TARGET 
       // start to watch pods in a non-existent namespace
       const watchResult = await CLI.command(`k get pods -w -n ${ns}`, this.app).then(async result => {
         await ReplExpect.ok(result)
+
+        const actualTitle = await this.app.client.getText(Selectors.TABLE_TITLE(result.count))
+        assert.strictEqual(actualTitle, 'Pod')
+
+        const actualSecondaryTitle = await this.app.client.getText(Selectors.TABLE_TITLE_SECONDARY(result.count))
+        assert.strictEqual(actualSecondaryTitle, ns)
+
         return result
       })
 


### PR DESCRIPTION
Fixes #4870

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
