### PR TITLE
fix(plugins/plugin-kubectl): leftover debug printfs in table-watch

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
@@ -86,7 +86,6 @@ function preprocessTable(raw: string, nCols): { rows: Pair[][]; leftover: string
     }
 
     const leftover = raw.slice(lastNewlineIdx)
-    console.error('!!!!!!!!', leftover, rows)
     return {
       leftover,
       rows: rows


### PR DESCRIPTION
Fixes #5317

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
