### PR TITLE
8.9.4

### DIFF
--- a/plugins/plugin-bash-like/web/css/static/xterm.css
+++ b/plugins/plugin-bash-like/web/css/static/xterm.css
@@ -4,7 +4,7 @@
    see https://github.com/xtermjs/xterm.js/pull/2067
    see https://github.com/IBM/kui/issues/1518
 */
-[kui-theme-style] .tab-container {
+[kui-theme-style] .kui--tab-content {
   .xterm-screen,
   .xterm-rows > div {
     width: 100% !important;
@@ -171,6 +171,7 @@ disabled see https://github.com/IBM/kui/issues/3939
   .xterm-rows {
     font-size: 1em;
     font-family: var(--font-monospace);
+    background-color: var(--color-repl-background);
     color: var(--color-text-01);
     transition: font-size 10ms ease-in-out, background 300ms ease-in-out;
   }

--- a/plugins/plugin-client-common/src/components/Client/InputStripe.tsx
+++ b/plugins/plugin-client-common/src/components/Client/InputStripe.tsx
@@ -17,18 +17,21 @@
 import * as React from 'react'
 import { Tab as KuiTab, eventBus } from '@kui-shell/core'
 
+import KuiContext from './context'
 import Block from '../Views/Terminal/Block'
+import KuiConfiguration from './KuiConfiguration'
 import { InputOptions } from '../Views/Terminal/Block/Input'
 import BlockModel, { Active } from '../Views/Terminal/Block/BlockModel'
 
 import '../../../web/css/static/InputStripe.scss'
 
-type Props = InputOptions & {
-  tab?: KuiTab
+type Props = Partial<KuiConfiguration> &
+  InputOptions & {
+    tab?: KuiTab
 
-  /** tab uuid; this is grafted in for you, by TabContent */
-  uuid?: string
-}
+    /** tab uuid; this is grafted in for you, by TabContent */
+    uuid?: string
+  }
 
 interface State {
   idx: number
@@ -54,19 +57,21 @@ export default class InputStripe extends React.PureComponent<Props, State> {
 
   public render() {
     return (
-      <div className="kui--input-stripe repl">
-        <Block
-          idx={this.state.idx}
-          uuid={this.props.uuid}
-          tab={this.props.tab}
-          model={this.state.model}
-          noOutput
-          noPromptContext
-          promptPlaceholder={this.props.promptPlaceholder}
-        >
-          {this.props.children}
-        </Block>
-      </div>
+      <KuiContext.Provider value={{ prompt: this.props.prompt || '\u276f' }}>
+        <div className="kui--input-stripe repl">
+          <Block
+            idx={this.state.idx}
+            uuid={this.props.uuid}
+            tab={this.props.tab}
+            model={this.state.model}
+            noOutput
+            noPromptContext
+            promptPlaceholder={this.props.promptPlaceholder}
+          >
+            {this.props.children}
+          </Block>
+        </div>
+      </KuiContext.Provider>
     )
   }
 }

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/Tab.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/Tab.tsx
@@ -134,7 +134,7 @@ export default class Tab extends React.PureComponent<Props, State> {
     }
 
     eventBus.onCommandStart(this.props.uuid, this.onCommandStart)
-    eventBus.onCommandComplete(this.props.uuid, this.onCommandStart)
+    eventBus.onCommandComplete(this.props.uuid, this.onCommandComplete)
     eventChannelUnsafe.on('/theme/change', this.onThemeChange)
   }
 

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -125,7 +125,9 @@ export abstract class InputProvider<S extends State = State> extends React.PureC
     return (
       !this.props.noPromptContext && (
         <KuiContext.Consumer>
-          {config => !config.noPromptContext && <span className="repl-context">{this.props.model.cwd}</span>}
+          {config =>
+            !config.noPromptContext && this.props.model && <span className="repl-context">{this.props.model.cwd}</span>
+          }
         </KuiContext.Consumer>
       )
     )


### PR DESCRIPTION
- [8.9.4 4c287d435] fix(plugins/plugn-client-common): TopTabStripe stays blue after command execution completes
 Date: Sat Jun 13 19:02:22 2020 -0400
 1 file changed, 1 insertion(+), 1 deletion(-)

- [8.9.4 f3f5b0d87] fix(plugins/plugin-client-common): in Popup mode, use > rather than / for prompt in bottom input
 Date: Sat Jun 13 19:36:16 2020 -0400
 2 files changed, 26 insertions(+), 19 deletions(-)

- [8.9.4 475885742] fix(plugins/plugin-bash-like): in Popup mode, active PTY is not themed, has flashing effect
 Date: Sat Jun 13 19:45:06 2020 -0400
 1 file changed, 2 insertions(+), 1 deletion(-)