### PR TITLE
fix(plugins/plugin-client-common): add support for titles in commentary

### DIFF
--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -197,7 +197,8 @@ export const WATCHER_N_CLOSE = (N: number) => WATCHER_N_DROPDOWN_ITEM(N, 'Stop w
 export const WATCHER_N_SHOW_AS_TABLE = (N: number) => WATCHER_N_DROPDOWN_ITEM(N, 'Show as table')
 
 // terminal card
-export const TERMINAl_CARD = `.kui--card`
+export const TERMINAL_CARD = `.kui--card`
+export const TERMINAL_CARD_TITLE = `${TERMINAL_CARD} .kui--card-title`
 
 export const CURRENT_GRID_FOR_SPLIT = (N: number) => `${CURRENT_PROMPT_BLOCK_FOR_SPLIT(N)} ${_PROMPT} ${_TABLE_AS_GRID}`
 export const CURRENT_GRID_BY_NAME_FOR_SPLIT = (N: number, name: string) =>

--- a/plugins/plugin-client-common/src/components/spi/Card/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Card/impl/PatternFly.tsx
@@ -120,7 +120,7 @@ export default class PatternflyCard extends React.PureComponent<Props, State> {
 
   private title() {
     if (this.props.title) {
-      return <CardTitle> {this.props.title} </CardTitle>
+      return <CardTitle className="kui--card-title">{this.props.title}</CardTitle>
     }
   }
 

--- a/plugins/plugin-client-common/src/controller/commentary.ts
+++ b/plugins/plugin-client-common/src/controller/commentary.ts
@@ -26,11 +26,13 @@ const usage: UsageModel = {
   docs: 'Commentary',
   optional: [
     {
-      name: '-f',
-      docs: 'File that contains the texts'
+      name: '--title',
+      alias: '-t',
+      docs: 'Title for the commentary'
     },
     {
       name: '--file',
+      alias: '-f',
       docs: 'File that contains the texts'
     }
   ]

--- a/plugins/plugin-core-support/src/test/core-support/card.ts
+++ b/plugins/plugin-core-support/src/test/core-support/card.ts
@@ -38,8 +38,8 @@ describe('card command', function(this: Common.ISuite) {
   it('should execute the command and show card with foo bar: card foo --title=bar', () =>
     CLI.command('card foo --title=bar', this.app)
       .then(async () => {
-        await this.app.client.waitForVisible(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD}`)
-        const text = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD}`)
+        await this.app.client.waitForVisible(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD}`)
+        const text = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD}`)
         return assert.ok(text.includes('foo') && text.includes('bar'))
       })
       .catch(Common.oops(this)))
@@ -47,9 +47,9 @@ describe('card command', function(this: Common.ISuite) {
   it('should show card with file', () =>
     CLI.command(`card -f=${ROOT}/tests/data/comment.md`, this.app)
       .then(async () => {
-        await this.app.client.waitForVisible(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD}`)
-        const head1: string = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD} h1`)
-        const head2: string = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD} h2`)
+        await this.app.client.waitForVisible(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD}`)
+        const head1: string = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD} h1`)
+        const head2: string = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD} h2`)
         return assert.ok(head1 === 'The Kui Framework for Graphical Terminals' && head2 === 'Installation')
       })
       .catch(Common.oops(this)))
@@ -57,8 +57,8 @@ describe('card command', function(this: Common.ISuite) {
   it('should execute the command and show card with image: card foo --title=bar --icon="icons/png/TestIcon.png"', () =>
     CLI.command('card foo --title=bar --icon="icons/png/TestIcon.png"', this.app)
       .then(async () => {
-        await this.app.client.waitForVisible(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD}`)
-        const text = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD}`)
+        await this.app.client.waitForVisible(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD}`)
+        const text = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD}`)
         return assert.ok(text.includes('foo') && text.includes('bar'))
       })
       .then(async () => {
@@ -70,7 +70,7 @@ describe('card command', function(this: Common.ISuite) {
               .getAttribute('src')
             const fs = require('fs')
             return fs.statSync(`${__dirname}/${imageSrc}`)
-          }, `${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD}`)
+          }, `${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD}`)
         }
 
         if (process.env.MOCHA_RUN_TARGET === 'webpack') {
@@ -82,7 +82,7 @@ describe('card command', function(this: Common.ISuite) {
             const image = new Image()
             image.src = `${window.location.origin}/${imageSrc}`
             if (image.height === 0) throw new Error(`image not found: ${window.location.origin}/${imageSrc}`)
-          }, `${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD}`)
+          }, `${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD}`)
         }
       })
       .catch(Common.oops(this)))

--- a/plugins/plugin-core-support/src/test/core-support/commentary.ts
+++ b/plugins/plugin-core-support/src/test/core-support/commentary.ts
@@ -27,12 +27,19 @@ describe('commentary command', function(this: Common.ISuite) {
 
   const addComment = () => {
     it('should show comment with file', () =>
-      CLI.command(`commentary -f=${ROOT}/tests/data/comment.md`, this.app)
+      CLI.command(`commentary --title "hello there" -f=${ROOT}/tests/data/comment.md`, this.app)
         .then(async () => {
-          await this.app.client.waitForVisible(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD}`)
-          const head1: string = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD} h1`)
-          const head2: string = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAl_CARD} h2`)
-          return assert.ok(head1 === 'The Kui Framework for Graphical Terminals' && head2 === 'Installation')
+          await this.app.client.waitForVisible(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD}`)
+          const title: string = await this.app.client.getText(
+            `${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD_TITLE}`
+          )
+          assert.strictEqual(title, 'hello there')
+
+          const head1: string = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD} h1`)
+          assert.strictEqual(head1, 'The Kui Framework for Graphical Terminals')
+
+          const head2: string = await this.app.client.getText(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD} h2`)
+          assert.strictEqual(head2, 'Installation')
         })
         .catch(Common.oops(this)))
   }


### PR DESCRIPTION
this also fixes a few minor issues hidden from users:

- the test api Selectors had TERMINAl lowercase l at the end
- assert.ok which should be two assert.strictEqual in the commentary test
- in the usage for commentary, we had two entries, for -f and --file. the usage model allows for a single entry with an alias field

Fixes #5434

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
