### PR TITLE
fix(plugins/plugin-client-common): defer loading of both icon sets

### DIFF
--- a/plugins/plugin-client-common/src/components/spi/Icons/index.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Icons/index.tsx
@@ -17,8 +17,9 @@
 import * as React from 'react'
 
 import KuiContext from '../../Client/context'
-import Carbon from './impl/Carbon'
-import PatternFly from './impl/PatternFly'
+
+const Carbon = React.lazy(() => import('./impl/Carbon'))
+const PatternFly = React.lazy(() => import('./impl/PatternFly'))
 
 export type SupportedIcon =
   | 'Add'
@@ -68,8 +69,10 @@ export default function iconImpl(props: Props): React.ReactElement {
     return <Carbon {...props} />
   }
   return (
-    <KuiContext.Consumer>
-      {config => (config.components === 'patternfly' ? <PatternFly {...props} /> : <Carbon {...props} />)}
-    </KuiContext.Consumer>
+    <React.Suspense fallback={<div />}>
+      <KuiContext.Consumer>
+        {config => (config.components === 'patternfly' ? <PatternFly {...props} /> : <Carbon {...props} />)}
+      </KuiContext.Consumer>
+    </React.Suspense>
   )
 }


### PR DESCRIPTION
Fixes #5444

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
