### PR TITLE
fix: npm run proxy failed if the project is not named as 'kui'

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "watch:webpack": "bash -c \"npm run pty:nodejs && (npm run proxy &); npm run _watch $WATCH_ARGS\"",
     "watch:electron": "bash -c \"npm run pty:electron && TARGET=electron-renderer npm run _watch\"",
     "watch": "bash -c \"npm run kill; npm run compile && npm run link && concurrently -n ES6,WEBPACK --kill-others 'npm run watch:source' 'npm run watch:electron'\"",
-    "proxy": "export PORT=8081; export KUI_USE_HTTP=true; npm run pty:nodejs && cd packages/proxy/app && npm install && ../../../tools/travis/proxy.sh ../../../..",
+    "proxy": "export PORT=8081; export KUI_USE_HTTP=true; npm run pty:nodejs && cd packages/proxy/app && npm install && ../../../tools/travis/proxy.sh ../../..",
     "watch:source": "tsc --build tsconfig.json --watch",
     "compile:prep": "touch node_modules/@kui-shell/prescan.json",
     "compile:source:es6": "tsc --build tsconfig.json",

--- a/tools/travis/proxy.sh
+++ b/tools/travis/proxy.sh
@@ -29,7 +29,7 @@ SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 if [ -n "$1" ]; then
     ROOT=$(cd "$1" && pwd)
 else
-    ROOT=..
+    ROOT=$SCRIPTDIR/../..
 fi
 
 start() {
@@ -37,7 +37,7 @@ start() {
     echo "$PID" > /tmp/kuiproxy.pid
     echo "start proxy $PID"
 
-    cd "$ROOT"/kui/packages/proxy && ./app/bin/www &
+    cd "$ROOT"/packages/proxy && ./app/bin/www &
     SUB=$!
     echo $SUB > /tmp/kuiproxy_subprocess.pid
 


### PR DESCRIPTION
Fixes #5111

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
