### PR TITLE
8.10.11

### DIFF
--- a/packages/core/src/core/events.ts
+++ b/packages/core/src/core/events.ts
@@ -285,12 +285,20 @@ class EventBus extends ReadEventBus {}
 export const eventBus = new EventBus()
 
 /**
+ * Hook an event listener up to tab events.
+ *
+ */
+export function wireToTabEvents(listener: () => void) {
+  eventBus.on('/tab/new', listener)
+  eventBus.on('/tab/switch/request', listener)
+}
+
+/**
  * Hook an event listener up to the family of standard user
  * interaction events.
  *
  */
 export function wireToStandardEvents(listener: () => void) {
-  eventBus.on('/tab/new', listener)
-  eventBus.on('/tab/switch/request', listener)
+  wireToTabEvents(listener)
   eventBus.onAnyCommandComplete(listener)
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,7 +67,7 @@ export { isUsageError, UsageError, UsageModel, UsageRow } from './core/usage-err
 export { isMessageWithUsageModel, isMessageWithCode } from './core/usage-error'
 
 // eventChannelUnsafe
-export { default as eventChannelUnsafe, wireToStandardEvents, eventBus } from './core/events'
+export { default as eventChannelUnsafe, wireToTabEvents, wireToStandardEvents, eventBus } from './core/events'
 
 // i18n
 export { fromMap as i18nFromMap, default as i18n } from './util/i18n'

--- a/plugins/plugin-kubectl/components/src/CurrentContext.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentContext.tsx
@@ -17,7 +17,14 @@
 import * as React from 'react'
 
 import { ViewLevel, TextWithIconWidget } from '@kui-shell/plugin-client-common'
-import { eventChannelUnsafe, getCurrentTab, wireToStandardEvents, inBrowser, i18n } from '@kui-shell/core'
+import {
+  eventChannelUnsafe,
+  getCurrentTab,
+  wireToTabEvents,
+  wireToStandardEvents,
+  inBrowser,
+  i18n
+} from '@kui-shell/core'
 import {
   getCurrentContextName,
   onKubectlConfigChangeEvents,
@@ -101,6 +108,7 @@ export default class CurrentContext extends React.PureComponent<{}, State> {
     this.reportCurrentContext()
 
     if (inBrowser()) {
+      wireToTabEvents(this.handler)
       onKubectlConfigChangeEvents(this.handler)
     } else {
       wireToStandardEvents(this.handler)

--- a/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
@@ -17,7 +17,14 @@
 import * as React from 'react'
 
 import { Icons, ViewLevel, TextWithIconWidget } from '@kui-shell/plugin-client-common'
-import { eventChannelUnsafe, getCurrentTab, wireToStandardEvents, inBrowser, i18n } from '@kui-shell/core'
+import {
+  eventChannelUnsafe,
+  getCurrentTab,
+  wireToTabEvents,
+  wireToStandardEvents,
+  inBrowser,
+  i18n
+} from '@kui-shell/core'
 import {
   KubeContext,
   getCurrentDefaultNamespace,
@@ -86,6 +93,7 @@ export default class CurrentNamespace extends React.PureComponent<{}, State> {
     this.reportCurrentNamespace()
 
     if (inBrowser()) {
+      wireToTabEvents(this.handler)
       onKubectlConfigChangeEvents(this.handler)
     } else {
       wireToStandardEvents(this.handler)


### PR DESCRIPTION
[8.10.11 6ddd4f71f] fix: CurrentContext and CurrentNamespace widgets may have stale data inBrowser
 Date: Wed Jul 8 18:24:44 2020 -0400
 4 files changed, 29 insertions(+), 5 deletions(-)