### PR TITLE
fix(plugins/plugin-ibmcloud): k get jobrun is always directed to code…

### DIFF
--- a/plugins/plugin-ibmcloud/ce/src/controller/job/list.ts
+++ b/plugins/plugin-ibmcloud/ce/src/controller/job/list.ts
@@ -14,4 +14,6 @@
  * limitations under the License.
  */
 
-export default 'kubectl get jobrun -o custom-columns=NAME:.metadata.name,JOBDEF:.metadata.labels.codeengine\\\\.cloud\\\\.ibm\\\\.com/job-definition,STATUS:.status.succeeded,START:.status.startTime,END:.status.completionTime'
+export const JobRunKind = 'JobRun.v1alpha1.codeengine.cloud.ibm.com'
+
+export default `kubectl get ${JobRunKind} -o custom-columns=NAME:.metadata.name,JOBDEF:.metadata.labels.codeengine\\\\.cloud\\\\.ibm\\\\.com/job-definition,STATUS:.status.succeeded,START:.status.startTime,END:.status.completionTime`

--- a/plugins/plugin-ibmcloud/ce/src/plugin.ts
+++ b/plugins/plugin-ibmcloud/ce/src/plugin.ts
@@ -26,6 +26,7 @@ import * as Application from './controller/application'
 
 // special case to handle a Duration column
 import KubectlGetJob from './controller/job/kubectl'
+import { JobRunKind } from './controller/job/list'
 
 // ibmcloud ce kubectl ... adds the kubeconfig for ce
 import Kubectl from './controller/kubectl'
@@ -41,7 +42,7 @@ export default async (registrar: Registrar) => {
   Bind(Secret, 'secret')
 
   // special case to handle a Duration column
-  BindGet(KubectlGetJob, 'jobrun', 'JobRun', 'JobRun.v1alpha1.codeengine.cloud.ibm.com')
+  BindGet(KubectlGetJob, JobRunKind)
 
   Kubectl(registrar)
 }


### PR DESCRIPTION
…engine CRD

Fixes #5377

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
