### PR TITLE
8.10.14

### DIFF
--- a/plugins/plugin-kubectl/oc/src/controller/oc/get/projects.ts
+++ b/plugins/plugin-kubectl/oc/src/controller/oc/get/projects.ts
@@ -46,7 +46,7 @@ export default function registerOcProjectGet(registrar: Registrar) {
     Object.assign({}, defaultFlags, { viewTransformer })
   )
 
-  const aliases = ['project', 'projects', 'ns', 'namespace']
+  const aliases = ['project', 'projects', 'ns', 'namespace', 'namespaces']
   aliases.forEach(ns => {
     registrar.listen(
       `/${commandPrefix}/oc/get/${ns}`,


### PR DESCRIPTION
[8.10.14 b0dbfe91d] fix(plugins/plugin-kubectl): `oc get namespaces` doesn't produce a RadioTable Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Tue Jul 21 13:50:45 2020 -0400
 1 file changed, 1 insertion(+), 1 deletion(-)
