### PR TITLE
feat: add capability to show welcome widget to new users in Terminal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ jobs:
     - env: LAYERS=k8s1 MOCHA_RUN_TARGET=webpack  NEEDS_K8S=true NEEDS_OC=true
     - env: LAYERS=k8s2 MOCHA_RUN_TARGET=webpack  NEEDS_K8S=true NEEDS_OC=true   NEEDS_TOP=true
 
-    - env: N="API" CLIENT="test" MOCHA_RUN_TARGET="webpack" LAYERS="response" CODECOV_OF_PRESCAN=true
+    - env: N="API" CLIENT="test" MOCHA_RUN_TARGET="webpack" LAYERS="response" CODECOV_OF_PRESCAN=true WELCOME=true
     - env: N="API" CLIENT="test" MOCHA_RUN_TARGET="electron" LAYERS="response"
-    - env: N="bottom-input" CLIENT="alternate" MOCHA_RUN_TARGET="webpack" LAYERS="bottom-input"
+    - env: N="bottom-input" CLIENT="alternate" MOCHA_RUN_TARGET="webpack" LAYERS="bottom-input" BOTTOM_INPUT_MODE=true WELCOME=true
 
     # CLIENT=default | os=Darwin | TARGET=electron | core, core-support, editor, core-support2
     - os: osx

--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -8,6 +8,7 @@ export const SIDECAR_FULLSCREEN = `${CURRENT_TAB} .kui--sidecar.visible.maximize
 export const TERMINAL_WITH_SIDECAR_VISIBLE = `${CURRENT_TAB} .repl.sidecar-visible`
 const _PROMPT_BLOCK = '.repl-block'
 export const PROMPT_BLOCK = `${CURRENT_TAB} .repl ${_PROMPT_BLOCK}`
+export const WELCOME_BLOCK = `${PROMPT_BLOCK} .kui--repl-message.kui--session-init-done`
 export const BOTTOM_PROMPT_BLOCK = `${CURRENT_TAB} .kui--input-stripe .repl-block`
 export const BOTTOM_PROMPT = `${BOTTOM_PROMPT_BLOCK} input`
 export const STATUS_STRIPE_BLOCK = '.kui--status-stripe .kui--input-stripe .repl-block'

--- a/plugins/plugin-client-alternate/src/test/bottom-input/new-tab.ts
+++ b/plugins/plugin-client-alternate/src/test/bottom-input/new-tab.ts
@@ -60,7 +60,14 @@ describe('core new tab from pty active tab via button click', function(this: Com
 
   it('should report proper version', () =>
     CLI.command('version', this.app)
-      .then(ReplExpect.okWithCustom({ expect: Common.expectedVersion }))
+      .then(async res => {
+        if (!process.env.WELCOME) {
+          return ReplExpect.okWithCustom({ expect: Common.expectedVersion })(res)
+        } else {
+          await this.app.client.waitForVisible(Selectors.WELCOME_BLOCK)
+          return ReplExpect.okWithCustom({ expect: Common.expectedVersion })({ app: res.app, count: res.count + 1 })
+        }
+      })
       .then(() => this.app.client.waitForVisible(Selectors.TAB_SELECTED_N(2)))
       .catch(Common.oops(this)))
 })

--- a/plugins/plugin-client-common/src/components/Client/Kui.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Kui.tsx
@@ -119,7 +119,8 @@ export class Kui extends React.PureComponent<Props, State> {
 
   private defaultFeatureFlag() {
     return {
-      sidecarName: 'breadcrumb'
+      sidecarName: 'breadcrumb',
+      showWelcomeMax: -1
     }
   }
 

--- a/plugins/plugin-client-common/src/components/Client/TabContent.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContent.tsx
@@ -212,23 +212,6 @@ export default class TabContent extends React.PureComponent<Props, State> {
     return <Loading description={strings('Please wait while we connect to your cloud')} />
   }
 
-  private sessionInitDoneMessage() {
-    return (
-      this.state.showSessionInitDone &&
-      this.state.sidecarWidth === Width.Closed && (
-        <KuiContext.Consumer>
-          {config =>
-            config.loadingDone && (
-              <div className="kui--repl-message kui--session-init-done">
-                <span className="repl-block">{config.loadingDone(this.state.tab.REPL)}</span>
-              </div>
-            )
-          }
-        </KuiContext.Consumer>
-      )
-    )
-  }
-
   private terminal() {
     if (this.state.sessionInit !== 'Done') {
       return (
@@ -247,7 +230,6 @@ export default class TabContent extends React.PureComponent<Props, State> {
     } else {
       return (
         <React.Fragment>
-          {this.sessionInitDoneMessage()}
           <KuiContext.Consumer>
             {config => (
               <ScrollableTerminal

--- a/plugins/plugin-client-common/src/components/Client/props/FeatureFlags.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/FeatureFlags.ts
@@ -29,6 +29,15 @@ type FeatureFlags = {
 
   /** [Optional] automatically pin watchable command ouptut to the WatchPane? */
   enableWatcherAutoPin?: boolean
+
+  /**
+   * [Optional] maximum number of times to show `loadingDone` to users
+   * if set to -1, always show welcome;
+   * if not 0, not show welcome
+   * default: -1
+   *
+   */
+  showWelcomeMax?: number
 }
 
 export default FeatureFlags

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
@@ -19,7 +19,7 @@ import { Tab as KuiTab, eventChannelUnsafe } from '@kui-shell/core'
 
 import Input, { InputOptions } from './Input'
 import Output from './Output'
-import { BlockModel, isActive, isEmpty, isFinished, isProcessing, hasUUID } from './BlockModel'
+import { BlockModel, isActive, isEmpty, isFinished, isProcessing, isAnnouncement, hasUUID } from './BlockModel'
 
 export type BlockViewTraits = {
   isPinned?: boolean
@@ -137,11 +137,14 @@ export default class Block extends React.PureComponent<Props, State> {
         <div
           className={'repl-block ' + this.props.model.state.toString()}
           data-pinned={this.props.isPinned || undefined}
+          data-announcement={isAnnouncement(this.props.model) || undefined}
           data-uuid={hasUUID(this.props.model) && this.props.model.execUUID}
           data-input-count={this.props.idx}
           ref={c => this.setState({ _block: c })}
         >
-          {isActive(this.props.model) || isEmpty(this.props.model) ? (
+          {isAnnouncement(this.props.model) ? (
+            this.output()
+          ) : isActive(this.props.model) || isEmpty(this.props.model) ? (
             this.input()
           ) : (
             <React.Fragment>

--- a/plugins/plugin-client-common/src/components/spi/Card/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Card/impl/PatternFly.tsx
@@ -82,18 +82,16 @@ export default class PatternflyCard extends React.PureComponent<Props, State> {
 
   /** card actions, icon and custom header node will be situated in Card Head */
   private header() {
-    if (this.props.header || this.props.actions || this.props.icon) {
-      return (
-        <CardHeader>
-          <CardHeaderMain>{this.props.header || (this.props.icon && this.icon())}</CardHeaderMain>
-          {this.props.actions && this.cardActions()}
-          <div>
-            {this.props.titleInHeader && this.title()}
-            {this.props.bodyInHeader && this.body()}
-          </div>
-        </CardHeader>
-      )
-    }
+    return (
+      <CardHeader>
+        <CardHeaderMain>{this.props.header || (this.props.icon && this.icon())}</CardHeaderMain>
+        {this.props.actions && this.cardActions()}
+        <div>
+          {this.props.titleInHeader && this.title()}
+          {this.props.bodyInHeader && this.body()}
+        </div>
+      </CardHeader>
+    )
   }
 
   private title() {

--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -55,6 +55,7 @@ export default function renderMain(props: KuiProps) {
       enableWatcherAutoPin
       {...props}
       loadingDone={loadingDone}
+      showWelcomeMax={0}
       toplevel={<Search />}
     >
       <ContextWidgets>


### PR DESCRIPTION
Fixes #4990

This feature could be enabled by setting `showWelcomeMax` to `-1` or some number in browser mode

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
