### PR TITLE
fix(plugins/plugin-client-common): Experimental badge should take up …

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Sidecar/Badge.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/Badge.tsx
@@ -20,7 +20,7 @@ import { Badge as KuiBadge, Tab, MultiModalResponse } from '@kui-shell/core'
 
 import HTMLDom from '../../Content/Scalar/HTMLDom'
 
-import '../../../../web/css/static/Tag.scss'
+import '../../../../web/scss/components/Tag/Tag.scss'
 
 interface Props {
   tab: Tab

--- a/plugins/plugin-client-common/src/components/spi/Tag/impl/Carbon.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Tag/impl/Carbon.tsx
@@ -24,7 +24,11 @@ import '../../../../../web/scss/components/Tag/Carbon.scss'
 export default function CarbonTag(props: Props) {
   return (
     <span title={props.title} className={props.spanclassname}>
-      <Tag {...props} type={props.type === 'error' ? 'red' : props.type === 'warning' ? 'warm-gray' : 'blue'} />
+      <Tag
+        {...props}
+        className={['kui--tag', props.className].join(' ')}
+        type={props.type === 'error' ? 'red' : props.type === 'warning' ? 'warm-gray' : 'blue'}
+      />
     </span>
   )
 }

--- a/plugins/plugin-client-common/src/components/spi/Tag/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Tag/impl/PatternFly.tsx
@@ -20,5 +20,5 @@ import { Badge } from '@patternfly/react-core'
 import Props from '../model'
 
 export default function PatternFlyTag(props: Props) {
-  return <Badge {...props} />
+  return <Badge {...props} className={['kui--tag', props.className].join(' ')} />
 }

--- a/plugins/plugin-client-common/web/css/static/repl.scss
+++ b/plugins/plugin-client-common/web/css/static/repl.scss
@@ -137,7 +137,7 @@
   }
   .kui--repl-block-experimental-tag {
     margin-right: 0.5rem;
-    .bx--tag.bx--tag--warm-gray {
+    .kui--tag {
       background-color: var(--color-latency-3);
       font-family: var(--font-sans-serif);
       color: inherit;

--- a/plugins/plugin-client-common/web/scss/components/Tag/Carbon.scss
+++ b/plugins/plugin-client-common/web/scss/components/Tag/Carbon.scss
@@ -16,7 +16,7 @@
 
 @import '~carbon-components/scss/components/tag/_tag.scss';
 
-[kui-theme-style] .kui--status-stripe .bx--tag {
+[kui-theme-style] .kui--status-stripe .kui--tag {
   color: var(--color-base00);
   background-color: var(--color-brand-03);
 

--- a/plugins/plugin-client-common/web/scss/components/Tag/Tag.scss
+++ b/plugins/plugin-client-common/web/scss/components/Tag/Tag.scss
@@ -1,6 +1,6 @@
 @import 'carbon-components/scss/components/tag/_tag.scss';
 
-[kui-theme-style] .bx--tag {
+.kui--tag {
   &.bx--tag--gray {
     background-color: var(--color-sidecar-border);
     color: var(--color-sidecar-background-01);

--- a/plugins/plugin-client-common/web/scss/components/Terminal/MiniSplit.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/MiniSplit.scss
@@ -22,8 +22,19 @@
   display: flex;
   flex-direction: column;
 
-  .repl-block + .repl-block.repl-active {
-    margin-top: 0.5rem;
+  .repl-block {
+    & + .repl-block.repl-active,
+    & + .repl-block.processing {
+      margin-top: 0.5rem;
+    }
+  }
+
+  .kui--repl-block-experimental-tag {
+    margin: 0;
+    .kui--tag {
+      height: 1.25rem;
+      font-size: 0.625rem;
+    }
   }
 
   .kui--repl-block-timestamp {
@@ -32,6 +43,7 @@
 
   .repl-block {
     margin: 0;
+    padding-bottom: 0;
   }
 
   .repl-prompt {


### PR DESCRIPTION
…less space in minisplits

This also does a small bit of cleanup to the Tag scss:

1) moves Tag.scss out of web/css/static and into web/scss/components/Tag
2) adds a `kui--tag` className, so we can avoid some Carbon-specificity in the component library-generic css

Fixes #5373

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
