### PR TITLE
fix: clients should be able to enable watcher auto pinning without en…

### DIFF
--- a/plugins/plugin-client-alternate/src/index.tsx
+++ b/plugins/plugin-client-alternate/src/index.tsx
@@ -26,5 +26,5 @@ import '../web/scss/components/TopTabStripe/Carbon.scss'
  */
 export default function BottomInputClient(props: KuiProps) {
   // prompt is unicode for "heavy right-pointing angle quotation mark ornament"
-  return <Kui {...props} bottomInput={<CustomInput />} noPromptContext prompt="&#x276f;" />
+  return <Kui {...props} enableWatcherAutoPin bottomInput={<CustomInput />} noPromptContext prompt="&#x276f;" />
 }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -147,8 +147,8 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
     }
   }
 
-  private allocateUUIDForScrollback() {
-    if (this.props.config.splitTerminals && !isPopup()) {
+  private allocateUUIDForScrollback(forSplit = false) {
+    if (forSplit || (this.props.config.splitTerminals && !isPopup())) {
       return `${this.props.uuid}_${uuid()}`
     } else {
       return this.props.uuid
@@ -158,7 +158,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
   private scrollback(
     pinBlock?: FinishedBlock,
     capturedValue?: string,
-    sbuuid = this.allocateUUIDForScrollback()
+    sbuuid = this.allocateUUIDForScrollback(!!pinBlock)
   ): ScrollbackState {
     const state = {
       uuid: sbuuid,
@@ -239,7 +239,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
 
   /**
    * When the following requirements meet, auto-pin the command block:
-   * 1. user has enbaled the splitTerminals anad enableWatcherAutoPin feature flag
+   * 1. user has enabled the enableWatcherAutoPin feature flag
    * 2. not in popup mode
    * 3. the scalar response is watchable, e.g. watchable table,
    * 4. the command option or exec options doesn't say alwaysViewIn Terminal,
@@ -248,7 +248,6 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
    */
   private shouldPinTheBlock(event: CommandCompleteEvent<ScalarResponse>) {
     return (
-      this.props.config.splitTerminals &&
       this.props.config.enableWatcherAutoPin &&
       !isPopup() &&
       isWatchable(event.response) &&
@@ -391,7 +390,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
       eventChannelUnsafe.off(`/terminal/clear/${state.uuid}`, clear)
     })
 
-    if (this.props.config.splitTerminals && !isPopup()) {
+    if ((this.props.config.splitTerminals || this.props.config.enableWatcherAutoPin) && !isPopup()) {
       const split = this.onSplit.bind(this)
       onSplit(state.uuid, split)
       state.cleaners.push(() => offSplit(state.uuid, split))


### PR DESCRIPTION
…abling splitTerminals

Fixes #5002

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
