### PR TITLE
fix: views relying on tab switch events can still produce stale data

### DIFF
--- a/packages/core/src/core/events.ts
+++ b/packages/core/src/core/events.ts
@@ -44,6 +44,7 @@ class WriteEventBus extends EventBusBase {
   public emit(channel: '/tab/new' | '/tab/close' | '/tab/offline', tab: Tab): void
   public emit(channel: '/tab/new/request'): void
   public emit(channel: '/tab/switch/request', idx: number): void
+  public emit(channel: '/tab/switch/complete', tab: Tab): void
   public emit(channel: string, args?: any) {
     return this.eventBus.emit(channel, args)
   }
@@ -95,6 +96,7 @@ class ReadEventBus extends WriteEventBus {
 
   public on(channel: '/tab/new/request', listener: () => void): void
   public on(channel: '/tab/switch/request', listener: (tabId: number) => void): void
+  public on(channel: '/tab/switch/complete', listener: (tab: Tab) => void): void
   public on(channel: string, listener: any) {
     return this.eventBus.on(channel, listener)
   }
@@ -290,7 +292,7 @@ export const eventBus = new EventBus()
  */
 export function wireToTabEvents(listener: () => void) {
   eventBus.on('/tab/new', listener)
-  eventBus.on('/tab/switch/request', listener)
+  eventBus.on('/tab/switch/complete', listener)
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,7 +121,8 @@ export { exec as internalBeCarefulExec, pexec as internalBeCarefulPExec, setEval
 export { CommandStartEvent, CommandCompleteEvent } from './repl/events'
 
 // Tabs
-export { Tab, getCurrentTab, pexecInCurrentTab, getTabId, getPrimaryTabId, sameTab } from './webapp/tab'
+export { Tab, getTabId, getPrimaryTabId, sameTab } from './webapp/tab'
+export { getCurrentTab, pexecInCurrentTab } from './webapp/current-tab'
 export { default as TabState } from './models/tab-state'
 
 // Themes

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -58,8 +58,9 @@ import SymbolTable from '../core/symbol-table'
 import { getModel } from '../commands/tree'
 import { isSuccessfulCommandResolution } from '../commands/resolution'
 
-import { Tab, getCurrentTab, getTabId } from '../webapp/tab'
+import { Tab, getTabId } from '../webapp/tab'
 import { Block } from '../webapp/models/block'
+import { getCurrentTab } from '../webapp/current-tab'
 
 import { Stream, Streamable } from '../models/streamable'
 import enforceUsage from './enforce-usage'

--- a/packages/core/src/webapp/current-tab.ts
+++ b/packages/core/src/webapp/current-tab.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-19 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Tab from './tab'
+import { eventBus } from '../core/events'
+
+let currentTab: Tab
+if (eventBus) {
+  eventBus.on('/tab/switch/complete', (tab: Tab) => {
+    currentTab = tab
+  })
+}
+
+export const getCurrentTab = (): Tab => {
+  return currentTab
+}
+
+export function pexecInCurrentTab(command: string) {
+  const { facade: tab } = (currentTab.querySelector('.kui--scrollback') as any) as {
+    facade: Tab
+  }
+  return tab.REPL.pexec(command, { tab })
+}

--- a/packages/core/src/webapp/tab.ts
+++ b/packages/core/src/webapp/tab.ts
@@ -64,15 +64,4 @@ export const sameTab = (tab1: Tab, tab2: Tab): boolean => {
   return getTabId(tab1) === getTabId(tab2)
 }
 
-export const getCurrentTab = (): Tab => {
-  return document.querySelector('.kui--tab-content.visible') as Tab
-}
-
-export function pexecInCurrentTab(command: string) {
-  const { facade: tab } = (document.querySelector('.kui--tab-content.visible .kui--scrollback') as any) as {
-    facade: Tab
-  }
-  return tab.REPL.pexec(command, { tab })
-}
-
 export default Tab

--- a/plugins/plugin-client-common/src/components/Client/TabContent.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContent.tsx
@@ -18,11 +18,9 @@ import SplitPane from 'react-split-pane'
 import * as React from 'react'
 import { eventChannelUnsafe, eventBus, Tab as KuiTab, TabState, initializeSession } from '@kui-shell/core'
 
-import Alert from '../spi/Alert'
 import Icons from '../spi/Icons'
 import KuiContext from './context'
 import Confirm from '../Views/Confirm'
-import Loading from '../spi/Loading'
 import { TopTabButton } from './TabModel'
 import Width from '../Views/Sidecar/width'
 import WatchPane, { Height } from '../Views/WatchPane'
@@ -75,6 +73,9 @@ type State = Partial<WithTab> & {
   splitPaneImplHacked?: boolean
 
   activeView: CurrentlyShowing
+
+  /** have we announced that we are the active tab? */
+  haveAnnouncedAsActive?: boolean
 }
 
 /**
@@ -183,8 +184,15 @@ export default class TabContent extends React.PureComponent<Props, State> {
       } catch (err) {
         console.error(err)
       }
+    } else if (state.tab && props.active !== state.haveAnnouncedAsActive) {
+      if (props.active) {
+        eventBus.emit('/tab/switch/complete', state.tab)
+      }
+      return {
+        haveAnnouncedAsActive: props.active
+      }
     } else {
-      return state
+      return null
     }
   }
 


### PR DESCRIPTION
this is because we are wiring to the initiation of a tab switch, rather than the completion thereof
this PR adds a new /tab/switch/complete event, and updates the default awareness wiring to use that instead of /tab/switch/request

Fixes #5101

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
