### PR TITLE
8.11.3

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Sidecar/ToolbarButton.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/ToolbarButton.tsx
@@ -21,6 +21,7 @@ import {
   ResourceWithMetadata,
   isViewButton,
   MultiModalResponse,
+  pexecInCurrentTab,
   ParsedOptions
 } from '@kui-shell/core'
 
@@ -59,7 +60,7 @@ export default class ToolbarButton<T extends ResourceWithMetadata = ResourceWith
       if (isViewButton(button) || button.confirm) {
         return tab.REPL.qexec(cmd, undefined, undefined, { rethrowErrors: true })
       } else {
-        return tab.REPL.pexec(cmd)
+        return pexecInCurrentTab(cmd)
       }
     } else {
       cmd(tab, response, args)

--- a/plugins/plugin-client-common/src/components/spi/RadioTable/impl/Carbon.tsx
+++ b/plugins/plugin-client-common/src/components/spi/RadioTable/impl/Carbon.tsx
@@ -91,18 +91,18 @@ export default class CarbonRadioTable extends React.PureComponent<Props, State> 
       breadcrumbs.push({ label: strings('nRows', table.body.length) })
     }
 
+    if (this.props.selectedIdx >= 0) {
+      const selectedRow = this.props.table.body[this.props.selectedIdx]
+      if (selectedRow.nameIdx !== undefined) {
+        breadcrumbs.push({ label: radioTableCellToString(selectedRow.cells[selectedRow.nameIdx]) })
+      }
+    }
+
     return <Toolbar className="kui--data-table-toolbar-top" breadcrumbs={breadcrumbs.length > 0 && breadcrumbs} />
   }
 
-  private bottomToolbar() {
-    if (this.props.selectedIdx >= 0) {
-      const selectedRow = this.props.table.body[this.props.selectedIdx]
-      return <Toolbar>{this.row(selectedRow, this.props.selectedIdx)}</Toolbar>
-    }
-  }
-
   private row(row: RadioTableRow, ridx: number, head = false, onSelect?: () => void) {
-    const isSelected = !onSelect && !head && ridx === this.props.selectedIdx - this.props.offset
+    const isSelected = !head && ridx === this.props.selectedIdx - this.props.offset
     const name = this.id(ridx)
 
     // notes: label is needed for selection
@@ -111,7 +111,11 @@ export default class CarbonRadioTable extends React.PureComponent<Props, State> 
         label
         head={head}
         key={ridx}
-        className={'kui--radio-table-row' + (head ? ' kui--radio-table-row--header-row' : '')}
+        className={
+          'kui--radio-table-row' +
+          (head ? ' kui--radio-table-row--header-row' : '') +
+          (isSelected ? ' kui--inverted-color-context bx--structured-list-row--selected' : '')
+        }
         data-name={row.nameIdx !== undefined ? radioTableCellToString(row.cells[row.nameIdx]) : name}
         data-is-selected={isSelected || undefined}
       >
@@ -164,9 +168,7 @@ export default class CarbonRadioTable extends React.PureComponent<Props, State> 
   private body() {
     return (
       <StructuredListBody className="kui--radio-table-body">
-        {this.props.table.body.map(
-          (row, idx) => idx !== this.props.selectedIdx && this.row(row, idx, false, row.onSelect)
-        )}
+        {this.props.table.body.map((row, idx) => this.row(row, idx, false, row.onSelect))}
       </StructuredListBody>
     )
   }
@@ -177,7 +179,6 @@ export default class CarbonRadioTable extends React.PureComponent<Props, State> 
         <div className="kui--screenshotable">
           <Card
             header={this.props.title && this.topToolbar()}
-            footer={this.bottomToolbar()}
             footerClassName="kui--inverted-color-context kui--no-padding"
           >
             <div className="kui--data-table-container">

--- a/plugins/plugin-client-common/src/controller/confirm.ts
+++ b/plugins/plugin-client-common/src/controller/confirm.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import { eventChannelUnsafe, getPrimaryTabId, Registrar, ExecType, UsageModel, i18n } from '@kui-shell/core'
+import {
+  eventChannelUnsafe,
+  getPrimaryTabId,
+  Registrar,
+  ExecType,
+  UsageModel,
+  i18n,
+  pexecInCurrentTab
+} from '@kui-shell/core'
 
 const strings = i18n('plugin-core-support')
 
@@ -57,7 +65,7 @@ export default async (commandTree: Registrar) => {
           if (!confirmed) {
             reject(strings('operationCancelled'))
           } else if (execOptions.type === ExecType.Nested) {
-            REPL.pexec(command, { tab }).then(resolve, reject)
+            pexecInCurrentTab(command).then(resolve, reject)
           } else {
             REPL.qexec(command, undefined, undefined, { tab }).then(resolve, reject)
           }

--- a/plugins/plugin-client-common/web/scss/components/RadioTable/Carbon.scss
+++ b/plugins/plugin-client-common/web/scss/components/RadioTable/Carbon.scss
@@ -21,7 +21,7 @@
 $max-body-height: 30rem;
 $min-body-width: 30rem;
 
-[kui-theme-style] .kui--radio-table .kui--radio-table-row:hover .bx--structured-list-svg {
+[kui-theme-style] .kui--radio-table .kui--radio-table-row:hover:not([data-is-selected]) .bx--structured-list-svg {
   fill: var(--color-text-02);
 }
 

--- a/plugins/plugin-client-common/web/scss/components/StructuredList/Carbon.scss
+++ b/plugins/plugin-client-common/web/scss/components/StructuredList/Carbon.scss
@@ -74,6 +74,13 @@
 }
 
 .bx--structured-list--selection
+  .bx--structured-list-row:hover:not(.bx--structured-list-row--header-row)
+  > .bx--structured-list-td,
+.bx--structured-list-row.bx--structured-list-row--selected > .bx--structured-list-td {
+  color: inherit;
+}
+
+.bx--structured-list--selection
   .bx--structured-list-row:hover:not(.bx--structured-list-row--header-row):not(.bx--structured-list-row--selected) {
   background-color: var(--color-ui-03);
   border-color: var(--color-table-border1);

--- a/plugins/plugin-client-common/web/scss/components/Table/tables.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/tables.scss
@@ -213,3 +213,11 @@ body[kui-theme-style] .kui--data-table-wrapper {
     overflow: auto;
   }
 }
+
+.kui--radio-table-row.kui--inverted-color-context.bx--structured-list-row--selected {
+  background-color: var(--color-sidecar-header);
+}
+
+[kui-theme-style='dark'] .kui--radio-table-row.kui--inverted-color-context.bx--structured-list-row--selected {
+  background-color: var(--color-sidecar-background);
+}

--- a/plugins/plugin-client-common/web/scss/components/Table/tables.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/tables.scss
@@ -161,8 +161,12 @@ body[kui-theme-style] .repl.sidecar-visible {
 
 .kui--scrollback div[data-table-watching] {
   @include full-width-tables;
-  .kui--data-table-container {
-    min-width: calc(1.5 * #{$min-body-width});
+}
+.kui--scrollback {
+  &:not([data-is-minisplit]):not([data-is-width-constrained]) .kui--data-table-container {
+    div[data-table-watching] {
+      min-width: calc(1.5 * #{$min-body-width});
+    }
   }
 }
 
@@ -205,7 +209,7 @@ body[kui-theme-style] .kui--data-table-wrapper {
 }
 
 /** inner scrolling for tall tables, when not in a minisplit */
-.kui--scrollback:not([data-is-minisplit]) {
+.kui--scrollback:not([data-is-minisplit]):not([data-is-width-constrained]) {
   .kui--data-table-container {
     min-width: $min-body-width;
     /* max-height: $max-body-height; see https://github.com/IBM/kui/issues/5221 */


### PR DESCRIPTION
[8.11.3 f61e7bb73] fix(plugins/plugin-client-commong): show RadioTable selected row in the table body and header breadcrumb
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Wed Jul 22 13:32:12 2020 -0400
 4 files changed, 28 insertions(+), 12 deletions(-)

[8.11.3 5847d19eb] fix(plugins/plugin-client-common): status column can be invisible in split tables
 Date: Wed Jul 22 16:42:41 2020 -0400
 1 file changed, 7 insertions(+), 3 deletions(-)

[8.11.3 ae794b316] fix(plugins/plugin-client-common): clicking on pod delete button can cause command to be executed in minisplit
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Wed Jul 22 17:37:58 2020 -0400
 2 files changed, 12 insertions(+), 3 deletions(-)