### PR TITLE
fix: empty watch tables/grids should show 'No resources'

### DIFF
--- a/plugins/plugin-client-common/i18n/resources_en_US.json
+++ b/plugins/plugin-client-common/i18n/resources_en_US.json
@@ -1,6 +1,7 @@
 {
   "Remove": "Remove",
   "ok": "ok",
+  "No resources": "No resources",
   "New Tab": "New Tab",
   "Split the Terminal": "Split the Terminal",
   "Show as table": "Show as table",

--- a/plugins/plugin-client-common/src/components/Content/Scalar/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Scalar/index.tsx
@@ -36,6 +36,7 @@ import { isError } from '../../Views/Terminal/Block/BlockModel'
 interface Props {
   tab: KuiTab
   response: ScalarResponse | Error
+  onUpdate?: () => void // content has updates
 }
 
 interface State {
@@ -83,7 +84,7 @@ export default class Scalar extends React.PureComponent<Props, State> {
           </KuiContext.Consumer>
         )
       } else if (isTable(response)) {
-        return renderTable(tab, tab.REPL, response, undefined, true)
+        return renderTable(tab, tab.REPL, response, undefined, true, undefined, this.props.onUpdate)
         // ^^^ Notes: typescript doesn't like this, and i don't know why:
         // "is not assignable to type IntrinsicAttributes..."
         // <PaginatedTable {...props} />
@@ -91,7 +92,7 @@ export default class Scalar extends React.PureComponent<Props, State> {
         return (
           <div className="result-vertical flex-layout" style={{ flex: 1, alignItems: 'unset' }}>
             {response.map((part, idx) => (
-              <Scalar key={idx} tab={this.props.tab} response={part} />
+              <Scalar key={idx} tab={this.props.tab} response={part} onUpdate={this.props.onUpdate} />
             ))}
           </div>
         )

--- a/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
@@ -154,6 +154,8 @@ export default class LivePaginatedTable extends PaginatedTable<LiveProps, LiveSt
     } else {
       this._deferredUpdate = newRows
     }
+
+    this.props.onUpdate()
   }
 
   /** End of a deferred batch of updates */

--- a/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
@@ -67,6 +67,9 @@ export type Props<T extends KuiTable = KuiTable> = PaginationConfiguration & {
 
   /** prefix breadcrumbs? */
   prefixBreadcrumbs?: BreadcrumbView[]
+
+  /** table finished updates */
+  onUpdate?: () => void
 }
 
 /** state of PaginatedTable component */

--- a/plugins/plugin-client-common/src/components/Content/Table/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/index.tsx
@@ -27,7 +27,8 @@ export default function renderTable(
   response: Table,
   paginate: boolean | number = 20,
   toolbars = false,
-  asGrid = false
+  asGrid = false,
+  onUpdate?: () => void
 ) {
   if (isWatchable(response)) {
     return (
@@ -41,6 +42,7 @@ export default function renderTable(
             title={!config.disableTableTitle}
             toolbars={toolbars}
             asGrid={asGrid}
+            onUpdate={onUpdate}
           />
         )}
       </KuiContext.Consumer>


### PR DESCRIPTION
Fixes #4884

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
