### PR TITLE
feat: initial/minimal snapshot/replay support

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -122,7 +122,7 @@ export { split, _split, Split } from './repl/split'
 export { ReplEval, DirectReplEval } from './repl/types'
 export { default as encodeComponent } from './repl/encode'
 export { exec as internalBeCarefulExec, pexec as internalBeCarefulPExec, setEvaluatorImpl, doEval } from './repl/exec'
-export { CommandStartEvent, CommandCompleteEvent } from './repl/events'
+export { CommandStartEvent, CommandCompleteEvent, Snapshot, SnapshotBlock } from './repl/events'
 
 // Tabs
 export { Tab, getTab, getCurrentTab, pexecInCurrentTab, getTabId, getPrimaryTabId, sameTab } from './webapp/tab'

--- a/packages/core/src/main/menu.ts
+++ b/packages/core/src/main/menu.ts
@@ -18,6 +18,7 @@
 
 import { productName } from '@kui-shell/client/config.d/name.json'
 import { Menu, MenuItemConstructorOptions } from 'electron'
+import open from './open'
 
 const isDev = false
 
@@ -64,9 +65,25 @@ const closeTab = () => tellRendererToExecute('tab close')
 const isDarwin = process.platform === 'darwin'
 const closeAccelerator = isDarwin ? 'Command+W' : 'Control+Shift+W'
 
-export const install = (createWindow: () => void) => {
+export const install = (createWindow: (executeThisArgvPlease?: string[]) => void) => {
   if (!isDev) {
     const fileMenuItems: MenuItemConstructorOptions[] = [
+      {
+        label: 'Open',
+        click: () => open(createWindow),
+        accelerator: 'CommandOrControl+O'
+      },
+      {
+        label: 'Open Recent',
+        role: 'recentdocuments' as any, // electron.d.ts insufficiency
+        submenu: [
+          {
+            label: 'Clear Recent',
+            role: 'clearrecentdocuments' as any // ibid
+          }
+        ]
+      },
+      { type: 'separator' },
       {
         label: 'New Window',
         click: () => createWindow(),

--- a/packages/core/src/main/open.ts
+++ b/packages/core/src/main/open.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Open a new window and replay the contents of the given `filepath` */
+export function replay(filepath: string, createWindow: (executeThisArgvPlease?: string[]) => void) {
+  createWindow(['replay', filepath])
+}
+
+/**
+ * Open a file and replay its session.
+ *
+ */
+export default async function open(createWindow: (executeThisArgvPlease?: string[]) => void) {
+  const { app, dialog } = await import('electron')
+  const resp = await dialog.showOpenDialog({
+    title: 'Select a Kui snapshot',
+    filters: [{ name: 'Kui snapshot', extensions: ['kui'] }]
+  })
+  if (!resp.canceled) {
+    resp.filePaths.forEach(filepath => {
+      app.addRecentDocument(filepath)
+      replay(filepath, createWindow)
+    })
+  }
+}

--- a/packages/core/src/models/history.ts
+++ b/packages/core/src/models/history.ts
@@ -44,9 +44,6 @@ export interface HistoryLine {
 
   /** Index into model */
   historyIdx: number
-
-  /** Is this line shown in the UI? */
-  isCurrentlyShown: boolean
 }
 
 /** A tuple of History entries, one per Tab (as specified by its given uuid) */
@@ -155,27 +152,8 @@ export class HistoryModel {
     return true
   }
 
-  /** Internal hide */
-  private hideAt(historyIdx: number) {
-    const line = this._lines[historyIdx]
-    if (line) {
-      line.isCurrentlyShown = false
-    }
-  }
-
-  /** Hide the given entry from future display */
-  public hide(historyIdx: number | number[]) {
-    debug('hiding', historyIdx)
-    if (typeof historyIdx === 'number') {
-      this.hideAt(historyIdx)
-    } else {
-      historyIdx.forEach(_ => this.hideAt(_))
-    }
-    this.save()
-  }
-
   /** add a line of repl history */
-  public add(line: Pick<HistoryLine, 'raw' | 'isCurrentlyShown'>): number {
+  public add(line: Pick<HistoryLine, 'raw'>): number {
     if (this._lines.length === 0 || JSON.stringify(this._lines[this._lines.length - 1]) !== JSON.stringify(line)) {
       // don't add sequential duplicates
       this._lines.push(Object.assign(line, { historyIdx: this._lines.length - 1 }))

--- a/packages/core/src/repl/events.ts
+++ b/packages/core/src/repl/events.ts
@@ -55,3 +55,33 @@ export type CommandStartHandler = (event: CommandStartEvent) => void
 export type CommandCompleteHandler<R extends KResponse = KResponse, T extends ResponseType = ResponseType> = (
   event: CommandCompleteEvent<R, T>
 ) => void
+
+/**
+ * SnapshotBlock: captures the start and complete of the command
+ * execution.
+ *
+ */
+export type SnapshotBlock = {
+  startTime: number
+  startEvent: Omit<CommandStartEvent, 'tab'> & { tab: Pick<CommandStartEvent['tab'], 'uuid'> }
+  completeEvent: Omit<CommandCompleteEvent, 'tab'> & { tab: Pick<CommandStartEvent['tab'], 'uuid'> }
+}
+
+export type SnapshotTab = {
+  uuid: string
+  blocks: SnapshotBlock[]
+}
+
+export type SnapshotWindow = {
+  uuid: string
+  tabs: SnapshotTab[]
+}
+
+/**
+ * Snapshot: captures the block-level snapshots across the entire
+ * session.
+ *
+ */
+export type Snapshot = {
+  windows: SnapshotWindow[]
+}

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -158,8 +158,7 @@ class InProcessExecutor implements Executor {
         if (!execOptions || execOptions.type !== ExecType.Nested) {
           const historyModel = getHistoryForTab(tab.uuid)
           return (execOptions.history = historyModel.add({
-            raw: command,
-            isCurrentlyShown: true
+            raw: command
           }))
         }
       }

--- a/plugins/plugin-client-common/src/components/Client/Kui.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Kui.tsx
@@ -23,6 +23,7 @@ import {
   i18n,
   REPL,
   Theme,
+  pexecInCurrentTab,
   inBrowser,
   eventChannelUnsafe,
   findThemeByName,
@@ -207,6 +208,14 @@ export class Kui extends React.PureComponent<Props, State> {
     console.error(error, errorInfo)
   }
 
+  private onTabReady() {
+    if (this.props.commandLine) {
+      pexecInCurrentTab(this.props.commandLine.join(' '))
+    }
+  }
+
+  private readonly _onTabReady = this.onTabReady.bind(this)
+
   public render() {
     if (!this.state.isBootstrapped) {
       return <Loading />
@@ -222,11 +231,14 @@ export class Kui extends React.PureComponent<Props, State> {
       )
     } else {
       const bottom = !!this.props.bottomInput && <InputStripe>{this.props.bottomInput}</InputStripe>
-
       return (
         <KuiContext.Provider value={this.state}>
           <div className="kui--full-height">
-            <TabContainer noActiveInput={!!this.props.bottomInput} bottom={bottom}>
+            <TabContainer
+              noActiveInput={!!this.props.bottomInput}
+              bottom={bottom}
+              onTabReady={this.props.commandLine && this._onTabReady}
+            >
               <ComboSidecar />
             </TabContainer>
             {this.props.toplevel}

--- a/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
@@ -43,6 +43,9 @@ interface State {
   /** list of current tabs; one TabContent for each */
   tabs: TabModel[]
 
+  /** Has the first tab activated itself? */
+  isFirstTabReady: boolean
+
   /** current active tab index */
   activeIdx: number
 }
@@ -53,6 +56,7 @@ export default class TabContainer extends React.PureComponent<Props, State> {
 
     this.state = {
       tabs: [this.newTabModel()],
+      isFirstTabReady: false,
       activeIdx: 0
     }
 
@@ -204,6 +208,13 @@ export default class TabContainer extends React.PureComponent<Props, State> {
     })
   }
 
+  private onTabReady(tab: Tab) {
+    if (this.props.onTabReady) {
+      this.props.onTabReady(tab)
+    }
+    this.setState({ isFirstTabReady: true })
+  }
+
   public render() {
     return (
       <div className="kui--full-height">
@@ -222,6 +233,9 @@ export default class TabContainer extends React.PureComponent<Props, State> {
               uuid={_.uuid}
               active={idx === this.state.activeIdx}
               willUpdateTopTabButtons={this.willUpdateTopTabButtons.bind(this, _.uuid)}
+              onTabReady={
+                idx === 0 && this.props.onTabReady && !this.state.isFirstTabReady && this.onTabReady.bind(this)
+              }
               state={_.state}
               {...this.props}
             >

--- a/plugins/plugin-client-common/src/components/Client/TabContent.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContent.tsx
@@ -43,13 +43,14 @@ interface WithTab {
 export type TabContentOptions = TerminalOptions & {
   /** [Optional] elements to be placed below the Terminal */
   bottom?: React.ReactElement<WithTabUUID & WithTab>
+
+  onTabReady?: (tab: KuiTab) => void
 }
 
 type Props = TabContentOptions &
   WithTabUUID & {
     active: boolean
     state: TabState
-    onTabReady?: (tab: KuiTab) => void
     willUpdateTopTabButtons?: (buttons: TopTabButton[]) => void
   }
 

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import { ScalarResponse, UsageError, inBrowser } from '@kui-shell/core'
+import {
+  CommandStartEvent,
+  CommandCompleteEvent,
+  ScalarResponse,
+  SnapshotBlock,
+  UsageError,
+  inBrowser
+} from '@kui-shell/core'
 
 const enum BlockState {
   Active = 'repl-active',
@@ -35,6 +42,8 @@ type WithResponse<R extends ScalarResponse> = { response: R } & WithStartTime
 type WithValue = { value: string }
 type WithAnnouncement = { isAnnouncement: boolean }
 type WithPreferences = { prefersTerminalPresentation: boolean }
+type WithCommandStart = { startEvent: CommandStartEvent }
+type WithCommandComplete = { completeEvent: CommandCompleteEvent }
 
 /** The canonical types of Blocks, which mix up the Traits as needed */
 type ActiveBlock = WithState<BlockState.Active> & WithCWD & Partial<WithValue>
@@ -43,14 +52,26 @@ export type AnnouncementBlock = WithState<BlockState.ValidResponse> &
   WithCWD &
   WithAnnouncement
 type EmptyBlock = WithState<BlockState.Empty> & WithCWD
-type ErrorBlock = WithState<BlockState.Error> & WithCommand & WithResponse<Error> & WithUUID & WithHistoryIndex
+type ErrorBlock = WithState<BlockState.Error> &
+  WithCommand &
+  WithResponse<Error> &
+  WithUUID &
+  WithHistoryIndex &
+  WithCommandStart &
+  WithCommandComplete
 type OkBlock = WithState<BlockState.ValidResponse> &
   WithCommand &
   WithResponse<ScalarResponse> &
   WithUUID &
   WithHistoryIndex &
+  WithCommandStart &
+  WithCommandComplete &
   WithPreferences
-export type ProcessingBlock = WithState<BlockState.Processing> & WithCommand & WithUUID & WithStartTime
+export type ProcessingBlock = WithState<BlockState.Processing> &
+  WithCommand &
+  WithUUID &
+  WithStartTime &
+  WithCommandStart
 type CancelledBlock = WithState<BlockState.Cancelled> & WithCWD & WithCommand & WithUUID & WithStartTime
 
 /** Blocks with an association to the History model */
@@ -139,17 +160,13 @@ export function Announcement(response: ScalarResponse): AnnouncementBlock {
 }
 
 /** Transform to Processing */
-export function Processing(
-  block: BlockModel,
-  command: string,
-  execUUID: string,
-  isExperimental = false
-): ProcessingBlock {
+export function Processing(block: BlockModel, startEvent: CommandStartEvent, isExperimental = false): ProcessingBlock {
   return {
-    command,
+    command: startEvent.command,
     isExperimental,
     cwd: block.cwd,
-    execUUID: execUUID,
+    execUUID: startEvent.execUUID,
+    startEvent,
     startTime: new Date(),
     state: BlockState.Processing
   }
@@ -181,12 +198,14 @@ export function Cancelled(block: BlockModel): CancelledBlock | EmptyBlock {
 /** Transform to Finished */
 export function Finished(
   block: ProcessingBlock,
-  response: ScalarResponse,
-  cancelled: boolean,
-  historyIdx: number,
+  event: CommandCompleteEvent,
   prefersTerminalPresentation = false
 ): FinishedBlock {
-  if (cancelled) {
+  const response = event.responseType === 'ScalarResponse' ? (event.response as ScalarResponse) : true
+  const { historyIdx } = event
+  const { startEvent } = block
+
+  if (event.cancelled) {
     return Cancelled(block)
   } else if (isError(response)) {
     return {
@@ -194,6 +213,8 @@ export function Finished(
       historyIdx,
       cwd: block.cwd,
       command: block.command,
+      startEvent,
+      completeEvent: event,
       isExperimental: block.isExperimental,
       state: BlockState.Error,
       execUUID: block.execUUID,
@@ -205,11 +226,47 @@ export function Finished(
       historyIdx,
       cwd: block.cwd,
       command: block.command,
+      startEvent,
+      completeEvent: event,
       isExperimental: block.isExperimental,
       execUUID: block.execUUID,
       startTime: block.startTime,
       prefersTerminalPresentation,
       state: BlockState.ValidResponse
     }
+  }
+}
+
+export function snapshot(block: BlockModel): SnapshotBlock {
+  if (!isAnnouncement(block) && (isOops(block) || isOk(block))) {
+    const execOptions = Object.assign(
+      {},
+      block.completeEvent.execOptions,
+      { block: undefined },
+      { tab: block.completeEvent.execOptions.tab.uuid }
+    )
+    const evaluatorOptions = Object.assign({}, block.completeEvent.evaluatorOptions, {
+      usage: undefined,
+      flags: undefined
+    })
+
+    return {
+      startTime: new Date(block.startTime).getTime(),
+      startEvent: Object.assign({}, block.startEvent, { tab: block.startEvent.tab.uuid }),
+      completeEvent: Object.assign(
+        {},
+        block.completeEvent,
+        { execOptions, evaluatorOptions },
+        { tab: block.completeEvent.tab.uuid }
+      )
+    }
+  }
+}
+
+export function isHidden(block: BlockModel) {
+  if (isActive(block) || isAnnouncement(block) || isCancelled(block) || isEmpty(block)) {
+    return false
+  } else {
+    return block.startEvent.echo === false
   }
 }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -29,7 +29,8 @@ import {
   History,
   CommandStartEvent,
   CommandCompleteEvent,
-  isWatchable
+  isWatchable,
+  SnapshotBlock
 } from '@kui-shell/core'
 
 import Block from './Block'
@@ -44,9 +45,11 @@ import {
   Cancelled,
   Processing,
   isActive,
+  isHidden,
   isOk,
   isProcessing,
   hasCommand,
+  snapshot,
   hasUUID,
   BlockModel
 } from './Block/BlockModel'
@@ -269,7 +272,21 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
     // prefetch command history; this helps with master history
     History(sbuuid)
 
+    // associate a tab facade with the split
     this.tabFor(state)
+
+    const onSnapshot = (handler: (snapshot: SnapshotBlock[]) => void) => {
+      const scrollbackIdx = this.findSplit(this.state, sbuuid)
+      if (scrollbackIdx < 0) {
+        throw new Error('Invalid state')
+      } else {
+        const { blocks } = this.state.splits[scrollbackIdx]
+        handler(blocks.map(snapshot).filter(_ => _))
+      }
+    }
+    eventBus.emitAddSnapshotable()
+    eventBus.onSnapshotRequest(onSnapshot)
+    state.cleaners.push(() => eventBus.offSnapshotRequest(onSnapshot))
 
     eventBus.onceWithTabId('/tab/close/request', sbuuid, async () => {
       // async, to allow for e.g. command completion events to finish
@@ -324,12 +341,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
 
   /** the REPL started executing a command */
   private onExecStart(uuid = this.currentUUID, event: CommandStartEvent) {
-    if (event.echo === false) {
-      // then the command wants to be incognito; e.g. onclickSilence for tables
-      return
-    }
-
-    if (isPopup() && this.isSidecarVisible()) {
+    if (event.echo !== false && isPopup() && this.isSidecarVisible()) {
       // see https://github.com/IBM/kui/issues/4183
       this.props.closeSidecar()
     }
@@ -343,9 +355,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
         return {
           blocks: curState.blocks
             .slice(0, idx)
-            .concat([
-              Processing(curState.blocks[idx], event.command, event.execUUID, event.evaluatorOptions.isExperimental)
-            ])
+            .concat([Processing(curState.blocks[idx], event, event.evaluatorOptions.isExperimental)])
         }
       })
     }
@@ -361,11 +371,6 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
 
   /** the REPL finished executing a command */
   private onExecEnd(uuid = this.currentUUID, event: CommandCompleteEvent<ScalarResponse>) {
-    if (event.echo === false) {
-      // then the command wants to be incognito; e.g. onclickSilence for tables
-      return
-    }
-
     if (!uuid) return
 
     this.splice(uuid, curState => {
@@ -381,15 +386,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
 
             const blocks = curState.blocks
               .slice(0, inProcessIdx) // everything before
-              .concat([
-                Finished(
-                  inProcess,
-                  event.responseType === 'ScalarResponse' ? event.response : true,
-                  event.cancelled,
-                  event.historyIdx,
-                  prefersTerminalPresentation
-                )
-              ]) // mark as finished
+              .concat([Finished(inProcess, event, prefersTerminalPresentation)]) // mark as finished
               .concat(curState.blocks.slice(inProcessIdx + 1)) // everything after
               .concat([Active()]) // plus a new block!
             return {
@@ -570,6 +567,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
    */
   private removeSplit(sbuuid: string) {
     this.setState(curState => {
+      eventBus.emitRemoveSnapshotable()
       eventBus.emitTabLayoutChange(this.props.tab.uuid)
 
       const idx = this.findSplit(this.state, sbuuid)
@@ -757,33 +755,35 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
                 ref: ref => this.tabRefFor(scrollback, ref),
                 onClick: this.onClick.bind(this, scrollback)
               },
-              scrollback.blocks.map((_, idx) => (
-                <Block
-                  key={(hasUUID(_) ? _.execUUID : idx) + `-${idx}-isPartOfMiniSplit=${isMiniSplit}`}
-                  idx={idx}
-                  displayedIdx={idx - scrollback.nAnnouncements + 1}
-                  model={_}
-                  uuid={scrollback.uuid}
-                  tab={tab}
-                  noActiveInput={this.props.noActiveInput}
-                  onOutputRender={this.onOutputRender.bind(this, scrollback)}
-                  willRemove={this.willRemoveBlock.bind(this, scrollback.uuid, idx)}
-                  willLoseFocus={() => this.doFocus(scrollback)}
-                  isExperimental={hasCommand(_) && _.isExperimental}
-                  isFocused={sbidx === this.state.focusedIdx && isActive(_)}
-                  prefersTerminalPresentation={isOk(_) && _.prefersTerminalPresentation}
-                  isPartOfMiniSplit={isMiniSplit}
-                  isVisibleInMiniSplit={idx === showThisIdxInMiniSplit || idx === nBlocks - 1}
-                  isWidthConstrained={isWidthConstrained}
-                  navigateTo={this.navigateTo.bind(this, scrollback)}
-                  ref={c => {
-                    if (isActive(_)) {
-                      // grab a ref to the active block, to help us maintain focus
-                      scrollback._activeBlock = c
-                    }
-                  }}
-                />
-              ))
+              scrollback.blocks
+                .filter(_ => !isHidden(_))
+                .map((_, idx) => (
+                  <Block
+                    key={(hasUUID(_) ? _.execUUID : idx) + `-${idx}-isPartOfMiniSplit=${isMiniSplit}`}
+                    idx={idx}
+                    displayedIdx={idx - scrollback.nAnnouncements + 1}
+                    model={_}
+                    uuid={scrollback.uuid}
+                    tab={tab}
+                    noActiveInput={this.props.noActiveInput}
+                    onOutputRender={this.onOutputRender.bind(this, scrollback)}
+                    willRemove={this.willRemoveBlock.bind(this, scrollback.uuid, idx)}
+                    willLoseFocus={() => this.doFocus(scrollback)}
+                    isExperimental={hasCommand(_) && _.isExperimental}
+                    isFocused={sbidx === this.state.focusedIdx && isActive(_)}
+                    prefersTerminalPresentation={isOk(_) && _.prefersTerminalPresentation}
+                    isPartOfMiniSplit={isMiniSplit}
+                    isVisibleInMiniSplit={idx === showThisIdxInMiniSplit || idx === nBlocks - 1}
+                    isWidthConstrained={isWidthConstrained}
+                    navigateTo={this.navigateTo.bind(this, scrollback)}
+                    ref={c => {
+                      if (isActive(_)) {
+                        // grab a ref to the active block, to help us maintain focus
+                        scrollback._activeBlock = c
+                      }
+                    }}
+                  />
+                ))
             )
           })}
 

--- a/plugins/plugin-core-support/src/lib/cmds/replay.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/replay.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { eventBus, Snapshot, SnapshotBlock, Registrar, UsageModel, promiseEach } from '@kui-shell/core'
+
+/**
+ * Schema for a serialized snapshot of the Inputs and Outputs of
+ * command executions.
+ */
+interface SerializedSnapshot {
+  apiVersion: 'kui-shell/v1'
+  kind: 'Snapshot'
+  spec: Snapshot
+}
+
+/** @return wether or not the given `raw` json is an instance of SerializedSnapshot */
+function isSerializedSnapshot(raw: Record<string, any>): raw is SerializedSnapshot {
+  const model = raw as SerializedSnapshot
+  return model.apiVersion === 'kui-shell/v1' && model.kind === 'Snapshot' && Array.isArray(model.spec.windows)
+}
+
+/** For the Kui command registration: enforce one mandatory positional parameter */
+function usage(cmd: string): { usage: UsageModel } {
+  return { usage: { strict: cmd, required: [{ name: '<filepath>', docs: 'path to saved snapshot' }] } }
+}
+
+let nSnapshotable = 0
+export function preload() {
+  eventBus.onAddSnapshotable(() => nSnapshotable++)
+  eventBus.onRemoveSnapshotable(() => nSnapshotable--)
+}
+
+/** Command registration */
+export default function(registrar: Registrar) {
+  // register the `replay` command
+  registrar.listen(
+    '/replay',
+    async ({ argvNoOptions, REPL, tab }) => {
+      const filepath = argvNoOptions[argvNoOptions.indexOf('replay') + 1]
+      const model = JSON.parse(
+        (await REPL.rexec<{ data: string }>(`vfs fstat ${REPL.encodeComponent(filepath)} --with-data`)).content.data
+      )
+
+      if (!isSerializedSnapshot(model)) {
+        console.error('invalid snapshot', model)
+        throw new Error('Invalid snapshot')
+      } else {
+        await promiseEach(model.spec.windows[0].tabs[0].blocks, async ({ startEvent, completeEvent }) => {
+          // NOTE: work around the replayability issue of split command not returning a replayable model: https://github.com/IBM/kui/issues/5399
+          if (startEvent.command === 'split') {
+            await REPL.qexec('split')
+          }
+
+          eventBus.emitCommandStart(
+            Object.assign({}, startEvent, { tab: Object.assign({}, tab, { uuid: startEvent.tab }) })
+          )
+          eventBus.emitCommandComplete(
+            Object.assign({}, completeEvent, { tab: Object.assign({}, tab, { uuid: completeEvent.tab }) })
+          )
+        })
+        return true
+      }
+    },
+    usage('replay')
+  )
+
+  // register the `snapshot` command
+  registrar.listen(
+    '/snapshot',
+    ({ argvNoOptions, REPL }) =>
+      new Promise((resolve, reject) => {
+        let nSplits = 0
+        let blocks: SnapshotBlock[] = []
+
+        eventBus.emitSnapshotRequest(async (blocksInSplit: SnapshotBlock[]) => {
+          blocks = blocks.concat(blocksInSplit)
+          nSplits++
+
+          if (nSplits === nSnapshotable) {
+            // sort blocks by startTime
+            blocks.sort((a, b) => (a.startTime > b.startTime ? 1 : -1))
+
+            try {
+              const filepath = argvNoOptions[argvNoOptions.indexOf('snapshot') + 1]
+              const snapshot: SerializedSnapshot = {
+                apiVersion: 'kui-shell/v1',
+                kind: 'Snapshot',
+                spec: {
+                  windows: [
+                    {
+                      uuid: '0',
+                      tabs: [
+                        {
+                          uuid: '0',
+                          blocks
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+              const data = JSON.stringify(snapshot)
+              await REPL.rexec<{ data: string }>(`fwrite ${REPL.encodeComponent(filepath)}`, { data })
+
+              resolve(true)
+            } catch (err) {
+              reject(err)
+            }
+          }
+        })
+      }),
+    usage('snapshot')
+  )
+}

--- a/plugins/plugin-core-support/src/plugin.ts
+++ b/plugins/plugin-core-support/src/plugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-19 IBM Corporation
+ * Copyright 2017-20 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import quit from './lib/cmds/quit'
 import clear from './lib/cmds/clear'
 import base64 from './lib/cmds/base64'
 import prompt from './lib/cmds/prompt'
+import replay from './lib/cmds/replay'
 import sleep from './lib/cmds/sleep'
 import history from './lib/cmds/history/history'
 import tabManagement from './lib/cmds/tab-management'
@@ -40,6 +41,7 @@ export default async (commandTree: Registrar) => {
     clear(commandTree),
     base64(commandTree),
     prompt(commandTree),
+    replay(commandTree),
     sleep(commandTree),
     history(commandTree),
     tabManagement(commandTree)

--- a/plugins/plugin-core-support/src/preload.ts
+++ b/plugins/plugin-core-support/src/preload.ts
@@ -29,6 +29,7 @@ const registration: PreloadRegistration = () => {
 
   if (!isHeadless()) {
     asyncs.push(import('./lib/cmds/zoom').then(_ => _.preload()))
+    asyncs.push(import('./lib/cmds/replay').then(_ => _.preload()))
   }
 
   return Promise.all(asyncs)

--- a/plugins/plugin-core-support/src/test/core-support/replay.ts
+++ b/plugins/plugin-core-support/src/test/core-support/replay.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI, ReplExpect, Selectors, SidecarExpect, testAbout } from '@kui-shell/test'
+import { splitViaCommand, focus } from '../core-support2/split-helpers'
+
+const base64Input = 'hi'
+const base64Output = Buffer.from(base64Input).toString('base64')
+
+describe(`snapshot and replay ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  it(`should base64 ${base64Input}`, () =>
+    CLI.command(`base64 ${base64Input}`, this.app)
+      .then(ReplExpect.okWithString(base64Output))
+      .catch(Common.oops(this, true)))
+  testAbout(this)
+
+  it('should snapshot', () =>
+    CLI.command('snapshot /tmp/test.kui', this.app)
+      .then(ReplExpect.justOK)
+      .catch(Common.oops(this, true)))
+
+  it('should refresh', () => Common.refresh(this))
+
+  it('should replay', async () => {
+    try {
+      const { count } = await CLI.command('replay /tmp/test.kui', this.app)
+
+      // verify the base64 command replay
+      let idx = 0
+      await this.app.client.waitUntil(async () => {
+        const txt = await this.app.client.getText(Selectors.OUTPUT_N(count))
+        if (++idx > 5) {
+          console.error(`still waiting for expected=${txt}; actual=${txt}`)
+        }
+        return txt === base64Output
+      }, CLI.waitTimeout)
+
+      // verify the about replay
+      await SidecarExpect.open(this.app)
+    } catch (err) {
+      await Common.oops(this, true)
+    }
+  })
+})
+
+describe(`split, snapshot and replay ${process.env.MOCHA_RUN_TARGET || ''}`, async function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  const splitTheTerminalViaCommand = splitViaCommand.bind(this)
+  const clickToFocus = focus.bind(this)
+
+  const doBase64 = (splitIdx: number) => {
+    clickToFocus(splitIdx)
+    it(`should base64 ${base64Input}`, () =>
+      CLI.commandInSplit(`base64 ${base64Input}`, this.app, splitIdx)
+        .then(ReplExpect.okWithString(base64Output))
+        .catch(Common.oops(this, true)))
+  }
+
+  const doSnapShot = (splitIdx: number) => {
+    it('should snapshot', () =>
+      CLI.commandInSplit('snapshot /tmp/test.kui', this.app, splitIdx)
+        .then(ReplExpect.justOK)
+        .catch(Common.oops(this, true)))
+  }
+
+  doBase64(1)
+  splitTheTerminalViaCommand(2)
+  clickToFocus(2)
+  doBase64(2)
+
+  doSnapShot(2)
+
+  it('should refresh', () => Common.refresh(this))
+  it('should replay', () => CLI.command('replay /tmp/test.kui', this.app).catch(Common.oops(this, true)))
+  it('should validate replay', async () => {
+    try {
+      const countInSplit1 = await CLI.commandInSplit('version', this.app, 1).then(_ => _.count)
+      const countInSplit2 = await CLI.commandInSplit('version', this.app, 2).then(_ => _.count)
+
+      let idx = 0
+      await this.app.client.waitUntil(async () => {
+        // commands in split1: [session connect in browser],base64, split, version
+        const base64InSplit1 = await this.app.client.getText(Selectors.OUTPUT_N(countInSplit1 - 2, 1))
+        // commands in split2: base64,version
+        const base64InSplit2 = await this.app.client.getText(Selectors.OUTPUT_N(countInSplit2 - 1, 2))
+
+        if (++idx > 5) {
+          console.error(`still waiting for expected=${base64Output}; actual=${base64InSplit1}, ${base64InSplit2}`)
+        }
+        return base64InSplit1 === base64Output && base64InSplit2 === base64Output
+      }, CLI.waitTimeout)
+    } catch (err) {
+      await Common.oops(this, true)
+    }
+  })
+})


### PR DESCRIPTION
Limitations:

1) does not handle multiple windows
2) does not handle multiple tabs
3) inconsistency between clearing of terminal and replay; clearing will not close the sidecar, but after a replay, the sidecar won't be open

Fixes #5280
Closes #5281 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
