### PR TITLE
fix: pexecs serviced by now-removed splits fail

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -371,6 +371,18 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
   }
 
   /**
+   * @return the index of the given scrollback, in the context of the
+   * current (given) state
+   * Note: if theres's no scrollback matched the given state,
+   * e.g. the scrollback has been removed, return 0
+   *
+   */
+  private findAvailableSplit(curState: State, uuid: string): number {
+    const focusedIdx = this.findSplit(curState, uuid)
+    return focusedIdx !== -1 ? focusedIdx : 0
+  }
+
+  /**
    * Remove the given split (identified by `sbuuid`) from the state.
    *
    */
@@ -402,7 +414,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
    */
   private splice(sbuuid: string, mutator: (state: ScrollbackState) => Pick<ScrollbackState, 'blocks'>) {
     this.setState(curState => {
-      const focusedIdx = this.findSplit(curState, sbuuid)
+      const focusedIdx = this.findAvailableSplit(curState, sbuuid)
       const splits = curState.splits
         .slice(0, focusedIdx)
         .concat([Object.assign({}, curState.splits[focusedIdx], mutator(curState.splits[focusedIdx]))])

--- a/plugins/plugin-kubectl/src/test/k8s2/usage.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/usage.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as assert from 'assert'
 
-import { Common, testAbout } from '@kui-shell/test'
+import { Common, testAbout, Selectors, ReplExpect, CLI } from '@kui-shell/test'
 import { doHelp } from '../../../tests/lib/k8s/utils'
 
 const commonModes = ['Introduction']
@@ -35,6 +36,33 @@ describe('kubectl dash h', function(this: Common.ISuite) {
 
   // switch to about, should see correct navigation, breadcrumbs and content
   testAbout(this)
+
+  it(`should split the terminal via button in the current tab and expect splitCount=2`, async () => {
+    try {
+      await this.app.client.click(Selectors.NEW_SPLIT_BUTTON)
+      await ReplExpect.splitCount(2)(this.app)
+    } catch (err) {
+      await Common.oops(this, true)(err)
+    }
+  })
+
+  testAbout(this)
+
+  it('should close the split via command in the current tab and expect splitCount=1', () =>
+    CLI.command('exit', this.app)
+      .then(() => ReplExpect.splitCount(1)(this.app))
+      .catch(Common.oops(this, true)))
+
+  it('should click kubectl help link in the about sidecar', async () => {
+    try {
+      await this.app.client.click(Selectors.SIDECAR_NAV_COMMAND_LINKS('Kubectl Help'))
+      await this.app.client.waitForVisible(Selectors.SIDECAR_BREADCRUMBS)
+      const breadcrumbs = await this.app.client.getText(Selectors.SIDECAR_BREADCRUMBS)
+      assert.ok(breadcrumbs, 'Kui')
+    } catch (err) {
+      await Common.oops(this, true)(err)
+    }
+  })
 
   // help on kubectl
   it('should refresh', () => Common.refresh(this))


### PR DESCRIPTION
Fixes #4875

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
