### PR TITLE
fix(plugins/plugin-kubectl): kubectl get -f can show undefined in tab…

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -25,7 +25,7 @@ import commandPrefix from '../command-prefix'
 import doGetWatchTable from './watch/get-watch'
 import extractAppAndName from '../../lib/util/name'
 import { isUsage, doHelp } from '../../lib/util/help'
-import { KubeOptions, isEntityRequest, isTableRequest, formatOf, isWatchRequest, getNamespace } from './options'
+import { KubeOptions, isEntityRequest, isTableRequest, fileOf, formatOf, isWatchRequest, getNamespace } from './options'
 import { stringToTable, KubeTableResponse, isKubeTableResponse, computeDurations } from '../../lib/view/formatTable'
 import {
   KubeResource,
@@ -242,9 +242,10 @@ export const doGet = (command: string) =>
 
     // first, we do the raw exec of the given command
     const isTableReq = isTableRequest(args)
-    const fullKind = isTableReq
-      ? getKind(command, args, args.argvNoOptions[args.argvNoOptions.indexOf('get') + 1])
-      : undefined
+    const fullKind =
+      isTableReq && !fileOf(args) // <-- don't call getKind for `get -f`
+        ? getKind(command, args, args.argvNoOptions[args.argvNoOptions.indexOf('get') + 1])
+        : undefined
 
     if (!isHeadless() && isWatchRequest(args)) {
       // special case: get --watch/watch-only


### PR DESCRIPTION
…le title

Fixes #5469

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
