### PR TITLE
feat(plugins/plugin-client-common): History navigation in minisplits …

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,7 +92,7 @@ import { getHistoryForTab } from './models/history'
 export function History(tab: string | Tab) {
   return getHistoryForTab(typeof tab === 'string' ? tab : tab.uuid)
 }
-export { HistoryModel } from './models/history'
+export { HistoryModel, HistoryLine } from './models/history'
 
 // pretty printing
 export { prettyPrintTime } from './webapp/util/time'

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -74,6 +74,9 @@ export interface InputOptions {
 
   /** Block is about to lose focus */
   willLoseFocus?: () => void
+
+  /** Navigation controller */
+  navigateTo?(dir: 'first' | 'last' | 'previous' | 'next'): void
 }
 
 type InputProps = {

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
@@ -46,6 +46,9 @@ type Props = InputOptions & {
 
   noActiveInput?: boolean
 
+  /** Is this block the one currently displayed in a MiniSplit */
+  isVisibleInMiniSplit?: boolean
+
   noOutput?: boolean
   onOutputRender?: (idx: number) => void
 } & BlockViewTraits
@@ -154,6 +157,7 @@ export default class Block extends React.PureComponent<Props, State> {
           data-uuid={hasUUID(this.props.model) && this.props.model.execUUID}
           data-input-count={this.props.idx}
           data-is-focused={this.props.isFocused || undefined}
+          data-is-visible-in-minisplit={this.props.isVisibleInMiniSplit || undefined}
           ref={c => this.setState({ _block: c })}
         >
           {isAnnouncement(this.props.model) ? (

--- a/plugins/plugin-client-common/web/scss/components/Terminal/MiniSplit.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/MiniSplit.scss
@@ -42,7 +42,7 @@
     &:not(.repl-active):not(.processing) {
       flex: 1;
 
-      &:not(:nth-last-child(2)) {
+      &:not([data-is-visible-in-minisplit]) {
         display: none;
       }
     }


### PR DESCRIPTION
…should navigate In/Out pairs

i.e. rather than iterating through the In to the next command, as in a plain Terminal

Fixes #5270

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
