### PR TITLE
fix: kubectl help misformats helm help tables

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown.tsx
@@ -135,7 +135,11 @@ export default class Markdown extends React.PureComponent<Props> {
             )
           },
           listItem: props => <ListItem className={props.className}>{props.children}</ListItem>,
-          table: props => <StructuredListWrapper className={props.className}>{props.children}</StructuredListWrapper>,
+          table: props => (
+            <StructuredListWrapper className={props.className + ' kui--table-like'}>
+              {props.children}
+            </StructuredListWrapper>
+          ),
           tableHead: props => <StructuredListHead className={props.className}>{props.children}</StructuredListHead>,
           tableBody: props => <StructuredListBody className={props.className}>{props.children}</StructuredListBody>,
           tableRow: props => (

--- a/plugins/plugin-kubectl/src/lib/util/help.ts
+++ b/plugins/plugin-kubectl/src/lib/util/help.ts
@@ -288,7 +288,7 @@ const renderHelpUnsafe = <O extends KubeOptions>(
               .join('\n')}\n`
         )
         .concat('\n\n')
-        .replace(/(--\S+)/g, '`$1`')
+        .replace(/(\s--\S+)/g, '`$1`')
         .replace(/^\n*([^\n.]+)(\.?)/, '### About\n#### $1')
         .replace(/\n\s*(Find more information at:)\s+([^\n]+)/, '') // [Find more information] will be in links below the menus
         .concat(!aliasesSection ? '' : `### Aliases\n${aliasesSection.content}`)


### PR DESCRIPTION
and any preformatted-as-markdown tables

Fixes #5080

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
