### PR TITLE
fix: still see name-related breadcrumbs and short-name header with feature flag sidecarName 'heroText'

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Sidecar/TopNavSidecar.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/TopNavSidecar.tsx
@@ -181,8 +181,8 @@ export default class TopNavSidecar extends BaseSidecar<MultiModalResponse, Histo
     return { 'flex-direction': 'column' }
   }
 
-  /** return the name from the response */
-  private name(): string {
+  /** return the pretty name or unadulterated name from the response */
+  private prettyName(): string {
     return (
       this.current.response &&
       (this.current.response.prettyName ||
@@ -190,6 +190,7 @@ export default class TopNavSidecar extends BaseSidecar<MultiModalResponse, Histo
     )
   }
 
+  /** display the unadulterated name from the response as sidecar header */
   private namePart() {
     if (this.context.sidecarName === 'heroText') {
       return (
@@ -197,7 +198,9 @@ export default class TopNavSidecar extends BaseSidecar<MultiModalResponse, Histo
           <div className="sidecar-header-text">
             <div className="sidecar-header-name" data-base-class="sidecar-header-name">
               <div className="sidecar-header-name-content" data-base-class="sidecar-header-name-content">
-                {this.name()}
+                {this.current.response && this.current.response.metadata
+                  ? this.current.response.metadata.name
+                  : undefined}
               </div>
             </div>
           </div>
@@ -344,15 +347,13 @@ export default class TopNavSidecar extends BaseSidecar<MultiModalResponse, Histo
 
   /** show name as breadcrumb when not showing context as hero text in sidecar header  */
   private nameBreadcrumb(): BreadcrumbView {
-    if (this.context.sidecarName === 'breadcrumb') {
-      const { onclick } = this.current.response
+    const { onclick } = this.current.response
 
-      return {
-        label: this.name(),
-        command: onclick && onclick.name,
-        isCurrentPage: true,
-        className: 'kui--sidecar-entity-name'
-      }
+    return {
+      label: this.prettyName(),
+      command: onclick && onclick.name,
+      isCurrentPage: true,
+      className: 'kui--sidecar-entity-name'
     }
   }
 
@@ -390,14 +391,13 @@ export default class TopNavSidecar extends BaseSidecar<MultiModalResponse, Histo
       return <div />
     }
 
+    const nameBreadCrumbs =
+      this.context.sidecarName === 'breadcrumb'
+        ? [this.nameBreadcrumb(), this.versionBreadcrumb(), this.nameHashBreadcrumb()]
+        : []
+
     try {
-      const breadcrumbs = [
-        this.namespaceBreadcrumb(),
-        this.kindBreadcrumb(),
-        this.nameBreadcrumb(),
-        this.versionBreadcrumb(),
-        this.nameHashBreadcrumb()
-      ].filter(_ => _)
+      const breadcrumbs = [this.namespaceBreadcrumb(), this.kindBreadcrumb()].concat(nameBreadCrumbs).filter(_ => _)
 
       // Note: data-view helps with tests
       return (


### PR DESCRIPTION
Fixes #5013

Screenshot show the sidecar title with feature flag `sidecarName='heroText' `
![image](https://user-images.githubusercontent.com/21212160/85868892-e4d07480-b798-11ea-94cc-1e9e01899b34.png)

Otherwise:
![image](https://user-images.githubusercontent.com/21212160/85868940-fb76cb80-b798-11ea-8c6f-5359b0055521.png)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
