### PR TITLE
chore: bump patternfly dependence to 4.32.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kui-shell",
-  "version": "8.10.0",
+  "version": "8.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -359,21 +359,6 @@
         "tmp": "0.2.1",
         "uuid": "8.2.0",
         "yargs-parser": "18.1.3"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-          "requires": {
-            "rimraf": "^3.0.0"
-          }
-        },
-        "uuid": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
-          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
-        }
       }
     },
     "@kui-shell/plugin-bash-like": {
@@ -391,16 +376,6 @@
         "ws": "7.3.0",
         "xterm": "4.7.0",
         "xterm-addon-fit": "^0.4.0"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-          "requires": {
-            "rimraf": "^3.0.0"
-          }
-        }
       }
     },
     "@kui-shell/plugin-carbon-themes": {
@@ -413,26 +388,16 @@
       "version": "file:plugins/plugin-client-common",
       "requires": {
         "@carbon/icons-react": "10.9.2",
-        "@patternfly/react-core": "4.18.5",
+        "@patternfly/react-core": "4.32.1",
         "carbon-components": "10.10.2",
         "carbon-components-react": "7.10.2",
         "carbon-icons": "7.0.7",
-        "cli-spinners": "^2.3.0",
+        "cli-spinners": "^2.4.0",
         "monaco-editor": "0.20.0",
         "monaco-editor-webpack-plugin": "1.9.0",
         "react-markdown": "4.3.1",
         "react-split-pane": "0.1.91",
         "tmp": "0.2.1"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-          "requires": {
-            "rimraf": "^3.0.0"
-          }
-        }
       }
     },
     "@kui-shell/plugin-core-support": {
@@ -441,16 +406,6 @@
         "colors": "1.4.0",
         "debug": "4.1.1",
         "tmp": "0.2.1"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-          "requires": {
-            "rimraf": "^3.0.0"
-          }
-        }
       }
     },
     "@kui-shell/plugin-core-themes": {
@@ -460,7 +415,22 @@
       "version": "file:plugins/plugin-electron-components"
     },
     "@kui-shell/plugin-git": {
-      "version": "file:plugins/plugin-git"
+      "version": "file:plugins/plugin-git",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
     },
     "@kui-shell/plugin-ibmcloud": {
       "version": "file:plugins/plugin-ibmcloud",
@@ -491,14 +461,6 @@
             "universalify": "^1.0.0"
           }
         },
-        "pretty-ms": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.0.tgz",
-          "integrity": "sha512-J3aPWiC5e9ZeZFuSeBraGxSkGMOvulSWsxDByOcbD1Pr75YL3LSNIKIb52WXbCLE1sS5s4inBBbryjF4Y05Ceg==",
-          "requires": {
-            "parse-ms": "^2.1.0"
-          }
-        },
         "universalify": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
@@ -509,7 +471,6 @@
     "@kui-shell/plugin-kubectl": {
       "version": "file:plugins/plugin-kubectl",
       "requires": {
-        "ansi_up": "4.0.4",
         "bytes-iec": "3.1.0",
         "command-exists": "1.2.9",
         "debug": "4.1.1",
@@ -547,23 +508,10 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         },
-        "tmp": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-          "requires": {
-            "rimraf": "^3.0.0"
-          }
-        },
         "universalify": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
           "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
-        },
-        "uuid": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
-          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
         }
       }
     },
@@ -573,7 +521,7 @@
     "@kui-shell/plugin-patternfly4-themes": {
       "version": "file:plugins/plugin-patternfly4-themes",
       "requires": {
-        "@patternfly/react-core": "4.18.5"
+        "@patternfly/react-core": "4.32.1"
       }
     },
     "@kui-shell/plugin-proxy-support": {
@@ -591,16 +539,6 @@
         "es6-promise-pool": "2.5.0",
         "jquery": "3.5.0",
         "tmp": "0.2.1"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-          "requires": {
-            "rimraf": "^3.0.0"
-          }
-        }
       }
     },
     "@kui-shell/proxy": {
@@ -682,13 +620,13 @@
       }
     },
     "@patternfly/react-core": {
-      "version": "4.18.5",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.18.5.tgz",
-      "integrity": "sha512-wUHLXPOklcAVA9nCnmUvGwdfTZnypxNUnA0l+eEiq1QWhQoSRdI7S/HNOelYhpRjMMwPwy3yMsJUjHsXdqv2FQ==",
+      "version": "4.32.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.32.1.tgz",
+      "integrity": "sha512-4FrKJvMfjHjWtmvGu1QVxo/nCdUgePlkdNzMs91r0wdL16CpfoQVtZcfZe4343fRAQ2ObeYfZ2GuiwvS1sw8Og==",
       "requires": {
-        "@patternfly/react-icons": "^4.3.5",
-        "@patternfly/react-styles": "^4.3.4",
-        "@patternfly/react-tokens": "^4.4.4",
+        "@patternfly/react-icons": "^4.5.0",
+        "@patternfly/react-styles": "^4.5.0",
+        "@patternfly/react-tokens": "^4.6.0",
         "focus-trap": "4.0.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -696,19 +634,19 @@
       }
     },
     "@patternfly/react-icons": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.4.2.tgz",
-      "integrity": "sha512-zj740Zm6243iAZI8O/ar90uUL4sRUikM/wEyAahAtelrKP3bqmEOorWClE7cAa3w6TPHYsS7f+Szn5HyKXD/8w=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.5.0.tgz",
+      "integrity": "sha512-wXAENYa6nST4D8DBkiCrZXf4aRTmVQNA4cyImMJ3aQWAzwJ7Xc1zIBBuYSX5EP0JOuf9DzWVCrzvgfQz1Fcx8g=="
     },
     "@patternfly/react-styles": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.4.2.tgz",
-      "integrity": "sha512-bYLEJzFTSZLZ9zxSl4b8SZ07LoR0DPCghf23fqGljcTBA97zxA8rLV/cFvlmPTw7o/clhTqAZqwjvs+m8RMmtA=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.5.0.tgz",
+      "integrity": "sha512-6w8mvxx/cC+yUzBKlWY8YRnavlWCTLWly1si0skleYPF1t69f3P+jeXNy39kH6+o2vXJR5MeecLrnuMV0XtKvg=="
     },
     "@patternfly/react-tokens": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.5.2.tgz",
-      "integrity": "sha512-hw8o1KLR+VNBmoCxy1LekLHIDilHTNGdXAevj548V0sp0SkdQYLu7mzJNd9HN8OVLBabcrk6XXkx0g8c6YnyhQ=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.6.0.tgz",
+      "integrity": "sha512-zpA4AlYqJNJm5aqsarBVjod1gjP9muJ5oWI2ZwGUFiw4YNRn8eY7QKQ1VvNZxqwI+WSXl98jTqJiKuJGF3DEvw=="
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
@@ -797,9 +735,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.0.23",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
-          "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw=="
+          "version": "14.0.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.26.tgz",
+          "integrity": "sha512-W+fpe5s91FBGE0pEa0lnqGLL4USgpLgs4nokw16SrBBco/gQxuua7KnArSEOd5iaMqbbSHV10vUDkJYJJqpXKA=="
         }
       }
     },
@@ -903,9 +841,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.0.23",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
-          "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw=="
+          "version": "14.0.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.26.tgz",
+          "integrity": "sha512-W+fpe5s91FBGE0pEa0lnqGLL4USgpLgs4nokw16SrBBco/gQxuua7KnArSEOd5iaMqbbSHV10vUDkJYJJqpXKA=="
         }
       }
     },
@@ -982,9 +920,9 @@
       }
     },
     "@types/webpack-sources": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.0.tgz",
-      "integrity": "sha512-c88dKrpSle9BtTqR6ifdaxu1Lvjsl3C5OsfvuUbUwdXymshv1TkufUAXBajCCUM/f/TmnkZC/Esb03MinzSiXQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.1.tgz",
+      "integrity": "sha512-B/RJcbpMp1/od7KADJlW/jeXTEau6NYmhWo+hB29cEfRriYK9SRlH8sY4hI9Au7nrP95Z5MumGvIEiEBHMxoWA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -1388,11 +1326,6 @@
       "requires": {
         "entities": "^1.1.2"
       }
-    },
-    "ansi_up": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-4.0.4.tgz",
-      "integrity": "sha512-vRxC8q6QY918MbehO869biJW4tiunJdjOhi5fpY6NLOliBQlZhOkKgABJKJqH+JZfb/WfjvjN1chLWI6tODerw=="
     },
     "any-observable": {
       "version": "0.3.0",
@@ -2506,9 +2439,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001099",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001099.tgz",
-      "integrity": "sha512-sdS9A+sQTk7wKoeuZBN/YMAHVztUfVnjDi4/UV3sDE8xoh7YR12hKW+pIdB3oqKGwr9XaFL2ovfzt9w8eUI5CA==",
+      "version": "1.0.30001106",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001106.tgz",
+      "integrity": "sha512-XqSQKt9Fd3Z9BoN0cpSaITcTInKhMNGkaWtQ4rDnyQU1BJzzWDWCUi3cJflaPWk2kbrkYkfMrMrjIFzb3kd6NQ==",
       "dev": true
     },
     "carbon-components": {
@@ -2805,9 +2738,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.3.0.tgz",
-      "integrity": "sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
+      "integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA=="
     },
     "cli-truncate": {
       "version": "0.2.1",
@@ -3741,9 +3674,9 @@
       }
     },
     "date-fns": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.14.0.tgz",
-      "integrity": "sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.15.0.tgz",
+      "integrity": "sha512-ZCPzAMJZn3rNUvvQIMlXhDr4A+Ar07eLeGsGREoWU19a3Pqf5oYa+ccd+B3F6XVtQY6HANMFdOQ8A+ipFnvJdQ==",
       "dev": true
     },
     "debug": {
@@ -4295,9 +4228,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.497",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.497.tgz",
-      "integrity": "sha512-sPdW5bUDZwiFtoonuZCUwRGzsZmKzcLM0bMVhp6SMCfUG+B3faENLx3cE+o+K0Jl+MPuNA9s9cScyFjOlixZpQ==",
+      "version": "1.3.509",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.509.tgz",
+      "integrity": "sha512-cN4lkjNRuTG8rtAqTOVgwpecEC2kbKA04PG6YijcKGHK/kD0xLjiqExcAOmLUwtXZRF8cBeam2I0VZcih919Ug==",
       "dev": true
     },
     "elegant-spinner": {
@@ -4360,9 +4293,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.2.0.tgz",
-      "integrity": "sha512-S7eiFb/erugyd1rLb6mQ3Vuq+EXHv5cpCkNqqIkYkBgN2QdFnyCZzFBleqwGEx4lgNGYij81BWnCrFNK7vxvjQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+      "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -5005,9 +4938,9 @@
       "dev": true
     },
     "events": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
       "dev": true
     },
     "eventsource": {
@@ -6711,9 +6644,9 @@
           "dev": true
         },
         "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+          "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
@@ -6890,9 +6823,9 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.2.tgz",
-      "integrity": "sha512-DF4osh1FM6l0RJc5YWYhSDB6TawiBRlbV9Cox8MWlidU218Tb7fm3lQTULyUJDfJ0tjbzl0W4q651mrCCEM55w==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -6901,7 +6834,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.16",
+        "lodash": "^4.17.19",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
         "rxjs": "^6.6.0",
@@ -7843,9 +7776,9 @@
           "dev": true
         },
         "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+          "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
@@ -9182,9 +9115,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.59",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.59.tgz",
-      "integrity": "sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw==",
+      "version": "1.1.60",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
+      "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
       "dev": true
     },
     "noop-logger": {
@@ -10006,9 +9939,9 @@
       "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "portfinder": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
-      "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.27.tgz",
+      "integrity": "sha512-bJ3U3MThKnyJ9Dx1Idtm5pQmxXqw08+XOHhi/Lie8OF1OlhVaBFhsntAIhkZYjfDcCzszSr0w1yCbccThhzgxQ==",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
@@ -10298,15 +10231,15 @@
       }
     },
     "postcss-modules-local-by-default": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.2.tgz",
-      "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
+      "integrity": "sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==",
       "dev": true,
       "requires": {
         "icss-utils": "^4.1.1",
-        "postcss": "^7.0.16",
+        "postcss": "^7.0.32",
         "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.0.0"
+        "postcss-value-parser": "^4.1.0"
       }
     },
     "postcss-modules-scope": {
@@ -11399,9 +11332,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
       "dev": true
     },
     "regex-not": {
@@ -12175,9 +12108,9 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "simple-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
     },
     "simple-get": {
       "version": "3.1.0",
@@ -13566,7 +13499,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
       "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "dev": true,
       "requires": {
         "rimraf": "^3.0.0"
       }
@@ -14104,8 +14036,7 @@
     "uuid": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
-      "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==",
-      "dev": true
+      "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",
@@ -14185,12 +14116,12 @@
       }
     },
     "watchpack": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.2.tgz",
-      "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
+      "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
       "dev": true,
       "requires": {
-        "chokidar": "^3.4.0",
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0",
         "watchpack-chokidar2": "^2.0.0"
@@ -14215,9 +14146,9 @@
           "optional": true
         },
         "chokidar": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-          "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
+          "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
           "dev": true,
           "optional": true,
           "requires": {

--- a/plugins/plugin-client-common/package.json
+++ b/plugins/plugin-client-common/package.json
@@ -21,11 +21,11 @@
   "types": "mdist/index.d.ts",
   "dependencies": {
     "@carbon/icons-react": "10.9.2",
-    "@patternfly/react-core": "4.18.5",
+    "@patternfly/react-core": "4.32.1",
     "carbon-components": "10.10.2",
     "carbon-components-react": "7.10.2",
     "carbon-icons": "7.0.7",
-    "cli-spinners": "^2.3.0",
+    "cli-spinners": "^2.4.0",
     "monaco-editor": "0.20.0",
     "monaco-editor-webpack-plugin": "1.9.0",
     "react-markdown": "4.3.1",

--- a/plugins/plugin-kubectl/package.json
+++ b/plugins/plugin-kubectl/package.json
@@ -27,7 +27,6 @@
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
   "dependencies": {
-    "ansi_up": "4.0.4",
     "bytes-iec": "3.1.0",
     "command-exists": "1.2.9",
     "debug": "4.1.1",

--- a/plugins/plugin-patternfly4-themes/package.json
+++ b/plugins/plugin-patternfly4-themes/package.json
@@ -28,6 +28,6 @@
   },
   "gitHead": "89de9f78e8a1a2bdd29d2e17d7c608ab006c6d32",
   "dependencies": {
-    "@patternfly/react-core": "4.18.5"
+    "@patternfly/react-core": "4.32.1"
   }
 }


### PR DESCRIPTION
also removes an unused dependence from plugin-kubectl

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
