### PR TITLE
fix(plugins/plugin-core-support): UpdateChecker always reports that a…

### DIFF
--- a/plugins/plugin-core-support/src/components/UpdateChecker.tsx
+++ b/plugins/plugin-core-support/src/components/UpdateChecker.tsx
@@ -59,6 +59,16 @@ interface State {
   dulyNoted: string
 }
 
+/**
+ * GitHub gives back "v8.10.0" and the Kui version command gives back "8.10.0".
+ *
+ * @see https://github.com/IBM/kui/issues/4918
+ *
+ */
+function stripOffPrefixV(githubVersionString: string): string {
+  return githubVersionString.replace(/^v/, '')
+}
+
 export default class UpdateChecker extends React.PureComponent<Props, State> {
   public constructor(props: Props) {
     super(props)
@@ -86,6 +96,7 @@ export default class UpdateChecker extends React.PureComponent<Props, State> {
       .then(res => {
         return res.body.children.filter(_ => _.name === 'entry')[0].children.find(_ => _.name === 'title').value
       })
+      .then(stripOffPrefixV) // see https://github.com/IBM/kui/issues/4918
       .then(latestVersion =>
         this.setState(curState => ({
           latestVersion,


### PR DESCRIPTION
…n update is available

Fixes #4918

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
