### PR TITLE
fix(plugins/plugin-kubectl): CurrentNamespace/Context widgets not live

### DIFF
--- a/plugins/plugin-client-common/src/components/spi/RadioTable/impl/Carbon.tsx
+++ b/plugins/plugin-client-common/src/components/spi/RadioTable/impl/Carbon.tsx
@@ -123,7 +123,7 @@ export default class CarbonRadioTable extends React.PureComponent<Props, State> 
             <StructuredListCell
               head={head}
               key={cidx}
-              title={typeof cell !== 'string' && cell.title}
+              title={(typeof cell !== 'string' && cell.title) || undefined}
               data-is-name={cidx === row.nameIdx ? true : undefined}
               data-key={typeof cell !== 'string' ? cell.key : undefined}
               className={`kui--radio-table-cell ${radioTableHintsAsCss(cell) || ''}`}

--- a/plugins/plugin-kubectl/components/src/CurrentContext.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentContext.tsx
@@ -111,6 +111,7 @@ export default class CurrentContext extends React.PureComponent<{}, State> {
       onKubectlConfigChangeEvents(this.handler)
     } else {
       wireToStandardEvents(this.handler)
+      onKubectlConfigChangeEvents(this.handler)
     }
   }
 

--- a/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
@@ -96,6 +96,7 @@ export default class CurrentNamespace extends React.PureComponent<{}, State> {
       onKubectlConfigChangeEvents(this.handler)
     } else {
       wireToStandardEvents(this.handler)
+      onKubectlConfigChangeEvents(this.handler)
     }
   }
 

--- a/plugins/plugin-kubectl/src/controller/kubectl/get-namespaces.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get-namespaces.ts
@@ -171,19 +171,6 @@ async function asRadioTable(
     )
   }
 
-  // place default at the top of the table, unless it is selected, in
-  // which case the view will take care of things
-  const rowIdxForDefaultNS = body.findIndex(_ => _.name === 'default')
-  if (rowIdxForDefaultNS !== 0 && rowIdxForDefaultNS !== defaultSelectedIdx && body.length > 2) {
-    const defaultRow = radio.body[rowIdxForDefaultNS]
-    radio.body.splice(rowIdxForDefaultNS, 1) // delete the default row from body
-    radio.body.splice(0, 0, defaultRow) // insert the default row at the top
-
-    if (defaultSelectedIdx < rowIdxForDefaultNS) {
-      radio.defaultSelectedIdx += 1
-    }
-  }
-
   return radio
 }
 


### PR DESCRIPTION
regression from the switch to quiet execs for the onSelect handlers

Fixes #5144

this also fixes a react warning message that appears in the console from the title support added to RadioTables

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
