### PR TITLE
Revert "fix(packages/core): repl exec should invoke commands separated by semicolon"

### DIFF
--- a/packages/core/src/core/repl.ts
+++ b/packages/core/src/core/repl.ts
@@ -25,6 +25,6 @@ export { encodeComponent }
 import { split, _split, Split } from '../repl/split'
 export { split, _split, Split }
 
-export { exec, click, qexec, pexec, rexec, getImpl, setEvaluatorImpl } from '../repl/exec'
+export { exec, click, semicolonInvoke, qexec, pexec, rexec, getImpl, setEvaluatorImpl } from '../repl/exec'
 
 export { ReplEval, DirectReplEval } from '../repl/types'

--- a/packages/core/src/models/repl.ts
+++ b/packages/core/src/models/repl.ts
@@ -15,8 +15,8 @@
  */
 
 import { Tab } from '../webapp/tab'
-import { RawContent, RawResponse } from './entity'
-import { KResponse } from './command'
+import { MixedResponse, RawContent, RawResponse } from './entity'
+import { EvaluatorArgs, KResponse } from './command'
 import { ExecOptions } from './execOptions'
 
 export default interface REPL {
@@ -63,6 +63,13 @@ export default interface REPL {
    *
    */
   update(tab: Tab, command: string, execOptions?: ExecOptions): Promise<void>
+
+  /**
+   * If the command is semicolon-separated, invoke each element of the
+   * split separately
+   *
+   */
+  semicolonInvoke(opts: EvaluatorArgs): Promise<MixedResponse>
 
   /**
    * Prepare a string to be part of a `command` argument to the *exec

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -40,6 +40,7 @@ import {
   CommandHandlerWithEvents,
   EvaluatorArgs as Arguments,
   ExecType,
+  EvaluatorArgs,
   KResponse,
   ParsedOptions,
   YargsParserFlags
@@ -309,7 +310,7 @@ class InProcessExecutor implements Executor {
   private async execUnsafe<T extends KResponse, O extends ParsedOptions>(
     commandUntrimmed: string,
     execOptions = emptyExecOptions()
-  ): Promise<T | CodedError<number> | HTMLElement | MixedResponse | CommandEvaluationError> {
+  ): Promise<T | CodedError<number> | HTMLElement | CommandEvaluationError> {
     //
     const tab = execOptions.tab || getCurrentTab()
 
@@ -406,54 +407,48 @@ class InProcessExecutor implements Executor {
         createOutputStream: execOptions.createOutputStream || (() => this.makeStream(getTabId(tab), execUUID))
       }
 
-      let response: T | Promise<T> | MixedResponse
-
-      const commands = command.split(/\s*;\s*/)
-      if (commands.length > 1) {
-        response = await semicolonInvoke(commands, execOptions)
-      } else {
-        try {
-          response = await Promise.resolve(
-            currentEvaluatorImpl.apply<T, O>(commandUntrimmed, execOptions, evaluator, args)
-          ).then(response => {
-            // indicate that the command was successfuly completed
-            evaluator.success({
-              tab,
-              type: (execOptions && execOptions.type) || ExecType.TopLevel,
-              isDrilldown: execOptions.isDrilldown,
-              command,
-              parsedOptions
-            })
-
-            return response
+      let response: T | Promise<T>
+      try {
+        response = await Promise.resolve(
+          currentEvaluatorImpl.apply<T, O>(commandUntrimmed, execOptions, evaluator, args)
+        ).then(response => {
+          // indicate that the command was successfuly completed
+          evaluator.success({
+            tab,
+            type: (execOptions && execOptions.type) || ExecType.TopLevel,
+            isDrilldown: execOptions.isDrilldown,
+            command,
+            parsedOptions
           })
-        } catch (err) {
-          evaluator.error(command, tab, execType, err)
-          if (execType === ExecType.Nested) {
-            throw err
-          }
-          response = err
-        }
 
-        if (evaluator.options.viewTransformer && execType !== ExecType.Nested) {
-          response = await Promise.resolve(response)
-            .then(async _ => {
-              const maybeAView = await evaluator.options.viewTransformer(args, _)
-              return maybeAView || _
-            })
-            .catch(err => {
-              // view transformer failed; treat this as the response to the user
-              return err
-            })
+          return response
+        })
+      } catch (err) {
+        evaluator.error(command, tab, execType, err)
+        if (execType === ExecType.Nested) {
+          throw err
         }
+        response = err
+      }
 
-        // the || true part is a safeguard for cases where typescript
-        // didn't catch a command handler returning nothing; it
-        // shouldn't happen, but probably isn't a sign of a dire
-        // problem. issue a debug warning, in any case
-        if (!response) {
-          debug('warning: command handler returned nothing', commandUntrimmed)
-        }
+      if (evaluator.options.viewTransformer && execType !== ExecType.Nested) {
+        response = await Promise.resolve(response)
+          .then(async _ => {
+            const maybeAView = await evaluator.options.viewTransformer(args, _)
+            return maybeAView || _
+          })
+          .catch(err => {
+            // view transformer failed; treat this as the response to the user
+            return err
+          })
+      }
+
+      // the || true part is a safeguard for cases where typescript
+      // didn't catch a command handler returning nothing; it
+      // shouldn't happen, but probably isn't a sign of a dire
+      // problem. issue a debug warning, in any case
+      if (!response) {
+        debug('warning: command handler returned nothing', commandUntrimmed)
       }
 
       this.emitCompletionEvent(
@@ -485,7 +480,7 @@ class InProcessExecutor implements Executor {
   public async exec<T extends KResponse, O extends ParsedOptions>(
     commandUntrimmed: string,
     execOptions = emptyExecOptions()
-  ): Promise<T | CodedError<number> | HTMLElement | MixedResponse | CommandEvaluationError> {
+  ): Promise<T | CodedError<number> | HTMLElement | CommandEvaluationError> {
     try {
       return await this.execUnsafe(commandUntrimmed, execOptions)
     } catch (err) {
@@ -628,28 +623,31 @@ export const setExecutorImpl = (impl: Executor): void => {
  * split separately
  *
  */
-async function semicolonInvoke(commands: string[], execOptions: ExecOptions): Promise<MixedResponse> {
-  debug('semicolonInvoke', commands)
+export async function semicolonInvoke(opts: EvaluatorArgs): Promise<MixedResponse> {
+  const commands = opts.command.split(/\s*;\s*/)
+  if (commands.length > 1) {
+    debug('semicolonInvoke', commands)
 
-  const nonEmptyCommands = commands.filter(_ => _)
+    const nonEmptyCommands = commands.filter(_ => _)
 
-  const result: MixedResponse = await promiseEach(nonEmptyCommands, async command => {
-    const entity = await qexec<MixedResponsePart | true>(
-      command,
-      undefined,
-      undefined,
-      Object.assign({}, execOptions, { quiet: false, /* block, */ execUUID: execOptions.execUUID })
-    )
+    const result: MixedResponse = await promiseEach(nonEmptyCommands, async command => {
+      const entity = await qexec<MixedResponsePart | true>(
+        command,
+        undefined,
+        undefined,
+        Object.assign({}, opts.execOptions, { quiet: false, /* block, */ execUUID: opts.execOptions.execUUID })
+      )
 
-    if (entity === true) {
-      // pty output
-      return ''
-    } else {
-      return entity
-    }
-  })
+      if (entity === true) {
+        // pty output
+        return ''
+      } else {
+        return entity
+      }
+    })
 
-  return result
+    return result
+  }
 }
 
 /**
@@ -657,7 +655,7 @@ async function semicolonInvoke(commands: string[], execOptions: ExecOptions): Pr
  *
  */
 export function getImpl(tab: Tab): REPL {
-  const impl = { qexec, rexec, pexec, click, encodeComponent, split } as REPL
+  const impl = { qexec, rexec, pexec, click, semicolonInvoke, encodeComponent, split } as REPL
   tab.REPL = impl
   return impl
 }

--- a/packages/core/src/repl/types.ts
+++ b/packages/core/src/repl/types.ts
@@ -17,7 +17,6 @@
 import { CodedError } from '../models/errors'
 import { ExecOptions } from '../models/execOptions'
 import { Evaluator, EvaluatorArgs, KResponse, ParsedOptions } from '../models/command'
-import { MixedResponse } from '../models/entity'
 
 /**
  * repl.exec, and the family repl.qexec, repl.pexec, etc. are all
@@ -29,7 +28,7 @@ export interface Executor {
   exec<T extends KResponse, O extends ParsedOptions>(
     commandUntrimmed: string,
     execOptions: ExecOptions
-  ): Promise<T | CodedError<number> | HTMLElement | MixedResponse>
+  ): Promise<T | CodedError<number> | HTMLElement>
 }
 
 /**

--- a/plugins/plugin-bash-like/fs/src/lib/ls.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/ls.ts
@@ -241,7 +241,10 @@ function toTable(entries: GlobStats[], args: Arguments<LsOptions>): HTMLElement 
  *
  */
 const doLs = (cmd: string) => async (opts: Arguments<LsOptions>): Promise<MixedResponse | HTMLElement | Table> => {
-  if (/\|/.test(opts.command)) {
+  const semi = await opts.REPL.semicolonInvoke(opts)
+  if (semi) {
+    return semi
+  } else if (/\|/.test(opts.command)) {
     // conservatively send possibly piped output to the PTY
     return opts.REPL.qexec(`sendtopty ${opts.command}`, opts.block)
   }


### PR DESCRIPTION
This reverts commit 016b3b03398a2baa35c6088b96a6b15b7e2969e5.

Fixes #5315

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
