### PR TITLE
fix(packages/core): repl exec should invoke commands separated by semicolon

### DIFF
--- a/packages/core/src/core/repl.ts
+++ b/packages/core/src/core/repl.ts
@@ -25,6 +25,6 @@ export { encodeComponent }
 import { split, _split, Split } from '../repl/split'
 export { split, _split, Split }
 
-export { exec, click, semicolonInvoke, qexec, pexec, rexec, getImpl, setEvaluatorImpl } from '../repl/exec'
+export { exec, click, qexec, pexec, rexec, getImpl, setEvaluatorImpl } from '../repl/exec'
 
 export { ReplEval, DirectReplEval } from '../repl/types'

--- a/packages/core/src/models/repl.ts
+++ b/packages/core/src/models/repl.ts
@@ -15,8 +15,8 @@
  */
 
 import { Tab } from '../webapp/tab'
-import { MixedResponse, RawContent, RawResponse } from './entity'
-import { EvaluatorArgs, KResponse } from './command'
+import { RawContent, RawResponse } from './entity'
+import { KResponse } from './command'
 import { ExecOptions } from './execOptions'
 
 export default interface REPL {
@@ -63,13 +63,6 @@ export default interface REPL {
    *
    */
   update(tab: Tab, command: string, execOptions?: ExecOptions): Promise<void>
-
-  /**
-   * If the command is semicolon-separated, invoke each element of the
-   * split separately
-   *
-   */
-  semicolonInvoke(opts: EvaluatorArgs): Promise<MixedResponse>
 
   /**
    * Prepare a string to be part of a `command` argument to the *exec

--- a/packages/core/src/repl/types.ts
+++ b/packages/core/src/repl/types.ts
@@ -17,6 +17,7 @@
 import { CodedError } from '../models/errors'
 import { ExecOptions } from '../models/execOptions'
 import { Evaluator, EvaluatorArgs, KResponse, ParsedOptions } from '../models/command'
+import { MixedResponse } from '../models/entity'
 
 /**
  * repl.exec, and the family repl.qexec, repl.pexec, etc. are all
@@ -28,7 +29,7 @@ export interface Executor {
   exec<T extends KResponse, O extends ParsedOptions>(
     commandUntrimmed: string,
     execOptions: ExecOptions
-  ): Promise<T | CodedError<number> | HTMLElement>
+  ): Promise<T | CodedError<number> | HTMLElement | MixedResponse>
 }
 
 /**

--- a/plugins/plugin-bash-like/fs/src/lib/ls.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/ls.ts
@@ -237,10 +237,7 @@ function toTable(entries: GlobStats[], args: Arguments<LsOptions>): HTMLElement 
  *
  */
 const doLs = (cmd: string) => async (opts: Arguments<LsOptions>): Promise<MixedResponse | HTMLElement | Table> => {
-  const semi = await opts.REPL.semicolonInvoke(opts)
-  if (semi) {
-    return semi
-  } else if (/\|/.test(opts.command)) {
+  if (/\|/.test(opts.command)) {
     // conservatively send possibly piped output to the PTY
     return opts.REPL.qexec(`sendtopty ${opts.command}`, opts.block)
   }


### PR DESCRIPTION
This PR takes the "semicolon invoke" logic, which previously was hacked into a few key spots (e.g. the `ls` command handler), and hoists it directly into the REPL. Thus, all command line submissions will now benefit from the same logic.

Fixes #5260

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
