### PR TITLE
feat: command history should be tab-specific

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ export {
 export { optionsToString as unparse } from './core/utility'
 export {
   ScalarResponse,
+  isScalarResponse,
   MetadataNamedResource,
   MixedResponse,
   isMixedResponse,
@@ -87,9 +88,9 @@ export { isWatchable, Watchable, Watcher, WatchPusher } from './core/jobs/watcha
 export { Abortable, FlowControllable } from './core/jobs/job'
 import { Tab } from './webapp/tab'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function History(tab: Tab) {
-  const model = (await import('./models/history')).default
-  return model
+import { getHistoryForTab } from './models/history'
+export function History(tab: string | Tab) {
+  return getHistoryForTab(typeof tab === 'string' ? tab : tab.uuid)
 }
 export { HistoryModel } from './models/history'
 

--- a/packages/core/src/models/command.ts
+++ b/packages/core/src/models/command.ts
@@ -31,6 +31,7 @@ import * as Yargs from 'yargs-parser'
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type KResponse<Content extends any = any> = Entity<Content>
+export default KResponse
 
 /**
  * "top-level", meaning the user hit enter in the CLI,

--- a/packages/core/src/models/entity.ts
+++ b/packages/core/src/models/entity.ts
@@ -18,8 +18,9 @@ import { isHTML } from '../util/types'
 import { Table, Row, isTable } from '../webapp/models/table'
 import { ToolbarText } from '../webapp/views/toolbar-text'
 import { UsageModel } from '../core/usage-error'
-import { MultiModalResponse } from './mmr/types'
-import { NavResponse } from './NavResponse'
+import isMultiModalResponse from './mmr/is'
+import MultiModalResponse from './mmr/types'
+import { NavResponse, isNavResponse } from './NavResponse'
 import RadioTable from './RadioTable'
 import Presentation from '../webapp/views/presentation'
 import { ReactNode, isValidElement } from 'react'
@@ -182,6 +183,10 @@ export function isRawResponse<Content extends RawContent>(entity: Entity<Content
  *
  */
 export type ScalarResponse<RowType extends Row = Row> = SimpleEntity | Table<RowType> | MixedResponse
+
+export function isScalarResponse(response: Entity): response is ScalarResponse {
+  return !isMultiModalResponse(response) && !isNavResponse(response)
+}
 
 export type ViewableResponse = MultiModalResponse | NavResponse | RadioTable
 

--- a/packages/core/src/models/mmr/is.ts
+++ b/packages/core/src/models/mmr/is.ts
@@ -21,3 +21,5 @@ export function isMultiModalResponse(entity: Entity): entity is MultiModalRespon
   const mmr = entity as MultiModalResponse
   return isMetadataBearing(mmr) && mmr.modes && Array.isArray(mmr.modes)
 }
+
+export default isMultiModalResponse

--- a/packages/core/src/repl/events.ts
+++ b/packages/core/src/repl/events.ts
@@ -27,9 +27,9 @@ export interface CommandStartEvent {
   echo: boolean
 }
 
-type ResponseTypeStr = 'MultiModalResponse' | 'NavResponse' | 'ScalarResponse' | 'Incomplete' | 'Error'
+export type ResponseType = 'MultiModalResponse' | 'NavResponse' | 'ScalarResponse' | 'Incomplete' | 'Error'
 
-export interface CommandCompleteEvent<R extends KResponse = KResponse, T extends ResponseTypeStr = ResponseTypeStr> {
+export interface CommandCompleteEvent<R extends KResponse = KResponse, T extends ResponseType = ResponseType> {
   tab: Tab
 
   command: string
@@ -45,10 +45,12 @@ export interface CommandCompleteEvent<R extends KResponse = KResponse, T extends
 
   response: R
   responseType: T
+
+  historyIdx: number
 }
 
 export type CommandStartHandler = (event: CommandStartEvent) => void
 
-export type CommandCompleteHandler<R extends KResponse = KResponse, T extends ResponseTypeStr = ResponseTypeStr> = (
+export type CommandCompleteHandler<R extends KResponse = KResponse, T extends ResponseType = ResponseType> = (
   event: CommandCompleteEvent<R, T>
 ) => void

--- a/packages/core/src/webapp/cancel.ts
+++ b/packages/core/src/webapp/cancel.ts
@@ -37,6 +37,7 @@ export default function doCancel(tab: Tab, block: Block) {
     execType: ExecType.TopLevel,
     cancelled: true,
     execUUID,
+    historyIdx: -1,
     command: undefined,
     argvNoOptions: undefined,
     execOptions: undefined,

--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -91,15 +91,35 @@ export const SIDECAR_CLOSE_BUTTON = `${SIDECAR} .sidecar-bottom-stripe-close a` 
 export const SIDECAR_RESUME_FROM_CLOSE_BUTTON = `${SIDECAR_BASE} .sidecar-bottom-stripe-close a` // resume button in minimized mode
 export const SIDECAR_FULLY_CLOSE_BUTTON = `${SIDECAR} .sidecar-bottom-stripe-quit a` // fully close button in the bottom stripe
 export const SIDECAR_FULLY_CLOSED = `${CURRENT_TAB} .kui--sidecar:not([data-visible])`
-export const PROCESSING_PROMPT_BLOCK = `${PROMPT_BLOCK}.repl-active`
-export const CURRENT_PROMPT_BLOCK = `${PROMPT_BLOCK}.repl-active`
+const current = (sel: string) => `${sel}.repl-active`
+export const PROCESSING_PROMPT_BLOCK = current(PROMPT_BLOCK)
+export const CURRENT_PROMPT_BLOCK = current(PROMPT_BLOCK)
+export const _PROMPT_BLOCK_N = (N: number) => `${_PROMPT_BLOCK}[data-input-count="${N}"]`
 export const PROMPT_BLOCK_N = (N: number) => `${PROMPT_BLOCK}[data-input-count="${N}"]`
 export const PROCESSING_N = (N: number) => `${PROMPT_BLOCK_N(N)}.processing`
 const _PROMPT = '.repl-input-element'
 export const CURRENT_PROMPT = `${CURRENT_PROMPT_BLOCK} ${_PROMPT}`
-export const PROMPT_N = (N: number) => `${PROMPT_BLOCK_N(N)} ${_PROMPT}`
-export const OUTPUT_N = (N: number) => `${PROMPT_BLOCK_N(N)} .repl-result`
-export const OUTPUT_N_STREAMING = (N: number) => `${PROMPT_BLOCK_N(N)} [data-stream]`
+
+/**
+ * Terminal splits
+ *
+ */
+export const NEW_SPLIT_BUTTON = '#kui--split-terminal-button'
+export const SPLITS = `${CURRENT_TAB} .kui--scrollback`
+export const SPLIT_N = (N: number) => `${SPLITS}:nth-child(${N})`
+export const SPLIT_N_OUTPUT = (N: number) => `${SPLITS}:nth-child(${N}) .repl-output`
+export const CURRENT_PROMPT_BLOCK_FOR_SPLIT = (splitIndex: number) => `${SPLIT_N(splitIndex)} ${current(_PROMPT_BLOCK)}`
+export const CURRENT_PROMPT_FOR_SPLIT = (splitIndex: number) =>
+  `${CURRENT_PROMPT_BLOCK_FOR_SPLIT(splitIndex)} ${_PROMPT}`
+export const PROMPT_BLOCK_N_FOR_SPLIT = (N: number, splitIndex: number) =>
+  `${SPLIT_N(splitIndex)} ${_PROMPT_BLOCK_N(N)}`
+export const PROMPT_N_FOR_SPLIT = (N: number, splitIndex: number) =>
+  `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} ${_PROMPT}`
+
+export const PROMPT_N = (N: number, splitIndex = 1) => `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} ${_PROMPT}`
+export const OUTPUT_N = (N: number, splitIndex = 1) => `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} .repl-result`
+export const OUTPUT_N_STREAMING = (N: number, splitIndex = 1) =>
+  `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} [data-stream]`
 export const OUTPUT_N_PTY = (N: number) => OUTPUT_N_STREAMING(N)
 export const PROMPT_BLOCK_LAST = `${PROMPT_BLOCK}:nth-last-child(2)`
 export const PROMPT_BLOCK_FINAL = `${PROMPT_BLOCK}:nth-last-child(1)`
@@ -111,9 +131,12 @@ export const PROMPT_FINAL = `${PROMPT_BLOCK_FINAL} .repl-input-element`
 export const OUTPUT_LAST = `${PROMPT_BLOCK_LAST} .repl-result`
 export const OUTPUT_LAST_STREAMING = `${PROMPT_BLOCK_LAST} [data-stream]`
 export const OUTPUT_LAST_PTY = OUTPUT_LAST_STREAMING
-export const LIST_RESULTS_N = (N: number) => `${PROMPT_BLOCK_N(N)} .repl-result tbody tr`
-export const LIST_RESULTS_BY_NAME_N = (N: number) => `${PROMPT_BLOCK_N(N)} .repl-result [data-name]`
-export const LIST_RESULT_BY_N_FOR_NAME = (N: number, name: string) => `${LIST_RESULTS_N(N)}[data-name="${name}"]`
+export const LIST_RESULTS_N = (N: number, splitIndex = 1) =>
+  `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} .repl-result tbody tr`
+export const LIST_RESULTS_BY_NAME_N = (N: number, splitIndex = 1) =>
+  `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} .repl-result [data-name]`
+export const LIST_RESULT_BY_N_FOR_NAME = (N: number, name: string, splitIndex = 1) =>
+  `${LIST_RESULTS_N(N, splitIndex)}[data-name="${name}"]`
 export const TABLE_HEADER_CELL = (cellKey: string) => `thead tr th button[data-key="${cellKey}"]`
 export const TABLE_CELL = (rowKey: string, cellKey: string) => `tbody [data-name="${rowKey}"] [data-key="${cellKey}"]`
 export const TABLE_SHOW_AS_GRID = (N: number) => `${OUTPUT_N(N)} .kui--toolbar-button-as-grid`
@@ -138,9 +161,9 @@ export const TABLE_TITLE_SECONDARY = (N: number) => `${OUTPUT_N(N)} .kui--second
 export const TABLE_TITLE_NROWS = (N: number) => `${OUTPUT_N(N)} .kui--nrows-breadcrumb`
 export const BY_NAME = (name: string) => `tbody [data-name="${name}"]`
 export const LIST_RESULT_FIRST = 'tbody tr:first-child .clickable'
-export const LIST_RESULT_BY_N_AND_NAME = (N: number, name: string) =>
-  `${LIST_RESULT_BY_N_FOR_NAME(N, name)} .entity-name`
-export const OK_N = (N: number) => `${PROMPT_BLOCK_N(N)} .repl-output .ok`
+export const LIST_RESULT_BY_N_AND_NAME = (N: number, name: string, splitIndex = 1) =>
+  `${LIST_RESULT_BY_N_FOR_NAME(N, name, splitIndex)} .entity-name`
+export const OK_N = (N: number, splitIndex = 1) => `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} .repl-output .ok`
 export const xtermRows = (N: number) => `${PROMPT_BLOCK_N(N)} .xterm-container .xterm-rows`
 
 export const WATCHER_N = (N: number) => `.kui--card.kui--card-${N}`
@@ -163,17 +186,6 @@ export const WATCHER_N_SHOW_AS_TABLE = (N: number) => WATCHER_N_DROPDOWN_ITEM(N,
 
 // terminal card
 export const TERMINAl_CARD = `.kui--card`
-
-/**
- * Terminal splits
- *
- */
-export const NEW_SPLIT_BUTTON = '#kui--split-terminal-button'
-export const SPLITS = `${CURRENT_TAB} .kui--scrollback`
-export const SPLIT_N = (N: number) => `${SPLITS}:nth-child(${N})`
-export const SPLIT_N_OUTPUT = (N: number) => `${SPLITS}:nth-child(${N}) .repl-output`
-export const CURRENT_PROMPT_BLOCK_FOR_SPLIT = (N: number) => `${SPLIT_N(N)} ${_PROMPT_BLOCK}`
-export const CURRENT_PROMPT_FOR_SPLIT = (N: number) => `${CURRENT_PROMPT_BLOCK_FOR_SPLIT(N)} ${_PROMPT}`
 
 export const CURRENT_GRID_FOR_SPLIT = (N: number) => `${CURRENT_PROMPT_BLOCK_FOR_SPLIT(N)} ${_PROMPT} ${_TABLE_AS_GRID}`
 export const CURRENT_GRID_BY_NAME_FOR_SPLIT = (N: number, name: string) =>

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -44,14 +44,18 @@ export type AnnouncementBlock = WithState<BlockState.ValidResponse> &
   WithCWD &
   WithAnnouncement
 type EmptyBlock = WithState<BlockState.Empty> & WithCWD
-type ErrorBlock = WithState<BlockState.Error> & WithCommand & WithResponse<Error> & WithUUID
+type ErrorBlock = WithState<BlockState.Error> & WithCommand & WithResponse<Error> & WithUUID & WithHistoryIndex
 type OkBlock = WithState<BlockState.ValidResponse> &
   WithCommand &
   WithResponse<ScalarResponse> &
   WithUUID &
+  WithHistoryIndex &
   WithPreferences
 export type ProcessingBlock = WithState<BlockState.Processing> & WithCommand & WithUUID & WithStartTime
 type CancelledBlock = WithState<BlockState.Cancelled> & WithCWD & WithCommand & WithUUID & WithStartTime
+
+/** Blocks with an association to the History model */
+type WithHistoryIndex = { historyIdx: number }
 
 /** FinishedBlocks are either ok, error, or cancelled */
 export type FinishedBlock = OkBlock | ErrorBlock | CancelledBlock | EmptyBlock
@@ -174,6 +178,7 @@ export function Finished(
   block: ProcessingBlock,
   response: ScalarResponse,
   cancelled: boolean,
+  historyIdx: number,
   prefersTerminalPresentation = false
 ): FinishedBlock {
   if (cancelled) {
@@ -181,6 +186,7 @@ export function Finished(
   } else if (isError(response)) {
     return {
       response,
+      historyIdx,
       cwd: block.cwd,
       command: block.command,
       state: BlockState.Error,
@@ -190,6 +196,7 @@ export function Finished(
   } else {
     return {
       response,
+      historyIdx,
       cwd: block.cwd,
       command: block.command,
       execUUID: block.execUUID,

--- a/plugins/plugin-core-support/src/test/core-support2/history-splits.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/history-splits.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI, ReplExpect } from '@kui-shell/test'
+import { expectSplits, focus, splitViaButton } from './split-helpers'
+
+function doEcho(this: Common.ISuite, msg: string, splitIndex = 1) {
+  const cmd = `echo ${msg}`
+
+  it(`should ${cmd}`, () =>
+    CLI.commandInSplit(cmd, this.app, splitIndex)
+      .then(ReplExpect.okWithPtyOutput(msg))
+      .catch(Common.oops(this, true)))
+
+  return cmd
+}
+
+function doValidate(this: Common.ISuite, num: number, msg: string, splitIndex = 1) {
+  it(`should list history ${num} expecting ${msg}`, () =>
+    CLI.commandInSplit(`history ${num}`, this.app, splitIndex)
+      .then(ReplExpect.okWith(msg))
+      .catch(Common.oops(this)))
+}
+
+describe('command history with splits', function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  const echo = doEcho.bind(this)
+  const split = splitViaButton.bind(this)
+  const focusOnSplit = focus.bind(this)
+  const validate1 = doValidate.bind(this, 1)
+  const validate2 = doValidate.bind(this, 2)
+  const validate5 = doValidate.bind(this, 5)
+  const count = expectSplits.bind(this)
+
+  const msg1 = 'xxxx'
+  const msg2 = 'yyyy'
+
+  count(1)
+  const cmd1 = echo(msg1)
+  validate1(cmd1)
+  count(1)
+
+  split(2)
+  count(2)
+  // focusOnSplit(2)
+
+  validate2(cmd1, 2) // history should have been copied over
+  const cmd2 = echo(msg2, 2)
+  count(2)
+  validate1(cmd2, 2) // msg2 better be the very last history entry
+  validate5(cmd1, 2) // msg1 had better be the fifth-last entry
+  count(2)
+
+  // msg2 better not be in the history for the first split
+  focusOnSplit(2, 1)
+  validate2(cmd1)
+  count(2)
+})

--- a/plugins/plugin-core-support/src/test/core-support2/split-helpers.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/split-helpers.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { notStrictEqual } from 'assert'
+import { CLI, Common, ReplExpect, Selectors } from '@kui-shell/test'
+
+/** Split the terminal in the current tab by using the split button */
+export function splitViaButton(this: Common.ISuite, splitCount: number) {
+  it(`should split the terminal via button in the current tab and expect splitCount=${splitCount}`, async () => {
+    try {
+      await this.app.client.click(Selectors.NEW_SPLIT_BUTTON)
+      await ReplExpect.splitCount(splitCount)(this.app)
+
+      await this.app.client.waitUntil(
+        () => this.app.client.hasFocus(Selectors.CURRENT_PROMPT_FOR_SPLIT(splitCount)),
+        CLI.waitTimeout
+      )
+    } catch (err) {
+      await Common.oops(this, true)(err)
+    }
+  })
+}
+
+/** Split the terminal in the current tab by using the "split" command */
+export function splitViaCommand(this: Common.ISuite, splitCount: number, expectErr = false) {
+  it(`should split the terminal via command in the current tab and expect splitCount=${splitCount}`, () =>
+    CLI.commandInSplit('split', this.app, splitCount - 1)
+      .then(expectErr ? ReplExpect.error(500) : ReplExpect.justOK)
+      .then(ReplExpect.splitCount(splitCount))
+      .catch(Common.oops(this, true)))
+}
+
+/** Close the split in the current tab by using the "exit" command */
+export function close(this: Common.ISuite, splitCount: number, inSplit: number) {
+  it(`should close the split via command in the current tab and expect splitCount=${splitCount}`, () =>
+    CLI.commandInSplit('exit', this.app, inSplit)
+      .then(() => ReplExpect.splitCount(splitCount)(this.app))
+      .catch(Common.oops(this, true)))
+}
+
+async function clickToFocus(this: Common.ISuite, toSplitIndex: number) {
+  console.error('1')
+  await this.app.client.click(Selectors.SPLIT_N(toSplitIndex))
+  console.error('2')
+  await this.app.client.waitUntil(
+    () => this.app.client.hasFocus(Selectors.CURRENT_PROMPT_FOR_SPLIT(toSplitIndex)),
+    CLI.waitTimeout
+  )
+  console.error('3', await this.app.client.hasFocus(Selectors.CURRENT_PROMPT_FOR_SPLIT(toSplitIndex)))
+}
+
+export function focus(this: Common.ISuite, toSplitIndex: number) {
+  const clickOn = clickToFocus.bind(this)
+  it(`should click to focus on split ${toSplitIndex}`, () => clickOn(toSplitIndex).catch(Common.oops(this, true)))
+}
+
+export function expectSplits(this: Common.ISuite, nSplits: number) {
+  it(`should have ${nSplits} split${nSplits === 1 ? '' : 's'}`, () => ReplExpect.splitCount(nSplits)(this.app))
+}
+
+/** Click to focus the given split */
+export function focusAndValidate(this: Common.ISuite, fromSplitIndex: number, toSplitIndex: number) {
+  it(`should click to focus from split ${fromSplitIndex} to split ${toSplitIndex}`, async () => {
+    try {
+      const res1 = await CLI.commandInSplit('split --debug', this.app, fromSplitIndex)
+      const N1 = res1.count
+      const id1 = await this.app.client.getText(Selectors.OUTPUT_N(N1))
+
+      await clickToFocus.bind(this)(toSplitIndex)
+
+      // last true: noFocus, since we want to do this ourselves
+      const res2 = await CLI.commandInSplit('split --debug', this.app, toSplitIndex)
+      const N2 = res2.count
+      const id2 = await this.app.client.getText(Selectors.OUTPUT_N(N2))
+      console.error('5')
+
+      notStrictEqual(id1, id2, 'the split identifiers should differ')
+    } catch (err) {
+      await Common.oops(this, true)
+    }
+  })
+}

--- a/plugins/plugin-core-support/src/test/core-support2/split-terminals.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/split-terminals.ts
@@ -19,91 +19,16 @@
  *
  */
 
-import { notStrictEqual } from 'assert'
 import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
+import { close, expectSplits, focusAndValidate, splitViaButton, splitViaCommand } from './split-helpers'
 
 /** Report Version */
-function version(this: Common.ISuite, splitCount: number) {
-  it(`should report proper version with splitCount=${splitCount}`, () =>
-    CLI.command('version', this.app)
+function version(this: Common.ISuite, splitIndex: number) {
+  it(`should report proper version with splitIndex=${splitIndex}`, () =>
+    CLI.commandInSplit('version', this.app, splitIndex)
       .then(ReplExpect.okWithCustom({ expect: Common.expectedVersion }))
-      .then(ReplExpect.splitCount(splitCount))
-      .catch(Common.oops(this)))
-}
-
-/** Split the terminal in the current tab by using the split button */
-function splitViaButton(this: Common.ISuite, splitCount: number) {
-  it(`should split the terminal via button in the current tab and expect splitCount=${splitCount}`, async () => {
-    try {
-      await this.app.client.click(Selectors.NEW_SPLIT_BUTTON)
-      await ReplExpect.splitCount(splitCount)(this.app)
-    } catch (err) {
-      await Common.oops(this, true)(err)
-    }
-  })
-}
-
-/** Split the terminal in the current tab by using the "split" command */
-function splitViaCommand(this: Common.ISuite, splitCount: number, expectErr = false) {
-  it(`should split the terminal via command in the current tab and expect splitCount=${splitCount}`, () =>
-    CLI.command('split', this.app)
-      .then(expectErr ? ReplExpect.error(500) : ReplExpect.justOK)
-      .then(ReplExpect.splitCount(splitCount))
+      .then(ReplExpect.splitCount(splitIndex))
       .catch(Common.oops(this, true)))
-}
-
-/** Close the split in the current tab by using the "exit" command */
-function close(this: Common.ISuite, splitCount: number) {
-  it(`should close the split via command in the current tab and expect splitCount=${splitCount}`, () =>
-    CLI.command('exit', this.app)
-      .then(() => ReplExpect.splitCount(splitCount)(this.app))
-      .catch(Common.oops(this, true)))
-}
-
-/** Click to focus the given split */
-function focus(this: Common.ISuite, fromSplitIndex: number, toSplitIndex: number) {
-  it(`should click to focus from split ${fromSplitIndex} to split ${toSplitIndex}`, async () => {
-    try {
-      const res1 = await CLI.command(
-        'split --debug',
-        this.app,
-        undefined,
-        undefined,
-        true,
-        Selectors.CURRENT_PROMPT_BLOCK_FOR_SPLIT(fromSplitIndex),
-        Selectors.CURRENT_PROMPT_FOR_SPLIT(fromSplitIndex)
-      )
-      const N1 = res1.count
-      const id1 = await this.app.client.getText(Selectors.OUTPUT_N(N1))
-
-      console.error('1')
-      await this.app.client.click(Selectors.SPLIT_N(toSplitIndex))
-      console.error('2')
-      await this.app.client.waitUntil(
-        () => this.app.client.hasFocus(Selectors.CURRENT_PROMPT_FOR_SPLIT(toSplitIndex)),
-        CLI.waitTimeout
-      )
-      console.error('3')
-
-      // last true: noFocus, since we want to do this ourselves
-      const res2 = await CLI.command(
-        'split --debug',
-        this.app,
-        undefined,
-        undefined,
-        true,
-        Selectors.CURRENT_PROMPT_BLOCK_FOR_SPLIT(toSplitIndex),
-        Selectors.CURRENT_PROMPT_FOR_SPLIT(toSplitIndex)
-      )
-      const N2 = res2.count
-      const id2 = await this.app.client.getText(Selectors.OUTPUT_N(N2))
-      console.error('5')
-
-      notStrictEqual(id1, id2, 'the split identifiers should differ')
-    } catch (err) {
-      await Common.oops(this, true)
-    }
-  })
 }
 
 describe(`split terminals ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
@@ -114,24 +39,36 @@ describe(`split terminals ${process.env.MOCHA_RUN_TARGET || ''}`, function(this:
   const splitTheTerminalViaButton = splitViaButton.bind(this)
   const splitTheTerminalViaCommand = splitViaCommand.bind(this)
   const closeTheSplit = close.bind(this)
-  const focusOnSplit = focus.bind(this)
+  const focusOnSplit = focusAndValidate.bind(this)
+  const count = expectSplits.bind(this)
 
   // here come the tests
 
+  count(1)
   splitTheTerminalViaCommand(2)
+  count(2)
   focusOnSplit(1, 2)
+  count(2)
   showVersion(2)
+  count(2)
   focusOnSplit(2, 1)
-  closeTheSplit(1)
+  count(2)
+  closeTheSplit(1, 2)
+  count(1)
+
   it('should still show version as the command, not exit', () => {
     return CLI.expectPriorInput(Selectors.PROMPT_N(1), 'version')
   })
 
   it('should refresh', () => Common.refresh(this))
 
+  count(1)
   showVersion(1)
+  count(1)
   splitTheTerminalViaButton(2)
+  count(2)
   showVersion(2)
+  count(2)
 
   /* if (MAX_TERMINALS === 3) {
     splitTheTerminalViaButton(3)
@@ -145,12 +82,17 @@ describe(`split terminals ${process.env.MOCHA_RUN_TARGET || ''}`, function(this:
     closeTheSplit(2)
   } */
 
-  closeTheSplit(1)
+  closeTheSplit(1, 2)
+  count(1)
   splitTheTerminalViaCommand(2)
-  closeTheSplit(1)
+  count(2)
+  closeTheSplit(1, 2)
+  count(1)
 
   splitTheTerminalViaCommand(2)
+  count(2)
   focusOnSplit(1, 2)
+  count(2)
 
   /* if (MAX_TERMINALS === 3) {
     splitTheTerminalViaCommand(3)


### PR DESCRIPTION
# Challenges

1) We want to have a consistent history presented for terminals in a given position; i.e. the Nth split in the Mth tab should always present the same command history, across sessions

2) Users may close splits and close tabs. If they close the last split in a tab, or the last tab, the first constraint is easy to maintain, because there is no reordering of the splits or tabs. If, however, they close some other split or tab other than the last, the first invariant must be reestablished

For example: start with 1 split, create a second split. Exit the *first* split. Now the previously second split is the apparent first (and only) split. Next create a new second split. Now the previously second split is the first split, and the new split is the second split. Which command history should the second split inherit?

# Solution

1) Instead of using a uuid.v4 to identify each split, use a uuid.v5.
2) Update command history to be indexed by the split identifier, rather than having a single global history.
3) The seed given to the v5 generator is an incrementing counter, *not* the split index. Until a split/tab is closed, the two are identical in the presented command history.
4) When the last split in a tab is closed, decrement the counter. This continues to preserve the above invariants.
5) When some other split is closed, don't decrement the counter. This will result in a fork of command history.
6) Whenever command history is forked, clone from the current first split.

The last point may need to be refined in the future: from which split does the new split fork?

Fixes #1299

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
