### PR TITLE
fix(plugins/plugin-client-common): kubectl watch is broken for server versions >= 1.17

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
@@ -251,7 +251,11 @@ class KubectlWatcher implements Abortable, Watcher {
    * schema the *user* requested satisfies this requirement.
    */
   // eslint-disable-next-line no-useless-constructor
-  public constructor(private readonly args: Arguments<KubeOptions>, private readonly output = formatOf(args)) {}
+  public constructor(
+    private readonly args: Arguments<KubeOptions>,
+    private readonly output = formatOf(args),
+    private readonly kubeServerVersion: { major: number; minor: number }
+  ) {}
 
   /**
    * Our impl of `Abortable` for use by the table view
@@ -446,6 +450,16 @@ class KubectlWatcher implements Abortable, Watcher {
   public async init(pusher: WatchPusher) {
     this.pusher = pusher
 
+    // prior to kubenetest sever version 1.17, it seems that the json output of watching
+    // a list of objects, e.g. kubectl get pods, doesn't have kind:List,
+    // whereas with 1.17, they fixed that, and you now need to specify that range in your jsonpath.
+    // see issue: https://github.com/IBM/kui/issues/5360
+    debug('kubeServerVersion', this.kubeServerVersion.major, this.kubeServerVersion.minor)
+    const jsonpathByVersion =
+      this.kubeServerVersion.major === 1 && this.kubeServerVersion.minor < 17
+        ? `'{.metadata.name}{"|"}{.kind}{"|"}{.apiVersion}{"|"}{.metadata.namespace}{"|\\n"}'`
+        : `'{range .items[*]}{.metadata.name}{"|"}{.kind}{"|"}{.apiVersion}{"|"}{.metadata.namespace}{"|\\n"}{end}'`
+
     // here, we initiate a kubectl watch, using a schema of our
     // choosing; we ask the PTY to stream output back to us, by using
     // the `onInit` API
@@ -454,8 +468,7 @@ class KubectlWatcher implements Abortable, Watcher {
       this.args.command
         .replace(/^k(\s)/, 'kubectl$1')
         .replace(/--watch=true|-w=true|--watch-only=true|--watch|-w|--watch-only/g, '--watch') // force --watch
-        .replace(new RegExp(`(-o|--output)(\\s+|=)${this.output}`), '') +
-        ` -o jsonpath='{.metadata.name}{"|"}{.kind}{"|"}{.apiVersion}{"|"}{.metadata.namespace}{"|\\n"}'`
+        .replace(new RegExp(`(-o|--output)(\\s+|=)${this.output}`), '') + ` -o jsonpath=${jsonpathByVersion}`
     )
     // ^^^^^ keep these in sync with nCols above !!
 
@@ -508,6 +521,15 @@ export default async function doGetWatchTable(args: Arguments<KubeOptions>): Pro
         .replace(/^k(\s)/, 'kubectl$1')
         .replace(/--watch=true|-w=true|--watch-only=true|--watch|-w|--watch-only/g, '')
     ) // strip --watch
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const kubeServerVersion = args.REPL.qexec<any>(`${getCommandFromArgs(args)} version -o json`).then(
+      ({ serverVersion }) => ({
+        major: parseInt(serverVersion.major),
+        minor: parseInt(serverVersion.minor)
+      })
+    )
+
     const initialTable = await args.REPL.qexec<Table>(cmd).catch((err: CodedError) => {
       if (err.code !== 404) {
         throw err
@@ -552,7 +574,7 @@ export default async function doGetWatchTable(args: Arguments<KubeOptions>): Pro
         title:
           initialTable.title ||
           (await getKind(getCommandFromArgs(args), args, args.argvNoOptions[args.argvNoOptions.indexOf('get') + 1])),
-        watch: new KubectlWatcher(args) // <-- our watcher
+        watch: new KubectlWatcher(args, undefined, await kubeServerVersion) // <-- our watcher
       }
     }
   } catch (err) {


### PR DESCRIPTION
Fixes #5360

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
