### PR TITLE
fix(plugins/plugin-kubectl): kubernetes contexts table renders poorly

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/contexts.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/contexts.ts
@@ -20,8 +20,6 @@ import {
   RadioTable,
   RadioTableRow,
   radioTableCellToString,
-  radioTableAddHint,
-  CellShould,
   Table,
   isTable,
   Row,
@@ -75,7 +73,6 @@ function rtRowsFor(row: Row, wide: boolean): RadioTableRow {
           })
     )
 
-    radioTableAddHint(rtRow, rtRow.nameIdx, [CellShould.BeHidden])
     rtRow.nameIdx = 1
   }
 


### PR DESCRIPTION
1) blank rows when in minisplit
2) too narrow when not

Fixes #5230

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
