### PR TITLE
fix(plugins/plugin-kubectl): kubectl watcher needs to pass through ku…

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
@@ -523,7 +523,9 @@ export default async function doGetWatchTable(args: Arguments<KubeOptions>): Pro
     ) // strip --watch
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const kubeServerVersion = args.REPL.qexec<any>(`${getCommandFromArgs(args)} version -o json`)
+    const kubeServerVersion = args.REPL.qexec<any>(
+      withKubeconfigFrom(args, `${getCommandFromArgs(args)} version -o json`)
+    )
       .then(_ => (typeof _ === 'string' ? JSON.parse(_) : _))
       .then(({ serverVersion }) => ({
         major: parseInt(serverVersion.major),


### PR DESCRIPTION
…beconfig in its call to kubectl version

Fixes #5368

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
