### PR TITLE
feat: initial/minimal snapshot/replay support

### DIFF
--- a/packages/core/src/core/events.ts
+++ b/packages/core/src/core/events.ts
@@ -23,7 +23,13 @@ import { ScalarResponse } from '../models/entity'
 import MultiModalResponse from '../models/mmr/types'
 import NavResponse from '../models/NavResponse'
 import Tab, { getPrimaryTabId } from '../webapp/tab'
-import { CommandStartEvent, CommandCompleteEvent, CommandStartHandler, CommandCompleteHandler } from '../repl/events'
+import {
+  CommandStartEvent,
+  CommandCompleteEvent,
+  CommandStartHandler,
+  CommandCompleteHandler,
+  SnapshotSplit
+} from '../repl/events'
 
 const eventChannelUnsafe = new EventEmitter()
 eventChannelUnsafe.setMaxListeners(100)
@@ -91,6 +97,21 @@ class WriteEventBus extends EventBusBase {
     }
   }
 
+  /** Indicate a new snapshotable element */
+  public emitAddSnapshotable(): void {
+    this.eventBus.emit('/snapshot/element/add')
+  }
+
+  /** Indicate a snapshotable element no longer exists */
+  public emitRemoveSnapshotable(): void {
+    this.eventBus.emit('/snapshot/element/remove')
+  }
+
+  /** Request a Snapshot of the given Tab */
+  public emitSnapshotRequest(cb: (snapshot: SnapshotSplit) => void): void {
+    this.eventBus.emit('/snapshot/request', cb)
+  }
+
   public emitWithTabId(channel: '/tab/offline' | '/tab/close/request', tabId: string, tab?: Tab): void {
     this.eventBus.emit(`${channel}/${tabId}`, tabId, tab)
   }
@@ -106,6 +127,25 @@ class ReadEventBus extends WriteEventBus {
   public on(channel: '/tab/switch/request', listener: (tabId: number) => void): void
   public on(channel: string, listener: any) {
     return this.eventBus.on(channel, listener)
+  }
+
+  /** Listen for snapshotable elements coming and going */
+  public onAddSnapshotable(listener: () => void) {
+    this.eventBus.on('/snapshot/element/add', listener)
+  }
+
+  public onRemoveSnapshotable(listener: () => void) {
+    this.eventBus.on('/snapshot/element/remove', listener)
+  }
+
+  /** Snapshot the Block state of the given Tab */
+  public onSnapshotRequest(listener: (cb: (snapshot: SnapshotSplit) => void) => void) {
+    this.eventBus.on(`/snapshot/request`, listener)
+  }
+
+  /** Snapshot the Block state of the given Tab */
+  public offSnapshotRequest(listener: (cb: (snapshot: SnapshotSplit) => void) => void) {
+    this.eventBus.off('/snapshot', listener)
   }
 
   /** User switching focus from one Split to another, within one Tab */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -120,7 +120,7 @@ export { split, _split, Split } from './repl/split'
 export { ReplEval, DirectReplEval } from './repl/types'
 export { default as encodeComponent } from './repl/encode'
 export { exec as internalBeCarefulExec, pexec as internalBeCarefulPExec, setEvaluatorImpl, doEval } from './repl/exec'
-export { CommandStartEvent, CommandCompleteEvent } from './repl/events'
+export { CommandStartEvent, CommandCompleteEvent, Snapshot, SnapshotSplit, SnapshotBlock } from './repl/events'
 
 // Tabs
 export { Tab, getTab, getCurrentTab, pexecInCurrentTab, getTabId, getPrimaryTabId, sameTab } from './webapp/tab'

--- a/packages/core/src/main/menu.ts
+++ b/packages/core/src/main/menu.ts
@@ -18,6 +18,7 @@
 
 import { productName } from '@kui-shell/client/config.d/name.json'
 import { Menu, MenuItemConstructorOptions } from 'electron'
+import open from './open'
 
 const isDev = false
 
@@ -64,9 +65,25 @@ const closeTab = () => tellRendererToExecute('tab close')
 const isDarwin = process.platform === 'darwin'
 const closeAccelerator = isDarwin ? 'Command+W' : 'Control+Shift+W'
 
-export const install = (createWindow: () => void) => {
+export const install = (createWindow: (executeThisArgvPlease?: string[]) => void) => {
   if (!isDev) {
     const fileMenuItems: MenuItemConstructorOptions[] = [
+      {
+        label: 'Open',
+        click: () => open(createWindow),
+        accelerator: 'CommandOrControl+O'
+      },
+      {
+        label: 'Open Recent',
+        role: 'recentdocuments' as any, // electron.d.ts insufficiency
+        submenu: [
+          {
+            label: 'Clear Recent',
+            role: 'clearrecentdocuments' as any // ibid
+          }
+        ]
+      },
+      { type: 'separator' },
       {
         label: 'New Window',
         click: () => createWindow(),

--- a/packages/core/src/main/open.ts
+++ b/packages/core/src/main/open.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Open a new window and replay the contents of the given `filepath` */
+export function replay(filepath: string, createWindow: (executeThisArgvPlease?: string[]) => void) {
+  createWindow(['replay', filepath])
+}
+
+/**
+ * Open a file and replay its session.
+ *
+ */
+export default async function open(createWindow: (executeThisArgvPlease?: string[]) => void) {
+  const { app, dialog } = await import('electron')
+  const resp = await dialog.showOpenDialog({
+    title: 'Select a Kui snapshot',
+    filters: [{ name: 'Kui snapshot', extensions: ['kui'] }]
+  })
+  if (!resp.canceled) {
+    resp.filePaths.forEach(filepath => {
+      app.addRecentDocument(filepath)
+      replay(filepath, createWindow)
+    })
+  }
+}

--- a/packages/core/src/models/history.ts
+++ b/packages/core/src/models/history.ts
@@ -44,9 +44,6 @@ export interface HistoryLine {
 
   /** Index into model */
   historyIdx: number
-
-  /** Is this line shown in the UI? */
-  isCurrentlyShown: boolean
 }
 
 /** A tuple of History entries, one per Tab (as specified by its given uuid) */
@@ -155,27 +152,8 @@ export class HistoryModel {
     return true
   }
 
-  /** Internal hide */
-  private hideAt(historyIdx: number) {
-    const line = this._lines[historyIdx]
-    if (line) {
-      line.isCurrentlyShown = false
-    }
-  }
-
-  /** Hide the given entry from future display */
-  public hide(historyIdx: number | number[]) {
-    debug('hiding', historyIdx)
-    if (typeof historyIdx === 'number') {
-      this.hideAt(historyIdx)
-    } else {
-      historyIdx.forEach(_ => this.hideAt(_))
-    }
-    this.save()
-  }
-
   /** add a line of repl history */
-  public add(line: Pick<HistoryLine, 'raw' | 'isCurrentlyShown'>): number {
+  public add(line: Pick<HistoryLine, 'raw'>): number {
     if (this._lines.length === 0 || JSON.stringify(this._lines[this._lines.length - 1]) !== JSON.stringify(line)) {
       // don't add sequential duplicates
       this._lines.push(Object.assign(line, { historyIdx: this._lines.length - 1 }))

--- a/packages/core/src/repl/events.ts
+++ b/packages/core/src/repl/events.ts
@@ -54,3 +54,37 @@ export type CommandStartHandler = (event: CommandStartEvent) => void
 export type CommandCompleteHandler<R extends KResponse = KResponse, T extends ResponseType = ResponseType> = (
   event: CommandCompleteEvent<R, T>
 ) => void
+
+/**
+ * SnapshotBlock: captures the start and complete of the command
+ * execution.
+ *
+ */
+export type SnapshotBlock = {
+  startEvent: Omit<CommandStartEvent, 'tab'>
+  completeEvent: Omit<CommandCompleteEvent, 'tab'>
+}
+
+export type SnapshotSplit = {
+  uuid: string
+  blocks: SnapshotBlock[]
+}
+
+export type SnapshotTab = {
+  uuid: string
+  splits: SnapshotSplit[]
+}
+
+export type SnapshotWindow = {
+  uuid: string
+  tabs: SnapshotTab[]
+}
+
+/**
+ * Snapshot: captures the block-level snapshots across the entire
+ * session.
+ *
+ */
+export type Snapshot = {
+  windows: SnapshotWindow[]
+}

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -159,8 +159,7 @@ class InProcessExecutor implements Executor {
         if (!execOptions || execOptions.type !== ExecType.Nested) {
           const historyModel = getHistoryForTab(tab.uuid)
           return (execOptions.history = historyModel.add({
-            raw: command,
-            isCurrentlyShown: true
+            raw: command
           }))
         }
       }

--- a/plugins/plugin-client-common/src/components/Client/Kui.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Kui.tsx
@@ -23,6 +23,7 @@ import {
   i18n,
   REPL,
   Theme,
+  pexecInCurrentTab,
   inBrowser,
   eventChannelUnsafe,
   findThemeByName,
@@ -207,6 +208,14 @@ export class Kui extends React.PureComponent<Props, State> {
     console.error(error, errorInfo)
   }
 
+  private onTabReady() {
+    if (this.props.commandLine) {
+      pexecInCurrentTab(this.props.commandLine.join(' '))
+    }
+  }
+
+  private readonly _onTabReady = this.onTabReady.bind(this)
+
   public render() {
     if (!this.state.isBootstrapped) {
       return <Loading />
@@ -222,11 +231,14 @@ export class Kui extends React.PureComponent<Props, State> {
       )
     } else {
       const bottom = !!this.props.bottomInput && <InputStripe>{this.props.bottomInput}</InputStripe>
-
       return (
         <KuiContext.Provider value={this.state}>
           <div className="kui--full-height">
-            <TabContainer noActiveInput={!!this.props.bottomInput} bottom={bottom}>
+            <TabContainer
+              noActiveInput={!!this.props.bottomInput}
+              bottom={bottom}
+              onTabReady={this.props.commandLine && this._onTabReady}
+            >
               <ComboSidecar />
             </TabContainer>
             {this.props.toplevel}

--- a/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
@@ -43,6 +43,9 @@ interface State {
   /** list of current tabs; one TabContent for each */
   tabs: TabModel[]
 
+  /** Has the first tab activated itself? */
+  isFirstTabReady: boolean
+
   /** current active tab index */
   activeIdx: number
 }
@@ -53,6 +56,7 @@ export default class TabContainer extends React.PureComponent<Props, State> {
 
     this.state = {
       tabs: [this.newTabModel()],
+      isFirstTabReady: false,
       activeIdx: 0
     }
 
@@ -204,6 +208,13 @@ export default class TabContainer extends React.PureComponent<Props, State> {
     })
   }
 
+  private onTabReady(tab: Tab) {
+    if (this.props.onTabReady) {
+      this.props.onTabReady(tab)
+    }
+    this.setState({ isFirstTabReady: true })
+  }
+
   public render() {
     return (
       <div className="kui--full-height">
@@ -222,6 +233,9 @@ export default class TabContainer extends React.PureComponent<Props, State> {
               uuid={_.uuid}
               active={idx === this.state.activeIdx}
               willUpdateTopTabButtons={this.willUpdateTopTabButtons.bind(this, _.uuid)}
+              onTabReady={
+                idx === 0 && this.props.onTabReady && !this.state.isFirstTabReady && this.onTabReady.bind(this)
+              }
               state={_.state}
               {...this.props}
             >

--- a/plugins/plugin-client-common/src/components/Client/TabContent.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContent.tsx
@@ -43,13 +43,14 @@ interface WithTab {
 export type TabContentOptions = TerminalOptions & {
   /** [Optional] elements to be placed below the Terminal */
   bottom?: React.ReactElement<WithTabUUID & WithTab>
+
+  onTabReady?: (tab: KuiTab) => void
 }
 
 type Props = TabContentOptions &
   WithTabUUID & {
     active: boolean
     state: TabState
-    onTabReady?: (tab: KuiTab) => void
     willUpdateTopTabButtons?: (buttons: TopTabButton[]) => void
   }
 

--- a/plugins/plugin-core-support/src/lib/cmds/replay.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/replay.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { eventBus, Snapshot, SnapshotSplit, Registrar, UsageModel } from '@kui-shell/core'
+
+/**
+ * Schema for a serialized snapshot of the Inputs and Outputs of
+ * command executions.
+ */
+interface SerializedSnapshot {
+  apiVersion: 'kui-shell/v1'
+  kind: 'Snapshot'
+  spec: Snapshot
+}
+
+/** @return wether or not the given `raw` json is an instance of SerializedSnapshot */
+function isSerializedSnapshot(raw: Record<string, any>): raw is SerializedSnapshot {
+  const model = raw as SerializedSnapshot
+  return model.apiVersion === 'kui-shell/v1' && model.kind === 'Snapshot' && Array.isArray(model.spec.windows)
+}
+
+/** For the Kui command registration: enforce one mandatory positional parameter */
+function usage(cmd: string): { usage: UsageModel } {
+  return { usage: { strict: cmd, required: [{ name: '<filepath>', docs: 'path to saved snapshot' }] } }
+}
+
+let nSnapshotable = 0
+export function preload() {
+  eventBus.onAddSnapshotable(() => nSnapshotable++)
+  eventBus.onRemoveSnapshotable(() => nSnapshotable--)
+}
+
+/** Command registration */
+export default function(registrar: Registrar) {
+  // register the `replay` command
+  registrar.listen(
+    '/replay',
+    async ({ argvNoOptions, REPL, tab }) => {
+      const filepath = argvNoOptions[argvNoOptions.indexOf('replay') + 1]
+      const model = JSON.parse(
+        (await REPL.rexec<{ data: string }>(`fstat ${REPL.encodeComponent(filepath)} --with-data`)).content.data
+      )
+
+      if (!isSerializedSnapshot(model)) {
+        console.error('invalid snapshot', model)
+        throw new Error('Invalid snapshot')
+      } else {
+        // TODO only replaying the first split
+        model.spec.windows[0].tabs[0].splits[0].blocks.forEach(({ startEvent, completeEvent }) => {
+          eventBus.emitCommandStart(Object.assign(startEvent, { tab }))
+          eventBus.emitCommandComplete(Object.assign(completeEvent, { tab }))
+        })
+
+        return true
+      }
+    },
+    usage('replay')
+  )
+
+  // register the `snapshot` command
+  registrar.listen(
+    '/snapshot',
+    ({ argvNoOptions, REPL }) =>
+      new Promise((resolve, reject) => {
+        const splits: SnapshotSplit[] = []
+
+        eventBus.emitSnapshotRequest(async (split: SnapshotSplit) => {
+          splits.push(split)
+          console.error('!!!!', splits.length, nSnapshotable)
+
+          if (splits.length === nSnapshotable) {
+            try {
+              const filepath = argvNoOptions[argvNoOptions.indexOf('snapshot') + 1]
+              const snapshot: SerializedSnapshot = {
+                apiVersion: 'kui-shell/v1',
+                kind: 'Snapshot',
+                spec: {
+                  windows: [
+                    {
+                      uuid: '0',
+                      tabs: [
+                        {
+                          uuid: '0',
+                          splits
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+              const data = JSON.stringify(snapshot)
+              await REPL.rexec<{ data: string }>(`fwrite ${REPL.encodeComponent(filepath)}`, { data })
+
+              resolve(true)
+            } catch (err) {
+              reject(err)
+            }
+          }
+        })
+      }),
+    usage('snapshot')
+  )
+}

--- a/plugins/plugin-core-support/src/plugin.ts
+++ b/plugins/plugin-core-support/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-19 IBM Corporation
+ * Copyright 2017-20 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import quit from './lib/cmds/quit'
 import clear from './lib/cmds/clear'
 import base64 from './lib/cmds/base64'
 import prompt from './lib/cmds/prompt'
+import replay from './lib/cmds/replay'
 import sleep from './lib/cmds/sleep'
 import history from './lib/cmds/history/history'
 import tabManagement from './lib/cmds/tab-management'
@@ -40,6 +41,7 @@ export default async (commandTree: Registrar) => {
     clear(commandTree),
     base64(commandTree),
     prompt(commandTree),
+    replay(commandTree),
     sleep(commandTree),
     history(commandTree),
     tabManagement(commandTree)

--- a/plugins/plugin-core-support/src/preload.ts
+++ b/plugins/plugin-core-support/src/preload.ts
@@ -29,6 +29,7 @@ const registration: PreloadRegistration = () => {
 
   if (!isHeadless()) {
     asyncs.push(import('./lib/cmds/zoom').then(_ => _.preload()))
+    asyncs.push(import('./lib/cmds/replay').then(_ => _.preload()))
   }
 
   return Promise.all(asyncs)

--- a/plugins/plugin-core-support/src/test/core-support/replay.ts
+++ b/plugins/plugin-core-support/src/test/core-support/replay.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI, ReplExpect, Selectors, SidecarExpect, testAbout } from '@kui-shell/test'
+
+const base64Input = 'hi'
+const base64Output = Buffer.from(base64Input).toString('base64')
+
+describe(`snapshot and replay ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  it(`should base64 ${base64Input}`, () =>
+    CLI.command(`base64 ${base64Input}`, this.app)
+      .then(ReplExpect.okWithString(base64Output))
+      .catch(Common.oops(this, true)))
+  testAbout(this)
+
+  it('should snapshot', () =>
+    CLI.command('snapshot /tmp/test.kui', this.app)
+      .then(ReplExpect.justOK)
+      .catch(Common.oops(this, true)))
+
+  it('should refresh', () => Common.refresh(this))
+
+  it('should replay', async () => {
+    try {
+      const { count } = await CLI.command('replay /tmp/test.kui', this.app)
+
+      // verify the base64 command replay
+      let idx = 0
+      await this.app.client.waitUntil(async () => {
+        const txt = await this.app.client.getText(Selectors.OUTPUT_N(count))
+        if (++idx > 5) {
+          console.error(`still waiting for expected=${txt}; actual=${txt}`)
+        }
+        return txt === base64Output
+      }, CLI.waitTimeout)
+
+      // verify the about replay
+      await SidecarExpect.open(this.app)
+    } catch (err) {
+      await Common.oops(this, true)
+    }
+  })
+})


### PR DESCRIPTION
Limitations:

1) only snapshots and replays the commands of the current tab
2) inconsistency between clearing of terminal and replay; clearing will not close the sidecar, but after a replay, the sidecar won't be open

Fixes #5280

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
