### PR TITLE
fix(plugins/plugin-kubectl): `oc get namespaces` doesn't produce a RadioTable

### DIFF
--- a/plugins/plugin-kubectl/oc/src/controller/oc/get/projects.ts
+++ b/plugins/plugin-kubectl/oc/src/controller/oc/get/projects.ts
@@ -46,7 +46,7 @@ export default function registerOcProjectGet(registrar: Registrar) {
     Object.assign({}, defaultFlags, { viewTransformer })
   )
 
-  const aliases = ['project', 'projects', 'ns', 'namespace']
+  const aliases = ['project', 'projects', 'ns', 'namespace', 'namespaces']
   aliases.forEach(ns => {
     registrar.listen(
       `/${commandPrefix}/oc/get/${ns}`,


### PR DESCRIPTION
Fixes #5227

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
