### PR TITLE
fix(plugins/plugin-client-common): `ok` string appears at the end of MixResponse

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
@@ -22,6 +22,7 @@ import {
   isHTML,
   isReactResponse,
   isMarkdownResponse,
+  isMixedResponse,
   isTable,
   eventChannelUnsafe,
   Tab as KuiTab,
@@ -194,6 +195,7 @@ export default class Output extends React.PureComponent<Props, State> {
         isMarkdownResponse(response) ||
         (typeof response === 'string' && response.length > 0) ||
         (isTable(response) && response.body.length > 0) ||
+        isMixedResponse(response) ||
         this.state.streamingOutput.length > 0
       )
     } else {


### PR DESCRIPTION
Fixes #5046

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
