### PR TITLE
feat: allow command registrations to express their experimental nature

### DIFF
--- a/packages/core/src/models/command.ts
+++ b/packages/core/src/models/command.ts
@@ -94,6 +94,12 @@ export interface CommandOptions extends CapabilityRequirements {
 
   /** model to view transformer */
   viewTransformer?: ViewTransformer<KResponse, ParsedOptions>
+
+  /**
+   * Is the command experimental? e.g. initial release, lack of test coverage
+   *
+   */
+  isExperimental?: boolean
 }
 
 export interface Event {

--- a/packages/core/src/repl/events.ts
+++ b/packages/core/src/repl/events.ts
@@ -25,6 +25,7 @@ export interface CommandStartEvent {
   execUUID: string
   execType: ExecType
   echo: boolean
+  evaluatorOptions: CommandOptions
 }
 
 export type ResponseType = 'MultiModalResponse' | 'NavResponse' | 'ScalarResponse' | 'Incomplete' | 'Error'

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -340,6 +340,7 @@ class InProcessExecutor implements Executor {
         tab,
         route: evaluator.route,
         command,
+        evaluatorOptions,
         execType,
         execUUID,
         echo: execOptions.echo

--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -123,6 +123,7 @@ export const OUTPUT_N_STREAMING = (N: number, splitIndex = 1) =>
   `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} [data-stream]`
 export const OUTPUT_N_PTY = (N: number) => OUTPUT_N_STREAMING(N)
 export const PROMPT_BLOCK_LAST = `${PROMPT_BLOCK}:nth-last-child(2)`
+export const EXPERIMENTAL_PROMPT_BLOCK_TAG = `${PROMPT_BLOCK_LAST} .repl-prompt-right-elements .kui--repl-block-experimental-tag`
 export const PROMPT_BLOCK_FINAL = `${PROMPT_BLOCK}:nth-last-child(1)`
 export const OVERFLOW_MENU = '.kui--repl-block-right-element.kui--toolbar-button-with-icon'
 export const PROMPT_BLOCK_MENU = (N: number) => `${PROMPT_BLOCK_N(N)} ${OVERFLOW_MENU}`

--- a/plugins/plugin-client-common/i18n/resources_en_US.json
+++ b/plugins/plugin-client-common/i18n/resources_en_US.json
@@ -1,4 +1,6 @@
 {
+  "ExperimentalTag": "Experimental",
+  "HoverExperimentalTag": "This command is highly experimental, and may change radically in the near future. Proceed with caution.",
   "Remove": "Remove",
   "ok": "ok",
   "Status Grid": "Status Grid",

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -28,7 +28,7 @@ const enum BlockState {
 /** Traits that Blocks might have */
 type WithCWD = { cwd: string }
 type WithUUID = { execUUID: string }
-type WithCommand = { command: string } & WithCWD
+type WithCommand = { command: string; isExperimental?: boolean } & WithCWD
 type WithStartTime = { startTime: Date }
 type WithState<S extends BlockState> = { state: S }
 type WithResponse<R extends ScalarResponse> = { response: R } & WithStartTime
@@ -139,9 +139,15 @@ export function Announcement(response: ScalarResponse): AnnouncementBlock {
 }
 
 /** Transform to Processing */
-export function Processing(block: BlockModel, command: string, execUUID: string): ProcessingBlock {
+export function Processing(
+  block: BlockModel,
+  command: string,
+  execUUID: string,
+  isExperimental = false
+): ProcessingBlock {
   return {
     command,
+    isExperimental,
     cwd: block.cwd,
     execUUID: execUUID,
     startTime: new Date(),
@@ -188,6 +194,7 @@ export function Finished(
       historyIdx,
       cwd: block.cwd,
       command: block.command,
+      isExperimental: block.isExperimental,
       state: BlockState.Error,
       execUUID: block.execUUID,
       startTime: block.startTime
@@ -198,6 +205,7 @@ export function Finished(
       historyIdx,
       cwd: block.cwd,
       command: block.command,
+      isExperimental: block.isExperimental,
       execUUID: block.execUUID,
       startTime: block.startTime,
       prefersTerminalPresentation,

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -28,6 +28,7 @@ import { BlockModel, isActive, isProcessing, isFinished, hasCommand, isEmpty, ha
 import { BlockViewTraits } from './'
 
 import DropDown, { DropDownAction } from '../../../spi/DropDown'
+import Tag from '../../../spi/Tag'
 
 const strings = i18n('plugin-client-common')
 const strings2 = i18n('plugin-client-common', 'screenshot')
@@ -97,6 +98,9 @@ type InputProps = {
 
   /** state of the Block, e.g. Processing? Active/accepting input? */
   model?: BlockModel
+
+  /** is the command experimental? */
+  isExperimental?: boolean
 }
 
 export type Props = InputOptions & InputProps & BlockViewTraits
@@ -387,6 +391,21 @@ export default class Input extends InputProvider {
     }
   }
 
+  /** render a tag for experimental command */
+  private experimentalTag() {
+    if (this.props.isExperimental) {
+      return (
+        <Tag
+          spanclassname="kui--repl-block-experimental-tag kui--repl-block-right-element"
+          title={strings('HoverExperimentalTag')}
+          type="warning"
+        >
+          {strings('ExperimentalTag')}
+        </Tag>
+      )
+    }
+  }
+
   /** render the time the block started processing */
   private timestamp() {
     if (!isEmpty(this.props.model) && (isProcessing(this.props.model) || isFinished(this.props.model))) {
@@ -482,6 +501,7 @@ export default class Input extends InputProvider {
     return (
       <span className="repl-prompt-right-elements">
         {this.errorIcon()}
+        {this.experimentalTag()}
         {this.timestamp()}
         {this.dropdown()}
         {/* this.close() */}

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
@@ -22,6 +22,7 @@ import Output from './Output'
 import { BlockModel, isActive, isEmpty, isFinished, isProcessing, isAnnouncement, hasUUID } from './BlockModel'
 
 export type BlockViewTraits = {
+  isExperimental?: boolean
   isFocused?: boolean
   prefersTerminalPresentation?: boolean
   isPartOfMiniSplit?: boolean
@@ -132,6 +133,7 @@ export default class Block extends React.PureComponent<Props, State> {
           uuid={this.props.uuid}
           tab={this.props.tab}
           model={this.props.model}
+          isExperimental={this.props.isExperimental}
           {...this.props}
           willScreenshot={this.state._block && this.props.willRemove ? () => this.willScreenshot() : undefined}
           _block={this.state._block}

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -46,6 +46,7 @@ import {
   isActive,
   isOk,
   isProcessing,
+  hasCommand,
   hasUUID,
   BlockModel
 } from './Block/BlockModel'
@@ -342,7 +343,9 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
         return {
           blocks: curState.blocks
             .slice(0, idx)
-            .concat([Processing(curState.blocks[idx], event.command, event.execUUID)])
+            .concat([
+              Processing(curState.blocks[idx], event.command, event.execUUID, event.evaluatorOptions.isExperimental)
+            ])
         }
       })
     }
@@ -766,6 +769,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
                   onOutputRender={this.onOutputRender.bind(this, scrollback)}
                   willRemove={this.willRemoveBlock.bind(this, scrollback.uuid, idx)}
                   willLoseFocus={() => this.doFocus(scrollback)}
+                  isExperimental={hasCommand(_) && _.isExperimental}
                   isFocused={sbidx === this.state.focusedIdx && isActive(_)}
                   prefersTerminalPresentation={isOk(_) && _.prefersTerminalPresentation}
                   isPartOfMiniSplit={isMiniSplit}

--- a/plugins/plugin-client-common/src/components/spi/Tag/impl/Carbon.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Tag/impl/Carbon.tsx
@@ -23,8 +23,8 @@ import '../../../../../web/scss/components/Tag/Carbon.scss'
 
 export default function CarbonTag(props: Props) {
   return (
-    <span title={props.title}>
-      <Tag {...props} type={props.type === 'error' ? 'red' : 'blue'} />
+    <span title={props.title} className={props.spanclassname}>
+      <Tag {...props} type={props.type === 'error' ? 'red' : props.type === 'warning' ? 'warm-gray' : 'blue'} />
     </span>
   )
 }

--- a/plugins/plugin-client-common/web/css/static/repl.scss
+++ b/plugins/plugin-client-common/web/css/static/repl.scss
@@ -135,6 +135,13 @@
     fill: var(--color-error);
     margin-right: 0.5rem;
   }
+  .kui--repl-block-experimental-tag {
+    margin-right: 0.5rem;
+    .bx--tag.bx--tag--warm-gray {
+      background-color: var(--color-latency-3);
+      color: inherit;
+    }
+  }
 }
 
 [kui-theme-style] .kui--repl-block-right-element {

--- a/plugins/plugin-client-test/src/lib/cmds/say-hello.ts
+++ b/plugins/plugin-client-test/src/lib/cmds/say-hello.ts
@@ -58,7 +58,7 @@ const sayTime3 = async () => {
   return prettyPrintTime(t2, 'long', t1)
 }
 
-const options: CommandOptions = {}
+const options: CommandOptions = { isExperimental: true }
 const options2: CommandOptions = Object.assign(
   {
     usage: {

--- a/plugins/plugin-client-test/src/test/response/string.ts
+++ b/plugins/plugin-client-test/src/test/response/string.ts
@@ -22,7 +22,7 @@
  *
  */
 
-import { TestStringResponse } from '@kui-shell/test'
+import { Common, CLI, Selectors, TestStringResponse } from '@kui-shell/test'
 
 /**
  * pty streaming
@@ -162,3 +162,13 @@ new TestStringResponse({
   expect: '+', // e.g. +102ms
   exact: false
 }).string()
+
+describe(`experimental command ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  it('should execute an experimental command', () =>
+    CLI.command('test string', this.app)
+      .then(() => this.app.client.waitForExist(Selectors.EXPERIMENTAL_PROMPT_BLOCK_TAG))
+      .catch(Common.oops(this, true)))
+})

--- a/plugins/plugin-ibmcloud/ce/src/bind.ts
+++ b/plugins/plugin-ibmcloud/ce/src/bind.ts
@@ -19,6 +19,7 @@ import { KubeOptions } from '@kui-shell/plugin-kubectl'
 
 import doListWith from './controller/generic/list'
 import doGetWith, { registration as getReg } from './controller/generic/get'
+import defaultOption from './controller/generic/option'
 
 type Handler = CommandHandler<KResponse, KubeOptions>
 type FlexHandler = string | Handler
@@ -36,7 +37,7 @@ export default function Bind(
         this.listen(
           `/ibmcloud/${ce}/${cmd}/get`,
           typeof provider.Get === 'string' ? doGetWith.bind(provider.Get) : provider.Get,
-          getReg
+          Object.assign({}, getReg, defaultOption)
         )
       )
     }
@@ -45,13 +46,14 @@ export default function Bind(
       cmds.forEach(cmd =>
         this.listen(
           `/ibmcloud/${ce}/${cmd}/list`,
-          typeof provider.List === 'string' ? doListWith.bind(provider.List) : provider.List
+          typeof provider.List === 'string' ? doListWith.bind(provider.List) : provider.List,
+          defaultOption
         )
       )
     }
 
     if (provider.Run) {
-      cmds.forEach(cmd => this.listen(`/ibmcloud/${ce}/${cmd}/run`, provider.Run))
+      cmds.forEach(cmd => this.listen(`/ibmcloud/${ce}/${cmd}/run`, provider.Run, defaultOption))
     }
   })
 }

--- a/plugins/plugin-ibmcloud/ce/src/controller/generic/option.ts
+++ b/plugins/plugin-ibmcloud/ce/src/controller/generic/option.ts
@@ -14,16 +14,4 @@
  * limitations under the License.
  */
 
-import { ReactNode } from 'react'
-
-interface Props {
-  id?: string
-  title?: string
-  type?: 'ok' | 'error' | 'warning'
-  className?: string
-  spanclassname?: string
-  children: ReactNode
-  onClick?: () => void
-}
-
-export default Props
+export default { isExperimental: true }


### PR DESCRIPTION
To register a command as experimental, users can add the command option `{ isExperimental: true }` in command registration.

For example, the following plugin.ts will give the command-line: `test string`  an experimental tag:

```typescript

import { Registrar } from '@kui-shell/core'

export default function(registrar: Registrar) {
   registrar.listen('/test/string', () => 'hello world', { isExperimental: true })
}
```

![Screen Shot 2020-08-14 at 11 58 01 AM](https://user-images.githubusercontent.com/21212160/90268694-694c8480-de25-11ea-87ea-9ad55e204b62.png)

Also updated ibmcloud ce commands to opt in this option

Fixes #5282

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
