### PR TITLE
fix(plugins/plugin-kubectl): certain filepath options to kubectl were…

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/options.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/options.ts
@@ -24,8 +24,9 @@ type TableFormat = 'wide' | string // want: 'custom-columns-file=' | 'custom-col
 type CustomFormat = string // want: 'go-template' | 'go-template-file' | 'jsonpath' | 'jsonpath-file'
 type OutputFormat = EntityFormat | TableFormat | CustomFormat
 
-export function fileOf(args: Arguments<KubeOptions>): string {
-  return args.parsedOptions.f || args.parsedOptions.filename
+export function fileOf(args: Pick<Arguments<KubeOptions>, 'parsedOptions'>): string {
+  const filename = args.parsedOptions.f || args.parsedOptions.filename
+  return typeof filename === 'string' ? filename : undefined
 }
 
 export function kustomizeOf(args: Arguments<KubeOptions>): string {
@@ -207,11 +208,26 @@ export interface KubeExecOptions extends ExecOptions {
   initialResponse: string
 }
 
+/** Options that specify a filepath */
+export type FilepathOption =
+  | 'kubeconfig'
+  | 'f'
+  | 'filename'
+  | 'k'
+  | 'kustomize'
+  | 'client-key'
+  | 'client-certificate'
+  | 'certificate-authority'
+  | 'cache-dir'
+
+/** An incomplete set of kubectl options */
 export interface KubeOptions extends ParsedOptions {
   A?: boolean
   'all-namespaces'?: boolean
 
+  cluster?: string
   context?: string
+  kubeconfig?: string
 
   n?: string
   namespace?: string


### PR DESCRIPTION
… not tilde-expanded

Fixes #5415

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
