### PR TITLE
fix(plugins/plugin-kubectl): event footer watching should also support named resources

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/options.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/options.ts
@@ -153,6 +153,11 @@ export function getNamespaceForArgv(args: Arguments<KubeOptions>): string {
   return !ns ? '' : `-n ${ns}`
 }
 
+/** @return the resource names array as expressed in the command line */
+export function getResourceNamesForArgv(kindFromArgv: string, args: Arguments<KubeOptions>): string[] {
+  return args.argvNoOptions.slice(args.argvNoOptions.indexOf(kindFromArgv) + 1)
+}
+
 export function getContext(args: Arguments<KubeOptions>) {
   return args.parsedOptions.context
 }

--- a/plugins/plugin-kubectl/src/controller/kubectl/status.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/status.ts
@@ -402,7 +402,7 @@ class StatusWatcher implements Abortable, Watcher {
     this.resourcesToWaitFor
       .map((_, idx) => {
         const { kind, name, namespace } = _
-        const eventWatcher = new EventWatcher(this.args, this.command, kind, name, namespace, true, pusher)
+        const eventWatcher = new EventWatcher(this.args, this.command, kind, [name], namespace, true, pusher)
         eventWatcher.init()
         this.ptyJob.push(eventWatcher)
 

--- a/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
@@ -32,7 +32,7 @@ import {
 
 import { kindPart } from '../fqn'
 import { getKind } from '../explain'
-import { formatOf, getLabel, getNamespace, KubeOptions, KubeExecOptions } from '../options'
+import { formatOf, getLabel, getNamespace, getResourceNamesForArgv, KubeOptions, KubeExecOptions } from '../options'
 
 import { getCommandFromArgs } from '../../../lib/util/util'
 import { Pair, getNamespaceBreadcrumbs } from '../../../lib/view/formatTable'
@@ -100,7 +100,7 @@ export class EventWatcher implements Abortable, Watcher {
     private readonly args: Arguments,
     private readonly command: string,
     private readonly kindByUser: string,
-    private readonly name: string,
+    private readonly name: string[],
     private readonly namespace: string,
     private readonly watchOnly: boolean,
     private readonly pusher: WatchPusher
@@ -128,12 +128,15 @@ export class EventWatcher implements Abortable, Watcher {
         debug('rawData', rawData)
         this.eventLeftover = preprocessed.leftover === '\n' ? undefined : preprocessed.leftover
 
-        // format the row as `[ago] involvedObject.name: message`
-        const sortedRows = preprocessed.rows.filter(notEmpty).sort((rowA, rowB) => {
-          const lastSeenA = new Date(rowA[0].value).getTime()
-          const lastSeenB = new Date(rowB[0].value).getTime()
-          return lastSeenA - lastSeenB
-        })
+        // filter and format the row as `[ago] involvedObject.name: message`
+        const sortedRows = preprocessed.rows
+          .filter(notEmpty)
+          .filter(row => !this.name || this.name.length === 0 || this.name.includes(row[1].value)) // filter the rows with `involvedObject.name` specified by `this.name`
+          .sort((rowA, rowB) => {
+            const lastSeenA = new Date(rowA[0].value).getTime()
+            const lastSeenB = new Date(rowB[0].value).getTime()
+            return lastSeenA - lastSeenB
+          })
 
         const agos = sortedRows.map(row => {
           const ago = Date.now() - new Date(row[0].value).getTime()
@@ -169,9 +172,7 @@ export class EventWatcher implements Abortable, Watcher {
 
   public async init() {
     const fullKind = await getKind(this.command, this.args, this.kindByUser)
-    const filter = this.name
-      ? `--field-selector=involvedObject.kind=${fullKind},involvedObject.name=${this.name}`
-      : `--field-selector=involvedObject.kind=${fullKind}`
+    const filter = `--field-selector=involvedObject.kind=${fullKind}`
 
     const output = `--no-headers -o jsonpath='{.lastTimestamp}{"|"}{.involvedObject.name}{"|"}{.message}{"|\\n"}'`
     const watch = this.watchOnly ? '--watch-only' : '-w'
@@ -416,12 +417,19 @@ class KubectlWatcher implements Abortable, Watcher {
     const cmd = getCommandFromArgs(this.args)
     const namespace = await getNamespace(this.args)
     const kindByUser = this.args.argvNoOptions[this.args.argvNoOptions.indexOf('get') + 1]
-    const getWithResourceName = this.args.argvNoOptions.indexOf(kindByUser) !== this.args.argvNoOptions.length - 1
 
-    if (getWithResourceName || getLabel(this.args) || this.args.parsedOptions['field-selector']) {
-      debug('event watch not support')
+    if (getLabel(this.args) || this.args.parsedOptions['field-selector']) {
+      debug('event watcher does not support label and field selector')
     } else {
-      const eventWatcher = new EventWatcher(this.args, cmd, kindByUser, undefined, namespace, false, this.pusher)
+      const eventWatcher = new EventWatcher(
+        this.args,
+        cmd,
+        kindByUser,
+        getResourceNamesForArgv(kindByUser, this.args),
+        namespace,
+        false,
+        this.pusher
+      )
       eventWatcher.init()
       this.ptyJob.push(eventWatcher)
     }

--- a/plugins/plugin-kubectl/src/test/k8s2/events-in-table.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/events-in-table.ts
@@ -71,6 +71,23 @@ commands.forEach(command => {
       }
     })
 
+    it(`should watch with resource name and expect events`, async () => {
+      try {
+        const res = await CLI.command(`${command} get pods ${name} --watch ${inNamespace}`, this.app)
+        console.log('wait for pod to come up')
+        await this.app.client.waitUntil(async () => {
+          return ReplExpect.okWithCustom({ selector: Selectors.BY_NAME(name) })(res)
+        })
+
+        console.log('wait for events')
+        await this.app.client.waitUntil(async () => {
+          return (await currentEventCount(this.app, res.count)) > 0
+        })
+      } catch (err) {
+        return Common.oops(this, true)(err)
+      }
+    })
+
     deleteNS(this, ns)
   })
 


### PR DESCRIPTION
Fixes #5180

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
