### PR TITLE
fix: views relying on tab switch events can still produce stale data

### DIFF
--- a/packages/core/src/core/events.ts
+++ b/packages/core/src/core/events.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corporation
+ * Copyright 2017-2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ class WriteEventBus extends EventBusBase {
   public emit(channel: '/tab/new' | '/tab/close' | '/tab/offline', tab: Tab): void
   public emit(channel: '/tab/new/request'): void
   public emit(channel: '/tab/switch/request', idx: number): void
+  public emit(channel: '/tab/switch/complete', tab: Tab): void
   public emit(channel: string, args?: any) {
     return this.eventBus.emit(channel, args)
   }
@@ -95,6 +96,7 @@ class ReadEventBus extends WriteEventBus {
 
   public on(channel: '/tab/new/request', listener: () => void): void
   public on(channel: '/tab/switch/request', listener: (tabId: number) => void): void
+  public on(channel: '/tab/switch/complete', listener: (tab: Tab) => void): void
   public on(channel: string, listener: any) {
     return this.eventBus.on(channel, listener)
   }
@@ -290,7 +292,7 @@ export const eventBus = new EventBus()
  */
 export function wireToTabEvents(listener: () => void) {
   eventBus.on('/tab/new', listener)
-  eventBus.on('/tab/switch/request', listener)
+  eventBus.on('/tab/switch/complete', listener)
 }
 
 /**

--- a/plugins/plugin-client-common/src/components/Client/TabContent.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContent.tsx
@@ -18,11 +18,9 @@ import SplitPane from 'react-split-pane'
 import * as React from 'react'
 import { eventChannelUnsafe, eventBus, Tab as KuiTab, TabState, initializeSession } from '@kui-shell/core'
 
-import Alert from '../spi/Alert'
 import Icons from '../spi/Icons'
 import KuiContext from './context'
 import Confirm from '../Views/Confirm'
-import Loading from '../spi/Loading'
 import { TopTabButton } from './TabModel'
 import Width from '../Views/Sidecar/width'
 import WatchPane, { Height } from '../Views/WatchPane'
@@ -75,6 +73,9 @@ type State = Partial<WithTab> & {
   splitPaneImplHacked?: boolean
 
   activeView: CurrentlyShowing
+
+  /** have we announced that we are the active tab? */
+  haveAnnouncedAsActive?: boolean
 }
 
 /**
@@ -183,8 +184,15 @@ export default class TabContent extends React.PureComponent<Props, State> {
       } catch (err) {
         console.error(err)
       }
+    } else if (state.tab && props.active !== state.haveAnnouncedAsActive) {
+      if (props.active) {
+        eventBus.emit('/tab/switch/complete', state.tab)
+      }
+      return {
+        haveAnnouncedAsActive: props.active
+      }
     } else {
-      return state
+      return null
     }
   }
 


### PR DESCRIPTION
this is because we are wiring to the initiation of a tab switch, rather than the completion thereof
this PR adds a new /tab/switch/complete event, and updates the default awareness wiring to use that instead of /tab/switch/request

Fixes #5101

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
