### PR TITLE
8.9.2

### DIFF
--- a/packages/core/src/core/jobs/watchable.ts
+++ b/packages/core/src/core/jobs/watchable.ts
@@ -33,13 +33,32 @@ export interface Watchable {
 
 /** callbacks to indicate state changes */
 export interface WatchPusher {
-  update: (response: Row, batch?: boolean) => void
+  /**
+   *
+   * @param response Updated row model
+   *
+   * @param batch? is this part of a batch update? Updates to the view
+   * will be deferred until a call to batchUpdateDone()
+   *
+   * @param changed? allows push provider to specify whether this
+   * update should be visualized as a change to the model [default:
+   * true]
+   */
+  update: (response: Row, batch?: boolean, changed?: boolean) => void
+
+  /** A batch of calls to `update` is complete */
   batchUpdateDone: () => void
 
+  /** The given keyed row is gone */
   offline: (rowKey: string) => void
 
+  /** No more updates will be performed */
   done: () => void
+
+  /** The entire underlying model has disappared */
   allOffline: () => void
+
+  /** The header model has changed */
   header: (response: Row) => void
 }
 

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/SplitTerminalButton.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/SplitTerminalButton.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from 'react'
-import { i18n } from '@kui-shell/core'
+import { i18n, pexecInCurrentTab } from '@kui-shell/core'
 
 import Icons from '../../spi/Icons'
 import KuiContext from '../context'
@@ -23,6 +23,11 @@ import onSplit from '../../../controller/split'
 
 const strings = i18n('plugin-client-common')
 
+/**
+ * re: the impl of the onClick handler, see
+ * https://github.com/IBM/kui/issues/4876
+ *
+ */
 export default class SplitTerminalButtonButton extends React.PureComponent {
   public render() {
     return (
@@ -36,7 +41,7 @@ export default class SplitTerminalButtonButton extends React.PureComponent {
               aria-label="Split terminal"
               tabIndex={0}
               title={strings('Split the Terminal')}
-              onClick={() => onSplit()}
+              onClick={() => onSplit().catch(() => pexecInCurrentTab('split'))}
             >
               <Icons icon="Split" />
             </a>

--- a/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
@@ -91,7 +91,7 @@ export default class LivePaginatedTable extends PaginatedTable<LiveProps, LiveSt
         }
       })
 
-      const newRow = kuiRow2carbonRow(this.state.headers)(kuiRow, foundIndex)
+      const newRow = kuiRow2carbonRow(this.state.headers, true)(kuiRow, foundIndex)
       const newRows = existingRows
         .slice(0, foundIndex)
         .concat([newRow])
@@ -116,8 +116,8 @@ export default class LivePaginatedTable extends PaginatedTable<LiveProps, LiveSt
    * update consumes the update notification and apply it to the table view
    *
    */
-  private update(newKuiRow: KuiRow, batch = false) {
-    const existingRows = this.state.rows
+  private update(newKuiRow: KuiRow, batch = false, justUpdated = true) {
+    const existingRows = this._deferredUpdate || this.state.rows
     const nRowsBefore = existingRows.length
 
     const foundIndex = existingRows.findIndex(
@@ -129,7 +129,7 @@ export default class LivePaginatedTable extends PaginatedTable<LiveProps, LiveSt
 
     const insertionIndex = foundIndex === -1 ? nRowsBefore : foundIndex
 
-    const newRow = kuiRow2carbonRow(this.state.headers)(newKuiRow, insertionIndex)
+    const newRow = kuiRow2carbonRow(this.state.headers, justUpdated)(newKuiRow, insertionIndex)
 
     // Notes: since PaginatedTable is a React.PureComponent, we will
     // need to create a new array, rather than mutating the existing
@@ -151,8 +151,6 @@ export default class LivePaginatedTable extends PaginatedTable<LiveProps, LiveSt
 
     if (!batch) {
       this.setState({ rows: newRows })
-    } else if (this._deferredUpdate) {
-      this._deferredUpdate = newRows
     } else {
       this._deferredUpdate = newRows
     }

--- a/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
@@ -204,7 +204,17 @@ export default class PaginatedTable<P extends Props, S extends State> extends Re
                 }
               >
                 {response.header && renderHeader(response.header, renderOpts)}
-                {renderBody(response.body, renderOpts, tab, repl, offset)}
+                {renderBody(
+                  response.body,
+                  this.state.rows.reduce((M, _) => {
+                    if (_.justUpdated) M[_.rowKey] = true
+                    return M
+                  }, {} as Record<string, boolean>),
+                  renderOpts,
+                  tab,
+                  repl,
+                  offset
+                )}
               </Table>
             </TableContainer>
           )}

--- a/plugins/plugin-client-common/src/components/Content/Table/TableBody.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableBody.tsx
@@ -20,6 +20,7 @@ import * as React from 'react'
 import { DataTableCustomRenderProps, TableBody, TableRow } from 'carbon-components-react'
 
 import renderCell from './TableCell'
+import { NamedDataTableRow } from './kui2carbon'
 
 /**
  * Render the TableBody part
@@ -29,24 +30,30 @@ import renderCell from './TableCell'
  */
 export default function renderBody(
   kuiBody: KuiRow[],
-  renderOpts: DataTableCustomRenderProps,
+  justUpdated: Record<string, boolean>, // rowKey index
+  renderOpts: DataTableCustomRenderProps<NamedDataTableRow>,
   tab: Tab,
   repl: REPL,
   offset: number
 ) {
   return (
     <TableBody>
-      {renderOpts.rows.map((row, ridx) => (
-        <TableRow
-          key={row.id}
-          {...renderOpts.getRowProps({
-            row,
-            'data-name': kuiBody[offset + ridx].name
-          })}
-        >
-          {row.cells.map(renderCell(kuiBody[offset + ridx], row, tab, repl))}
-        </TableRow>
-      ))}
+      {renderOpts.rows.map((row, ridx) => {
+        const kuiRow = kuiBody[offset + ridx]
+        const updated = justUpdated[kuiRow.rowKey]
+
+        return (
+          <TableRow
+            key={row.id}
+            {...renderOpts.getRowProps({
+              row,
+              'data-name': kuiBody[offset + ridx].name
+            })}
+          >
+            {row.cells.map(renderCell(kuiRow, updated, tab, repl))}
+          </TableRow>
+        )
+      })}
     </TableBody>
   )
 }

--- a/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
@@ -17,7 +17,7 @@
 import { Cell as KuiCell, Row as KuiRow, Tab, REPL } from '@kui-shell/core'
 
 import * as React from 'react'
-import { TableCell, DataTableRow, DataTableCell } from 'carbon-components-react'
+import { TableCell, DataTableCell } from 'carbon-components-react'
 
 /**
  * Generate an onclick handler for a cell
@@ -58,7 +58,7 @@ export function onClickForCell(
  * Render a TableCell part
  *
  */
-export default function renderCell(kuiRow: KuiRow, row: DataTableRow, tab: Tab, repl: REPL) {
+export default function renderCell(kuiRow: KuiRow, justUpdated: boolean, tab: Tab, repl: REPL) {
   return function KuiTableCell(cell: DataTableCell, cidx: number) {
     // e.g. is this a badge/status-like cell?
     const tag = cidx > 0 && kuiRow.attributes[cidx - 1].tag
@@ -95,7 +95,13 @@ export default function renderCell(kuiRow: KuiRow, row: DataTableRow, tab: Tab, 
           className={outerClassName}
         >
           {tag === 'badge' && (
-            <span title={innerText} data-tag="badge-circle" className={kuiRow.attributes[cidx - 1].css} />
+            <span
+              key={kuiRow.attributes[cidx - 1].css /* force restart of animation if color changes */}
+              title={innerText}
+              data-tag="badge-circle"
+              className={kuiRow.attributes[cidx - 1].css}
+              data-just-updated={justUpdated || undefined}
+            />
           )}
           <span className="kui--cell-inner-text">{innerText}</span>
         </span>

--- a/plugins/plugin-client-common/src/components/Content/Table/kui2carbon.ts
+++ b/plugins/plugin-client-common/src/components/Content/Table/kui2carbon.ts
@@ -20,6 +20,7 @@ import { DataTableHeader, DataTableRow } from 'carbon-components-react'
 export interface NamedDataTableRow extends DataTableRow {
   NAME: string
   rowKey: string
+  justUpdated: boolean
 }
 
 /** attempt to infer header model from body model */
@@ -56,11 +57,11 @@ export function kuiHeader2carbonHeader(header: KuiRow): DataTableHeader[] {
  * DataTable.
  *
  */
-export function kuiRow2carbonRow(headers: DataTableHeader[]) {
+export function kuiRow2carbonRow(headers: DataTableHeader[], justUpdated = false) {
   return (row: KuiRow, ridx: number): NamedDataTableRow => {
     const isSelected = row.rowCSS ? row.rowCSS.includes('selected-row') : false
 
-    const rowData = { id: ridx.toString(), rowKey: row.rowKey, isSelected, NAME: '' }
+    const rowData = { id: ridx.toString(), rowKey: row.rowKey, isSelected, NAME: '', justUpdated }
     rowData[headers[0].key] = row.name
 
     if (!row.key) {

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -371,6 +371,18 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
   }
 
   /**
+   * @return the index of the given scrollback, in the context of the
+   * current (given) state
+   * Note: if theres's no scrollback matched the given state,
+   * e.g. the scrollback has been removed, return 0
+   *
+   */
+  private findAvailableSplit(curState: State, uuid: string): number {
+    const focusedIdx = this.findSplit(curState, uuid)
+    return focusedIdx !== -1 ? focusedIdx : 0
+  }
+
+  /**
    * Remove the given split (identified by `sbuuid`) from the state.
    *
    */
@@ -402,7 +414,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
    */
   private splice(sbuuid: string, mutator: (state: ScrollbackState) => Pick<ScrollbackState, 'blocks'>) {
     this.setState(curState => {
-      const focusedIdx = this.findSplit(curState, sbuuid)
+      const focusedIdx = this.findAvailableSplit(curState, sbuuid)
       const splits = curState.splits
         .slice(0, focusedIdx)
         .concat([Object.assign({}, curState.splits[focusedIdx], mutator(curState.splits[focusedIdx]))])

--- a/plugins/plugin-client-common/web/css/static/ui.css
+++ b/plugins/plugin-client-common/web/css/static/ui.css
@@ -696,7 +696,11 @@ input.repl-partial,
   animation: pulse 1000ms 1;
 }
 body {
-  --animation-repeating-pulse: pulse 1000ms infinite alternate-reverse;
+  --animation-short-repeating-pulse: pulse 1000ms 3 alternate-reverse;
+  --animation-medium-repeating-pulse: pulse 1000ms 6 alternate-reverse;
+  --animation-long-repeating-pulse: pulse 1000ms 20 alternate-reverse;
+  --animation-infinite-repeating-pulse: pulse 1000ms infinite alternate-reverse;
+  --animation-repeating-pulse: var(--animation-infinite-repeating-pulse);
 }
 .repeating-pulse {
   animation: var(--animation-repeating-pulse);

--- a/plugins/plugin-client-common/web/scss/components/Table/badges.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/badges.scss
@@ -103,7 +103,13 @@
 }
 
 [data-table-watching='true'] .bx--data-table {
-  [data-tag='badge-circle'].yellow-background {
-    animation: var(--animation-repeating-pulse);
+  [data-tag='badge-circle'][data-just-updated] {
+    &.yellow-background {
+      animation: var(--animation-infinite-repeating-pulse);
+    }
+
+    &.red-background {
+      animation: pulse 1000ms 6 alternate-reverse;
+    }
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Table/tables.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/tables.scss
@@ -151,7 +151,7 @@ body .bx--data-table {
 }
 
 @mixin full-width-tables {
-  .kui--data-table-wrapper {
+  .kui--data-table-wrapper:not(.kui--data-table-as-grid) {
     /* render tables full-width when sidecar is open https://github.com/IBM/kui/issues/3952 */
     flex: 1;
   }

--- a/plugins/plugin-kubectl/i18n/logs_en_US.json
+++ b/plugins/plugin-kubectl/i18n/logs_en_US.json
@@ -8,16 +8,37 @@
   "Details": "Details",
   "No log data": "No log data",
   "No matching pods": "No matching pods",
+
   "Logs are live streaming. Showing all containers.": "Logs are live **streaming**. Showing **all containers**.",
+  "Logs are live streaming. Showing all containers. Showing previous instance.": "Logs are live **streaming**. Showing **all containers** of **previous instance**.",
+
   "Log streaming is paused. Showing all containers.": "Log streaming is **paused**. Showing **all containers**.",
+  "Log streaming is paused. Showing all containers. Showing previous instance.": "Log streaming is **paused**. Showing **all containers** of **previous instance**.",
+
   "Log streaming stopped. Showing all containers.": "Log streaming **stopped**. Showing **all containers**.",
+  "Log streaming stopped. Showing all containers. Showing previous instance.": "Log streaming **stopped**. Showing **all containers** of **previous instance**.",
+
   "Log streaming stopped abnormally. Showing all containers.": "Log streaming **stopped abnormally**. Showing **all containers**.",
+  "Log streaming stopped abnormally. Showing all containers. Showing previous instance.": "Log streaming **stopped abnormally**. Showing **all containers** of **previous instance**.",
+
   "Logs are live streaming. Showing container X.": "Logs are live **streaming**. Showing container **{0}**.",
+  "Logs are live streaming. Showing container X. Showing previous instance.": "Logs are live **streaming**. Showing container **{0}** of **previous instance**.",
+
   "Log streaming is paused. Showing container X.": "Log streaming is **paused**. Showing container **{0}**.",
+  "Log streaming is paused. Showing container X. Showing previous instance.": "Log streaming is **paused**. Showing container **{0}** of **previous instance**.",
+
   "Log streaming stopped. Showing container X.": "Log streaming **stopped**. Showing container **{0}**.",
+  "Log streaming stopped. Showing container X. Showing previous instance.": "Log streaming **stopped**. Showing container **{0}** of **previous instance**.",
+
   "Log streaming stopped abnormally. Showing container X.": "Log streaming **stopped abnormally**. Showing container **{0}**.",
+  "Log streaming stopped abnormally. Showing container X. Showing previous instance.": "Log streaming **stopped abnormally**. Showing container **{0}** of **previous instance**.",
+
   "Log streaming stopped.": "Log streaming **stopped**.",
+  "Log streaming stopped. Showing previous instance.": "Log streaming **stopped**. Showing **previous instance**.",
+
   "Log streaming stopped abnormally.": "Log streaming **stopped abnormally**.",
+  "Log streaming stopped abnormally. Showing previous instance.": "Log streaming **stopped abnormally**. Showing **previous instance**.",
+
   "Pause Streaming": "Pause Streaming",
   "Resume Streaming": "Resume Streaming",
   "Retry": "Retry",

--- a/plugins/plugin-kubectl/logs/src/controller/kubectl/logs.ts
+++ b/plugins/plugin-kubectl/logs/src/controller/kubectl/logs.ts
@@ -21,7 +21,8 @@ import {
   KubeOptions,
   doExecWithPty,
   doExecWithStdout,
-  defaultFlags as flags,
+  defaultFlags,
+  flags,
   getLabel,
   getTransformer,
   getCommandFromArgs,
@@ -40,11 +41,15 @@ import commandPrefix from '../command-prefix'
 const strings = i18n('plugin-kubectl', 'logs')
 
 interface LogOptions extends KubeOptions {
-  f: string
-  follow: string
+  // f: boolean
+  follow: boolean
+  p: boolean
   previous: boolean
   tail: number
 }
+
+/** for command registration, which of those options is a boolean? */
+const booleans = ['p', 'previous', 'f', 'follow']
 
 /**
  * Send the request to a PTY for deeper handling, then (possibly) add
@@ -166,10 +171,10 @@ function viewTransformer(defaultMode: string) {
 }
 
 export const doLogs = getOrPty('logs')
-export const logsFlags = Object.assign({}, flags, { viewTransformer: viewTransformer('logs') })
+export const logsFlags = Object.assign({}, flags(booleans), { viewTransformer: viewTransformer('logs') })
 
 export const doExec = getOrPty('exec')
-export const execFlags = Object.assign({}, flags, { viewTransformer: viewTransformer('terminal') })
+export const execFlags = Object.assign({}, defaultFlags, { viewTransformer: viewTransformer('terminal') })
 
 export default (registrar: Registrar) => {
   registrar.listen(`/${commandPrefix}/kubectl/logs`, doLogs, logsFlags)

--- a/plugins/plugin-kubectl/logs/src/test/logs/helpers.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/helpers.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CLI, Common, ReplExpect, Selectors, SidecarExpect } from '@kui-shell/test'
+import { defaultModeForGet, waitForGreen } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
+
+export function create(this: Common.ISuite, ns: string, inputEncoded: string, podName: string) {
+  it(`should create sample pod from URL`, () => {
+    return CLI.command(`echo ${inputEncoded} | base64 --decode | kubectl create -f - -n ${ns}`, this.app)
+      .then(ReplExpect.okWithPtyOutput(podName))
+      .catch(Common.oops(this, true))
+  })
+}
+
+export function wait(this: Common.ISuite, ns: string, podName: string) {
+  it(`should wait for the pod to come up`, () => {
+    return CLI.command(`kubectl get pod ${podName} -n ${ns} -w`, this.app)
+      .then(ReplExpect.okWithCustom({ selector: Selectors.BY_NAME(podName) }))
+      .then(selector => waitForGreen(this.app, selector))
+      .catch(Common.oops(this, true))
+  })
+}
+
+export function get(this: Common.ISuite, ns: string, podName: string, wait = true) {
+  it(`should get pod ${podName} via kubectl then click`, async () => {
+    try {
+      const selector: string = await CLI.command(`kubectl get pods ${podName} -n ${ns}`, this.app).then(
+        ReplExpect.okWithCustom({ selector: Selectors.BY_NAME(podName) })
+      )
+
+      if (wait) {
+        // wait for the badge to become green
+        await waitForGreen(this.app, selector)
+      }
+
+      // now click on the table row
+      await this.app.client.click(`${selector} .clickable`)
+      await SidecarExpect.open(this.app)
+        .then(SidecarExpect.mode(defaultModeForGet))
+        .then(SidecarExpect.showing(podName))
+    } catch (err) {
+      return Common.oops(this, true)(err)
+    }
+  })
+}
+
+export async function clickRetry(this: Common.ISuite) {
+  await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON('retry-streaming'))
+  await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON('retry-streaming'))
+}
+
+async function waitUntilPreviousIs(this: Common.ISuite, type: 'info' | 'warning', previous: boolean) {
+  const click = clickRetry.bind(this)
+
+  await this.app.client.waitUntil(async () => {
+    if (!this.app.client.isExisting(Selectors.SIDECAR_TOOLBAR_TEXT(type))) {
+      await click()
+      return false
+    } else {
+      return true
+    }
+  })
+
+  await SidecarExpect.toolbarText({ type, text: previous ? 'previous instance' : '' })
+}
+
+export function logs(
+  this: Common.ISuite,
+  ns: string,
+  podName: string,
+  containerName: string,
+  type: 'info' | 'warning',
+  previous: boolean
+) {
+  const wait = waitUntilPreviousIs.bind(this, type, previous)
+
+  it(`should get logs for ${podName} with previous=${previous} via command`, async () => {
+    try {
+      await CLI.command(
+        `kubectl logs ${podName} -c ${containerName} -n ${ns} ${previous ? '--previous' : ''}`,
+        this.app
+      )
+        .then(ReplExpect.justOK)
+        .then(SidecarExpect.open)
+        .then(SidecarExpect.showing(podName, undefined, undefined, ns))
+        .then(SidecarExpect.mode('logs'))
+
+      await wait()
+    } catch (err) {
+      await Common.oops(this, true)
+    }
+  })
+}
+
+export function clickPrevious(this: Common.ISuite, type: 'info' | 'warning', previous: boolean) {
+  const wait = waitUntilPreviousIs.bind(this, type, previous)
+
+  it(`should click the previous toggle button and expect previous=${previous}`, async () => {
+    const mode = 'kubectl-logs-previous-toggle'
+    await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON(mode))
+    await this.app.client.click(Selectors.SIDECAR_MODE_BUTTON(mode))
+    await wait()
+  })
+}

--- a/plugins/plugin-kubectl/logs/src/test/logs/logs-tab-previous.ts
+++ b/plugins/plugin-kubectl/logs/src/test/logs/logs-tab-previous.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common } from '@kui-shell/test'
+import { createNS, allocateNS, deleteNS } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
+
+import { clickPrevious, create, logs, wait } from './helpers'
+
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+const ROOT = dirname(require.resolve('@kui-shell/plugin-kubectl/tests/package.json'))
+const inputBuffer = readFileSync(join(ROOT, 'data/k8s/crashy.yaml'))
+const inputEncoded = inputBuffer.toString('base64')
+
+const podName = 'kui-crashy'
+const containerName = 'crashy'
+
+describe(`kubectl Logs previous tab ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  const ns = createNS()
+
+  const createPodWithoutWaiting = create.bind(this, ns)
+  const waitForPod = wait.bind(this, ns, podName)
+  const kubectlLogs = logs.bind(this, ns, podName, containerName, 'warning', false)
+  const kubectlLogsPrevious = logs.bind(this, ns, podName, containerName, 'warning', true)
+  const clickPreviousToggle = clickPrevious.bind(this)
+
+  /* Here comes the test */
+  allocateNS(this, ns)
+
+  createPodWithoutWaiting(inputEncoded, podName)
+  waitForPod()
+
+  kubectlLogsPrevious()
+  clickPreviousToggle('warning', false) // click toggle and expect previous=false
+
+  kubectlLogs()
+  clickPreviousToggle('warning', true) // click toggle and expect previous=true
+
+  deleteNS(this, ns)
+})

--- a/plugins/plugin-kubectl/src/controller/kubectl/flags.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/flags.ts
@@ -25,11 +25,11 @@ const defaultBooleans = [
   'ignore-not-found',
   'no-headers',
 
+  // exec
   'i',
   'it',
   'ti',
   'stdin',
-
   't',
   'tty',
 

--- a/plugins/plugin-kubectl/src/controller/kubectl/options.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/options.ts
@@ -134,6 +134,12 @@ export function hasLabel(args: Arguments<KubeOptions>) {
   return false
 }
 
+/** @return the namespace as expressed in the command line, or undefined if not */
+export function getNamespaceAsExpressed(args: Arguments<KubeOptions>): string {
+  return args.parsedOptions.n || args.parsedOptions.namespace
+}
+
+/** @return the namespace as expressed in the command line, or the default from context */
 export async function getNamespace(args: Arguments<KubeOptions>): Promise<string> {
   return args.parsedOptions.n || args.parsedOptions.namespace || (await getCurrentDefaultNamespace(args))
 }

--- a/plugins/plugin-kubectl/src/controller/kubectl/options.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/options.ts
@@ -203,6 +203,9 @@ export interface KubeOptions extends ParsedOptions {
 
   wait?: boolean
 
+  p?: boolean
+  previous?: boolean
+
   l?: string
   label?: string
 

--- a/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
@@ -30,8 +30,8 @@ import {
 import { kindPart } from '../fqn'
 import { formatOf, KubeOptions, KubeExecOptions } from '../options'
 
-import { Pair } from '../../../lib/view/formatTable'
 import { getCommandFromArgs } from '../../../lib/util/util'
+import { Pair, getNamespaceBreadcrumbs } from '../../../lib/view/formatTable'
 
 const debug = Debug('plugin-kubectl/controller/watch/watcher')
 
@@ -346,7 +346,7 @@ export default async function doGetWatchTable(args: Arguments<KubeOptions>): Pro
       return {
         header: initialTable.header,
         body: initialTable.body,
-        breadcrumbs: initialTable.breadcrumbs,
+        breadcrumbs: initialTable.breadcrumbs || (await getNamespaceBreadcrumbs(initialTable.title, args)),
         title: initialTable.title,
         watch: new KubectlWatcher(args) // <-- our watcher
       }

--- a/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
@@ -238,13 +238,16 @@ class KubectlWatcher implements Abortable, Watcher {
           // based on the information we got back, 1) we push updates to
           // the table model; and 2) we may be able to discern that we
           // can stop watching
+          const apiVersion = rows[0][2].value
+          const kind = rows[0][1].value
+          const isEvent = apiVersion === 'v1' && kind === 'Event'
           table.body.forEach(row => {
             // push an update to the table model
             // true means we want to do a batch update
             if (row.isDeleted) {
               this.pusher.offline(row.name)
             } else {
-              this.pusher.update(row, true)
+              this.pusher.update(row, true, !isEvent)
             }
           })
 

--- a/plugins/plugin-kubectl/src/index.ts
+++ b/plugins/plugin-kubectl/src/index.ts
@@ -58,7 +58,7 @@ export { doExecRaw, doNativeExec } from './controller/kubectl/raw'
 
 export { default as commandPrefix } from './controller/command-prefix'
 
-export { default as defaultFlags, crudFlags } from './controller/kubectl/flags'
+export { default as defaultFlags, crudFlags, flags } from './controller/kubectl/flags'
 
 export { getCurrentContext, getCurrentContextName, getCurrentDefaultNamespace } from './controller/kubectl/contexts'
 

--- a/plugins/plugin-kubectl/src/lib/view/modes/ContainerCommon.tsx
+++ b/plugins/plugin-kubectl/src/lib/view/modes/ContainerCommon.tsx
@@ -98,7 +98,6 @@ export abstract class ContainerComponent<State extends ContainerState> extends R
   }
 
   /** Buttons to display in the Toolbar. */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected toolbarButtons(status: StreamingStatus): Button[] {
     return this.toolbarButtonsForError(status).concat(this.toolbarButtonsForStreaming(status), this.containerList())
   }

--- a/plugins/plugin-kubectl/src/lib/view/modes/ExecIntoPod.tsx
+++ b/plugins/plugin-kubectl/src/lib/view/modes/ExecIntoPod.tsx
@@ -264,17 +264,19 @@ export class Terminal<S extends TerminalState = TerminalState> extends Container
     }
   }
 
-  protected showContainer(container: string) {
-    super.showContainer(container)
-
-    this.setState(() => {
+  protected showContainer(container: string, extraState?: (curState: S) => Partial<S>) {
+    this.setState(curState => {
       this.abortPriorJob()
 
-      return {
-        job: undefined,
-        streamUUID: undefined,
-        isTerminated: false
-      }
+      return Object.assign(
+        {
+          container,
+          job: undefined,
+          streamUUID: undefined,
+          isTerminated: false
+        },
+        extraState ? extraState(curState) : {}
+      )
     })
   }
 

--- a/plugins/plugin-kubectl/src/test/k8s2/usage.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/usage.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as assert from 'assert'
 
-import { Common, testAbout } from '@kui-shell/test'
+import { Common, testAbout, Selectors, ReplExpect, CLI } from '@kui-shell/test'
 import { doHelp } from '../../../tests/lib/k8s/utils'
 
 const commonModes = ['Introduction']
@@ -35,6 +36,33 @@ describe('kubectl dash h', function(this: Common.ISuite) {
 
   // switch to about, should see correct navigation, breadcrumbs and content
   testAbout(this)
+
+  it(`should split the terminal via button in the current tab and expect splitCount=2`, async () => {
+    try {
+      await this.app.client.click(Selectors.NEW_SPLIT_BUTTON)
+      await ReplExpect.splitCount(2)(this.app)
+    } catch (err) {
+      await Common.oops(this, true)(err)
+    }
+  })
+
+  testAbout(this)
+
+  it('should close the split via command in the current tab and expect splitCount=1', () =>
+    CLI.command('exit', this.app)
+      .then(() => ReplExpect.splitCount(1)(this.app))
+      .catch(Common.oops(this, true)))
+
+  it('should click kubectl help link in the about sidecar', async () => {
+    try {
+      await this.app.client.click(Selectors.SIDECAR_NAV_COMMAND_LINKS('Kubectl Help'))
+      await this.app.client.waitForVisible(Selectors.SIDECAR_BREADCRUMBS)
+      const breadcrumbs = await this.app.client.getText(Selectors.SIDECAR_BREADCRUMBS)
+      assert.ok(breadcrumbs, 'Kui')
+    } catch (err) {
+      await Common.oops(this, true)(err)
+    }
+  })
 
   // help on kubectl
   it('should refresh', () => Common.refresh(this))

--- a/plugins/plugin-kubectl/tests/data/k8s/crashy.yaml
+++ b/plugins/plugin-kubectl/tests/data/k8s/crashy.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kui-crashy
+spec:
+  containers:
+  - name: crashy
+    image: nginx
+    command: ["/bin/sh", "-c", "echo logtest; sleep 5; echo exiting; exit"]


### PR DESCRIPTION
[8.9.2 39d8d74ad] feat(plugins/plugin-kubectl): Show Previous option for Logs tab
 Date: Wed Jun 10 12:55:01 2020 -0400
 12 files changed, 308 insertions(+), 94 deletions(-)
 create mode 100644 plugins/plugin-kubectl/logs/src/test/logs/helpers.ts
 create mode 100644 plugins/plugin-kubectl/logs/src/test/logs/logs-tab-previous.ts
 create mode 100644 plugins/plugin-kubectl/tests/data/k8s/crashy.yaml

[8.9.2 4b0550ac6] fix(plugins/plugin-client-common): table container should only be width:100% for table not display-as-grid
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Wed Jun 10 18:59:18 2020 -0400
 1 file changed, 1 insertion(+), 1 deletion(-)

[8.9.2 f4fcd30dd] fix: don't blink yellow forever for kubectl events
 Date: Thu Jun 11 15:23:49 2020 -0400
 9 files changed, 83 insertions(+), 29 deletions(-)

[8.9.2 41d31a796] fix: pexecs serviced by now-removed splits fail
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Thu Jun 11 17:01:55 2020 -0400
 2 files changed, 42 insertions(+), 2 deletions(-)

[8.9.2 a5640fc90] fix(plugins/plugin-kubectl): kubectl watch tables may lack namespace breadcrumb
 Date: Thu Jun 11 21:00:51 2020 -0400
 3 files changed, 26 insertions(+), 10 deletions(-)

[8.9.2 c52d33d72] fix(plugins/plugin-client-common): split button errors are not reported to the user
 Date: Fri Jun 12 07:41:34 2020 -0400
 1 file changed, 7 insertions(+), 2 deletions(-)
