### PR TITLE
fix(plugins/plugin-kubectl): drilldown command of resources in watch --all-namespace table doesn't have '-o yaml'

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
@@ -32,7 +32,15 @@ import {
 
 import { kindPart } from '../fqn'
 import { getKind } from '../explain'
-import { formatOf, isForAllNamespaces, getLabel, getNamespace, getResourceNamesForArgv, KubeOptions, KubeExecOptions } from '../options'
+import {
+  formatOf,
+  isForAllNamespaces,
+  getLabel,
+  getNamespace,
+  getResourceNamesForArgv,
+  KubeOptions,
+  KubeExecOptions
+} from '../options'
 
 import { getCommandFromArgs } from '../../../lib/util/util'
 import {
@@ -283,7 +291,9 @@ class KubectlWatcher implements Abortable, Watcher {
       }
     })
 
-    return formatTable(getCommandFromArgs(this.args), 'get', kind, this.args, allNamespacesTable)
+    const cmd = getCommandFromArgs(this.args)
+    const cmdForDrilldown = cmd === 'k' ? 'kubectl' : cmd
+    return formatTable(cmdForDrilldown, 'get', kind, this.args, allNamespacesTable)
   }
 
   /**


### PR DESCRIPTION
Fixes #5208

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
