### PR TITLE
feat: commentary command to add comments to REPL

### DIFF
--- a/packages/core/src/models/command.ts
+++ b/packages/core/src/models/command.ts
@@ -100,6 +100,12 @@ export interface CommandOptions extends CapabilityRequirements {
    *
    */
   isExperimental?: boolean
+
+  /**
+   * Is the command only want to show output and hide input?
+   *
+   */
+  outputOnly?: boolean
 }
 
 export interface Event {

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -41,7 +41,7 @@ type WithState<S extends BlockState> = { state: S }
 type WithResponse<R extends ScalarResponse> = { response: R } & WithStartTime
 type WithValue = { value: string }
 type WithAnnouncement = { isAnnouncement: boolean }
-type WithPreferences = { prefersTerminalPresentation: boolean }
+type WithPreferences = { prefersTerminalPresentation: boolean; outputOnly?: boolean }
 type WithCommandStart = { startEvent: CommandStartEvent }
 type WithCommandComplete = { completeEvent: CommandCompleteEvent }
 
@@ -199,7 +199,8 @@ export function Cancelled(block: BlockModel): CancelledBlock | EmptyBlock {
 export function Finished(
   block: ProcessingBlock,
   event: CommandCompleteEvent,
-  prefersTerminalPresentation = false
+  prefersTerminalPresentation = false,
+  outputOnly = false
 ): FinishedBlock {
   const response = event.responseType === 'ScalarResponse' ? (event.response as ScalarResponse) : true
   const { historyIdx } = event
@@ -232,6 +233,7 @@ export function Finished(
       execUUID: block.execUUID,
       startTime: block.startTime,
       prefersTerminalPresentation,
+      outputOnly,
       state: BlockState.ValidResponse
     }
   }
@@ -269,4 +271,8 @@ export function isHidden(block: BlockModel) {
   } else {
     return block.startEvent.echo === false
   }
+}
+
+export function isOutputOnly(block: BlockModel) {
+  return isOk(block) && block.outputOnly
 }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
@@ -19,7 +19,16 @@ import { Tab as KuiTab, eventChannelUnsafe } from '@kui-shell/core'
 
 import Input, { InputOptions } from './Input'
 import Output from './Output'
-import { BlockModel, isActive, isEmpty, isFinished, isProcessing, isAnnouncement, hasUUID } from './BlockModel'
+import {
+  BlockModel,
+  isActive,
+  isEmpty,
+  isFinished,
+  isOutputOnly,
+  isProcessing,
+  isAnnouncement,
+  hasUUID
+} from './BlockModel'
 
 export type BlockViewTraits = {
   isExperimental?: boolean
@@ -162,7 +171,7 @@ export default class Block extends React.PureComponent<Props, State> {
           data-is-visible-in-minisplit={this.props.isVisibleInMiniSplit || undefined}
           ref={c => this.setState({ _block: c })}
         >
-          {isAnnouncement(this.props.model) ? (
+          {isAnnouncement(this.props.model) || isOutputOnly(this.props.model) ? (
             this.output()
           ) : isActive(this.props.model) || isEmpty(this.props.model) ? (
             this.input()

--- a/plugins/plugin-client-common/src/controller/commentary.ts
+++ b/plugins/plugin-client-common/src/controller/commentary.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Arguments, Registrar, UsageModel } from '@kui-shell/core'
+
+/**
+ * commentary command usage
+ */
+const usage: UsageModel = {
+  command: 'commentary',
+  strict: 'commentary',
+  example: 'commentary -f [<markdown file path>]',
+  docs: 'Commentary',
+  optional: [
+    {
+      name: '-f',
+      docs: 'File that contains the texts'
+    },
+    {
+      name: '--file',
+      docs: 'File that contains the texts'
+    }
+  ]
+}
+
+async function addComment(args: Arguments) {
+  // delegate to the card command
+  return args.tab.REPL.qexec(args.command.replace(/^commentary/, 'card'))
+}
+
+/**
+ * This plugin introduces the /card command
+ *
+ */
+export default async (commandTree: Registrar) => {
+  commandTree.listen('/commentary', addComment, { usage, outputOnly: true })
+}

--- a/plugins/plugin-client-common/src/plugin.ts
+++ b/plugins/plugin-client-common/src/plugin.ts
@@ -22,5 +22,6 @@ export default async (registrar: Registrar) => {
     await import(/* webpackMode: "lazy" */ './controller/split').then(_ => registrar.listen('/split', _.default))
     await import(/* webpackMode: "lazy" */ './controller/alert').then(_ => _.default(registrar))
     await import(/* webpackMode: "lazy" */ './controller/card').then(_ => _.default(registrar))
+    await import(/* webpackMode: "lazy" */ './controller/commentary').then(_ => _.default(registrar))
   }
 }

--- a/plugins/plugin-core-support/src/test/core-support/card.ts
+++ b/plugins/plugin-core-support/src/test/core-support/card.ts
@@ -13,9 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as assert from 'assert'
+import { dirname } from 'path'
 
 import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
+
+const ROOT = dirname(require.resolve('@kui-shell/plugin-core-support/package.json'))
 
 describe('card command', function(this: Common.ISuite) {
   before(Common.before(this))
@@ -37,6 +41,16 @@ describe('card command', function(this: Common.ISuite) {
         await this.app.client.waitForVisible(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD}`)
         const text = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD}`)
         return assert.ok(text.includes('foo') && text.includes('bar'))
+      })
+      .catch(Common.oops(this)))
+
+  it('should show card with file', () =>
+    CLI.command(`card -f=${ROOT}/tests/data/comment.md`, this.app)
+      .then(async () => {
+        await this.app.client.waitForVisible(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD}`)
+        const head1: string = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD} h1`)
+        const head2: string = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD} h2`)
+        return assert.ok(head1 === 'The Kui Framework for Graphical Terminals' && head2 === 'Installation')
       })
       .catch(Common.oops(this)))
 

--- a/plugins/plugin-core-support/src/test/core-support/commentary.ts
+++ b/plugins/plugin-core-support/src/test/core-support/commentary.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert'
+import { dirname } from 'path'
+
+import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
+
+const ROOT = dirname(require.resolve('@kui-shell/plugin-core-support/package.json'))
+
+describe('commentary command', function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  const addComment = () => {
+    it('should show comment with file', () =>
+      CLI.command(`commentary -f=${ROOT}/tests/data/comment.md`, this.app)
+        .then(async () => {
+          await this.app.client.waitForVisible(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD}`)
+          const head1: string = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD} h1`)
+          const head2: string = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD} h2`)
+          return assert.ok(head1 === 'The Kui Framework for Graphical Terminals' && head2 === 'Installation')
+        })
+        .catch(Common.oops(this)))
+  }
+
+  addComment()
+  it('should show version', () =>
+    CLI.command('version', this.app)
+      .then(ReplExpect.okWithCustom({ expect: Common.expectedVersion }))
+      .catch(Common.oops(this)))
+  addComment()
+})

--- a/plugins/plugin-core-support/tests/data/comment.md
+++ b/plugins/plugin-core-support/tests/data/comment.md
@@ -1,0 +1,3 @@
+# The Kui Framework for Graphical Terminals
+
+## Installation


### PR DESCRIPTION
This PR introduces the command: commentary that add the capability of commenting in the REPL

Usage: `commentary -f file.md`

E.g. `commentary README.md`

![Screen Shot 2020-08-20 at 5 54 55 PM](https://user-images.githubusercontent.com/21212160/90829715-4252ee80-e30e-11ea-84cb-041aa901f2c6.png)



Fixes #5428

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
