### PR TITLE
fix(plugins/plugin-bash-like): ls should measure gridTemplateColumns more intelligently

### DIFF
--- a/plugins/plugin-bash-like/fs/src/lib/ls.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/ls.ts
@@ -190,6 +190,7 @@ function toTable(entries: GlobStats[], args: Arguments<LsOptions>): HTMLElement 
 
   if (!args.parsedOptions.l) {
     const frag = document.createDocumentFragment()
+    let longest = ''
 
     body.forEach(_ => {
       const cell = document.createElement('div')
@@ -200,10 +201,17 @@ function toTable(entries: GlobStats[], args: Arguments<LsOptions>): HTMLElement 
       cell.classList.add('clickable')
       cell.onclick = () => args.REPL.pexec(_.onclick)
       frag.appendChild(cell)
+
+      longest = _.name.length >= longest.length ? _.name : longest
     })
 
-    const em = 0
-    const ex = body.reduce((max, _) => Math.max(max, _.name.length), 0)
+    let ex = 0
+    let em = 2 // <-- for good measure
+    for (let idx = 0; idx < longest.length; idx++) {
+      const char = longest.charAt(idx)
+      if (char === 'm') em++
+      else ex++
+    }
 
     const container = document.createElement('div')
     container.classList.add('grid-layout')


### PR DESCRIPTION
For a typical ls command, the following screenshots show the effect of measurement 

Before the change:
![Screen Shot 2020-08-13 at 2 25 35 PM](https://user-images.githubusercontent.com/21212160/90172830-8fb0e800-dd71-11ea-9bb9-8f08afed2bd4.png)

After the change:
![Screen Shot 2020-08-13 at 2 25 59 PM](https://user-images.githubusercontent.com/21212160/90172811-8889da00-dd71-11ea-83df-76947a7ca64d.png)
Fixes #5353

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
