### PR TITLE
fix(plugins/plugin-client-common): regression: non-empty repl output has 'ok' at the end

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
@@ -60,7 +60,7 @@ type Props = {
 } & BlockViewTraits
 
 interface State {
-  assertHasContent: boolean
+  assertHasContent?: boolean
   isResultRendered: boolean
 
   streamingOutput: Streamable[]
@@ -79,7 +79,6 @@ export default class Output extends React.PureComponent<Props, State> {
     }
 
     this.state = {
-      assertHasContent: false,
       isResultRendered: false,
       streamingOutput: [],
       streamingConsumer


### PR DESCRIPTION
Fixes #4924

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
