### PR TITLE
fix: multiple issues with tab switching versus status stripe widgets

### DIFF
--- a/packages/core/src/core/events.ts
+++ b/packages/core/src/core/events.ts
@@ -288,7 +288,7 @@ export const eventBus = new EventBus()
  * Hook an event listener up to tab events.
  *
  */
-export function wireToTabEvents(listener: () => void) {
+export function wireToTabEvents(listener: (tab?: Tab | number) => void) {
   eventBus.on('/tab/new', listener)
   eventBus.on('/tab/switch/request', listener)
 }
@@ -298,7 +298,7 @@ export function wireToTabEvents(listener: () => void) {
  * interaction events.
  *
  */
-export function wireToStandardEvents(listener: () => void) {
+export function wireToStandardEvents(listener: (tab?: Tab | number) => void) {
   wireToTabEvents(listener)
-  eventBus.onAnyCommandComplete(listener)
+  eventBus.onAnyCommandComplete(() => listener())
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,7 +121,7 @@ export { exec as internalBeCarefulExec, pexec as internalBeCarefulPExec, setEval
 export { CommandStartEvent, CommandCompleteEvent } from './repl/events'
 
 // Tabs
-export { Tab, getCurrentTab, pexecInCurrentTab, getTabId, getPrimaryTabId, sameTab } from './webapp/tab'
+export { Tab, getTab, getCurrentTab, pexecInCurrentTab, getTabId, getPrimaryTabId, sameTab } from './webapp/tab'
 export { default as TabState } from './models/tab-state'
 
 // Themes

--- a/packages/core/src/models/tab-state.ts
+++ b/packages/core/src/models/tab-state.ts
@@ -156,12 +156,14 @@ export default class TabState {
   public restore() {
     process.env = this._env
 
-    if (inBrowser()) {
-      debug('changing cwd', process.env.PWD, this._cwd)
-      process.env.PWD = this._cwd
-    } else {
-      debug('changing cwd', process.cwd(), this._cwd)
-      process.chdir(this._cwd)
+    if (this._cwd !== undefined) {
+      if (inBrowser()) {
+        debug('changing cwd', process.env.PWD, this._cwd)
+        process.env.PWD = this._cwd
+      } else {
+        debug('changing cwd', process.cwd(), this._cwd)
+        process.chdir(this._cwd)
+      }
     }
   }
 }

--- a/packages/core/src/webapp/tab.ts
+++ b/packages/core/src/webapp/tab.ts
@@ -68,6 +68,16 @@ export const getCurrentTab = (): Tab => {
   return document.querySelector('.kui--tab-content.visible') as Tab
 }
 
+export const getTab = (idx: Tab | number): Tab => {
+  if (!idx) {
+    return getCurrentTab()
+  } else if (typeof idx === 'number') {
+    return document.querySelector(`.kui--tab-content[data-tab-id="${idx}"]`) as Tab
+  } else {
+    return idx
+  }
+}
+
 export function pexecInCurrentTab(command: string) {
   const { facade: tab } = (document.querySelector('.kui--tab-content.visible .kui--scrollback') as any) as {
     facade: Tab

--- a/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
@@ -213,7 +213,7 @@ export default class TabContainer extends React.PureComponent<Props, State> {
           tabs={this.state.tabs}
           onNewTab={() => this.onNewTab()}
           onCloseTab={(idx: number) => this.onCloseTab(idx)}
-          onSwitchTab={(idx: number) => this.onSwitchTab(idx)}
+          onSwitchTab={(idx: number) => eventBus.emit('/tab/switch/request', idx)}
         />
         <div className="tab-container">
           {this.state.tabs.map((_, idx) => (

--- a/plugins/plugin-kubectl/components/src/CurrentContext.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentContext.tsx
@@ -19,7 +19,8 @@ import * as React from 'react'
 import { ViewLevel, TextWithIconWidget } from '@kui-shell/plugin-client-common'
 import {
   eventChannelUnsafe,
-  getCurrentTab,
+  getTab,
+  Tab,
   wireToTabEvents,
   wireToStandardEvents,
   inBrowser,
@@ -75,8 +76,8 @@ export default class CurrentContext extends React.PureComponent<{}, State> {
     return context
   }
 
-  private async reportCurrentContext() {
-    const tab = getCurrentTab()
+  private async reportCurrentContext(idx?: Tab | number) {
+    const tab = getTab(idx)
     if (!tab || !tab.REPL) {
       if (tab && !tab.REPL) {
         eventChannelUnsafe.once(`/tab/new/${tab.uuid}`, () => this.reportCurrentContext())
@@ -105,8 +106,6 @@ export default class CurrentContext extends React.PureComponent<{}, State> {
    *
    */
   public componentDidMount() {
-    this.reportCurrentContext()
-
     if (inBrowser()) {
       wireToTabEvents(this.handler)
       onKubectlConfigChangeEvents(this.handler)

--- a/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
@@ -19,7 +19,8 @@ import * as React from 'react'
 import { Icons, ViewLevel, TextWithIconWidget } from '@kui-shell/plugin-client-common'
 import {
   eventChannelUnsafe,
-  getCurrentTab,
+  getTab,
+  Tab,
   wireToTabEvents,
   wireToStandardEvents,
   inBrowser,
@@ -56,8 +57,8 @@ export default class CurrentNamespace extends React.PureComponent<{}, State> {
     return context.metadata.namespace
   }
 
-  private async reportCurrentNamespace() {
-    const tab = getCurrentTab()
+  private async reportCurrentNamespace(idx?: Tab | number) {
+    const tab = getTab(idx)
     if (!tab || !tab.REPL) {
       if (tab && !tab.REPL) {
         eventChannelUnsafe.once(`/tab/new/${tab.uuid}`, () => this.reportCurrentNamespace())
@@ -90,8 +91,6 @@ export default class CurrentNamespace extends React.PureComponent<{}, State> {
    *
    */
   public componentDidMount() {
-    this.reportCurrentNamespace()
-
     if (inBrowser()) {
       wireToTabEvents(this.handler)
       onKubectlConfigChangeEvents(this.handler)


### PR DESCRIPTION
1) we have only a /tab/switch/request (i.e. the initiation, not the completion) of a tab switch; having a channel for the completion might be possible, but is more tricky

2) the tab-state save/restore logic sometimes smashes in undefined values, which can mess up the KUBECONFIG env

3) kube's CurrentContext and CurrentNamespace widgets were performing two queries on tab startup, when only one (each) is needed

Fixes #5101
Closes #5103 
Closes #5105 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
