### PR TITLE
fix(plugins/plugin-client-common): watch tables with with "No resources" should display that text inside the table

### DIFF
--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -123,6 +123,7 @@ export const TABLE_PAGINATION_FORWARD = (N: number) =>
 export const TABLE_PAGINATION_BACKWARD = (N: number) =>
   `${OUTPUT_N(N)} .kui--data-table-toolbar-pagination button.bx--pagination__button--backward`
 export const TABLE_FOOTER = (N: number) => `${OUTPUT_N(N)} .kui--data-table-footer-messages`
+export const TABLE_HAS_NO_RESOURCES = '.kui--data-table-has-no-resources'
 
 const _TABLE_AS_GRID = '.kui--data-table-as-grid'
 export const TABLE_AS_GRID = (N: number) => `${OUTPUT_N(N)} ${_TABLE_AS_GRID}`

--- a/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
@@ -48,7 +48,7 @@ export default class LivePaginatedTable extends PaginatedTable<LiveProps, LiveSt
   /** Render the component */
   public render() {
     if (this.props.onRender) {
-      setTimeout(() => this.props.onRender(this.state.rows.length > 0))
+      setTimeout(() => this.props.onRender(true))
     }
     return (
       <div data-table-watching={this.state.isWatching} data-table-as-grid={this.state.asGrid}>

--- a/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
@@ -207,6 +207,10 @@ export default class PaginatedTable<P extends Props, S extends State> extends Re
     }, {} as Record<string, boolean>)
   }
 
+  private noResources() {
+    return <div className="kui--data-table-has-no-resources kui--hero-text">{strings('No resources')}</div>
+  }
+
   private table() {
     const { tab, repl, response } = this.props
     const { headers, rows, page } = this.state
@@ -259,6 +263,7 @@ export default class PaginatedTable<P extends Props, S extends State> extends Re
     return (
       <React.Fragment>
         {includeToolbars && this.topToolbar(lightweightTables)}
+        {this.state.rows.length === 0 && this.noResources()}
         {this.state.asGrid ? this.grid(this.state.rows) : this.table()}
         {includeToolbars && this.bottomToolbar(lightweightTables)}
       </React.Fragment>

--- a/plugins/plugin-core-support/src/test/core-support2/history.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/history.ts
@@ -66,7 +66,7 @@ describe('command history', function(this: Common.ISuite) {
 
   it(`should list history with filter, expect nothing`, () =>
     CLI.command(`history gumbogumbo`, this.app)
-      .then(ReplExpect.justOK) // some random string that won't be in the command history
+      .then(ReplExpect.okWithCustom({ selector: Selectors.TABLE_HAS_NO_RESOURCES })) // some random string that won't be in the command history
       .catch(Common.oops(this)))
 
   it(`should delete command history`, () =>
@@ -76,7 +76,7 @@ describe('command history', function(this: Common.ISuite) {
 
   it(`should list history with no args after delete and expect nothing`, () =>
     CLI.command(`history`, this.app)
-      .then(ReplExpect.justOK)
+      .then(ReplExpect.okWithCustom({ selector: Selectors.TABLE_HAS_NO_RESOURCES }))
       .catch(Common.oops(this)))
 
   it(`should list history with idx arg after delete and expect only the previous`, () =>
@@ -91,6 +91,6 @@ describe('command history', function(this: Common.ISuite) {
 
   it(`should list history with idx and filter args after delete and expect nothing`, () =>
     CLI.command(`history 10 lls`, this.app)
-      .then(ReplExpect.justOK) // some random string that won't be in the command history
+      .then(ReplExpect.okWithCustom({ selector: Selectors.TABLE_HAS_NO_RESOURCES })) // some random string that won't be in the command history
       .catch(Common.oops(this)))
 })

--- a/plugins/plugin-kubectl/src/test/k8s2/aaa-watch-error-handling-via-table.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/aaa-watch-error-handling-via-table.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert'
-
 import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
 import { createNS, waitForGreen, waitForRed } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
 
@@ -72,19 +70,6 @@ wdescribe(`kubectl watch error handler via table ${process.env.MOCHA_RUN_TARGET 
     'error: the server doesn\'t have a resource type "shouldNotExist"'
   )
 
-  const resultHasEmptyWatchText = async (count: number, positive = true) => {
-    await this.app.client.waitForExist(Selectors.OK_N(count), CLI.waitTimeout)
-
-    await this.app.client.waitUntil(async () => {
-      const emptyWatchText = await this.app.client.getText(Selectors.OK_N(count))
-      if (positive) {
-        return emptyWatchText.includes('No resources')
-      } else {
-        return !emptyWatchText.includes('No resources')
-      }
-    }, CLI.waitTimeout)
-  }
-
   // here comes the tests should start watching successfully
   it(`should watch pods, starting from an non-existent namespace`, async () => {
     try {
@@ -93,11 +78,9 @@ wdescribe(`kubectl watch error handler via table ${process.env.MOCHA_RUN_TARGET 
       console.error('watch from non-existent namespace 0')
       // start to watch pods in a non-existent namespace
       const watchResult = await CLI.command(`k get pods -w -n ${ns}`, this.app).then(async result => {
-        await ReplExpect.ok(result)
+        await ReplExpect.okWithCustom({ selector: Selectors.TABLE_HAS_NO_RESOURCES })(result)
         return result
       })
-
-      await resultHasEmptyWatchText(watchResult.count)
 
       console.error('watch from non-existent namespace 1')
       // create the namespace
@@ -121,8 +104,6 @@ wdescribe(`kubectl watch error handler via table ${process.env.MOCHA_RUN_TARGET 
       await waitForGreen(this.app, watchStatus)
 
       console.error('watch from non-existent namespace 4')
-
-      await resultHasEmptyWatchText(watchResult.count, false)
 
       // delete the pod
       await CLI.command(`k delete pods nginx -n ${ns}`, this.app)


### PR DESCRIPTION
Fixes #5176

Screenshot below shows how empty watch tables look in normal terminal and minisplit with this PR. 
![Screen Shot 2020-07-17 at 3 09 46 PM](https://user-images.githubusercontent.com/21212160/87822556-ac740180-c83f-11ea-8ebc-93850ae08e52.png)


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
