### PR TITLE
feat(plugins/plugin-client-common): allow easier rerunning of command from terminal

### DIFF
--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -128,6 +128,8 @@ export const PROMPT_BLOCK_FINAL = `${PROMPT_BLOCK}:nth-last-child(1)`
 export const OVERFLOW_MENU = '.kui--repl-block-right-element.kui--toolbar-button-with-icon'
 export const PROMPT_BLOCK_MENU = (N: number) => `${PROMPT_BLOCK_N(N)} ${OVERFLOW_MENU}`
 export const BLOCK_REMOVE_BUTTON = `${OVERFLOW_MENU} button[data-mode="Remove"]` // in carbon, this is a global
+export const COMMAND_COPY_BUTTON = `${OVERFLOW_MENU} button[data-mode="Copy"]` // in carbon, this is a global
+export const COMMAND_RERUN_BUTTON = `${OVERFLOW_MENU} button[data-mode="Rerun"]` // in carbon, this is a global
 export const PROMPT_LAST = `${PROMPT_BLOCK_LAST} .repl-input-element`
 export const PROMPT_FINAL = `${PROMPT_BLOCK_FINAL} .repl-input-element`
 export const OUTPUT_LAST = `${PROMPT_BLOCK_LAST} .repl-result`

--- a/plugins/plugin-bash-like/src/test/bash-like/rerun.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/rerun.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI, Selectors, ReplExpect, SidecarExpect } from '@kui-shell/test'
+
+const runTheTests = process.env.MOCHA_RUN_TARGET !== 'webpack' || process.env.KUI_USE_PROXY === 'true'
+const pit = runTheTests ? it : xit
+
+describe(`rerun command ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  it('should rerun about', async () => {
+    try {
+      // do about
+      const res = await CLI.command('about', this.app)
+      await this.app.client.waitForVisible(Selectors.SIDECAR)
+      await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON_SELECTED_V2('about'))
+
+      // close sidecar
+      await this.app.client.waitForVisible(Selectors.SIDECAR_FULLY_CLOSE_BUTTON)
+      await this.app.client.click(Selectors.SIDECAR_FULLY_CLOSE_BUTTON)
+      await SidecarExpect.fullyClosed(this.app)
+
+      // rerun about
+      await this.app.client.click(Selectors.PROMPT_BLOCK_MENU(res.count))
+      await this.app.client.waitForVisible(Selectors.COMMAND_RERUN_BUTTON)
+      await this.app.client.click(Selectors.COMMAND_RERUN_BUTTON)
+
+      // sidecar should open
+      await this.app.client.waitForVisible(Selectors.SIDECAR)
+      await this.app.client.waitForVisible(Selectors.SIDECAR_MODE_BUTTON_SELECTED_V2('about'))
+    } catch (err) {
+      await Common.oops(this, true)(err)
+    }
+  })
+
+  pit('should rerun pwd', async () => {
+    try {
+      const pwdRes = await CLI.command('pwd', this.app)
+      await ReplExpect.okWithAny(pwdRes)
+      const initialDirectory = await this.app.client.getText(Selectors.OUTPUT_LAST_PTY)
+
+      await CLI.command('cd /tmp', this.app).then(ReplExpect.okWithAny)
+      const cdDirectory = await this.app.client.getText(Selectors.OUTPUT_LAST)
+
+      await this.app.client.click(Selectors.PROMPT_BLOCK_MENU(pwdRes.count))
+      await this.app.client.waitForVisible(Selectors.COMMAND_RERUN_BUTTON)
+      await this.app.client.click(Selectors.COMMAND_RERUN_BUTTON)
+
+      let idx = 0
+      await this.app.client.waitUntil(async () => {
+        const rerunDirectory = await this.app.client.getText(Selectors.OUTPUT_N_PTY(pwdRes.count))
+        if (++idx > 5) {
+          console.error(`still waiting for expected=${cdDirectory}; actual=${rerunDirectory}`)
+        }
+        return rerunDirectory !== initialDirectory && rerunDirectory === cdDirectory
+      }, CLI.waitTimeout)
+    } catch (err) {
+      await Common.oops(this, true)(err)
+    }
+  })
+})

--- a/plugins/plugin-client-common/i18n/resources_en_US.json
+++ b/plugins/plugin-client-common/i18n/resources_en_US.json
@@ -15,6 +15,8 @@
   "Drilling down to show the": "Drilling down to show the",
   "concurrencyInDurationSplit": "{0}-way concurrency with execution time {1}",
   "concurrencyColdStartInDurationSplit": "{0}-way concurrency in cold starts with execution time {1}",
+  "Copy": "Copy",
+  "Rerun": "Rerun",
   "Split the Terminal": "Split the Terminal",
   "Output has been pinned to a watch pane": "Output has been **pinned** to a watch pane",
   "No more splits allowed": "No more splits allowed",

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -46,6 +46,7 @@ type WithAnnouncement = { isAnnouncement: boolean }
 type WithPreferences = { prefersTerminalPresentation: boolean; outputOnly?: boolean }
 type WithCommandStart = { startEvent: CommandStartEvent }
 type WithCommandComplete = { completeEvent: CommandCompleteEvent }
+type WithRerun = { isRerun: boolean }
 
 /** The canonical types of Blocks, which mix up the Traits as needed */
 type ActiveBlock = WithState<BlockState.Active> & WithCWD & Partial<WithValue>
@@ -73,6 +74,7 @@ export type ProcessingBlock = WithState<BlockState.Processing> &
   WithCommand &
   WithUUID &
   WithStartTime &
+  WithRerun &
   WithCommandStart
 type CancelledBlock = WithState<BlockState.Cancelled> & WithCWD & WithCommand & WithUUID & WithStartTime
 export type CompleteBlock = OkBlock | ErrorBlock
@@ -163,12 +165,18 @@ export function Announcement(response: ScalarResponse): AnnouncementBlock {
 }
 
 /** Transform to Processing */
-export function Processing(block: BlockModel, startEvent: CommandStartEvent, isExperimental = false): ProcessingBlock {
+export function Processing(
+  block: BlockModel,
+  startEvent: CommandStartEvent,
+  isExperimental = false,
+  isRerun = false
+): ProcessingBlock {
   return {
     command: startEvent.command,
     isExperimental,
     cwd: block.cwd,
     execUUID: startEvent.execUUID,
+    isRerun,
     startEvent,
     startTime: new Date(),
     state: BlockState.Processing

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -390,7 +390,7 @@ export default class Input extends InputProvider {
               }}
               ref={c => c && c.focus()}
             />
-            {this.inputStatus()}
+            {this.inputStatus(value)}
           </span>
         )
       } else {
@@ -398,7 +398,7 @@ export default class Input extends InputProvider {
         return (
           <div className="repl-input-element-wrapper flex-layout flex-fill">
             <span className="repl-input-element flex-fill">{value}</span>
-            {this.inputStatus()}
+            {this.inputStatus(value)}
           </div>
         )
       }
@@ -452,6 +452,27 @@ export default class Input extends InputProvider {
     } */
   }
 
+  private rerunAction(command: string): DropDownAction[] {
+    return [
+      {
+        label: strings('Rerun'),
+        handler: () =>
+          hasUUID(this.props.model)
+            ? this.props.tab.REPL.pexec(command, { execUUID: this.props.model.execUUID })
+            : this.props.tab.REPL.pexec(command)
+      }
+    ]
+  }
+
+  private copyAction(command: string): DropDownAction[] {
+    return [
+      {
+        label: strings('Copy'),
+        handler: () => navigator.clipboard.writeText(command)
+      }
+    ]
+  }
+
   private removeAction(): DropDownAction[] {
     return !this.props.willRemove
       ? []
@@ -475,9 +496,13 @@ export default class Input extends InputProvider {
   }
 
   /** DropDown menu for completed blocks */
-  private dropdown() {
+  private dropdown(command: string) {
     if (!isActive(this.props.model)) {
-      const actions = this.screenshotAction().concat(this.removeAction())
+      const actions = this.screenshotAction().concat(
+        this.copyAction(command),
+        this.rerunAction(command),
+        this.removeAction()
+      )
       return (
         <DropDown
           actions={actions}
@@ -521,12 +546,12 @@ export default class Input extends InputProvider {
   }
 
   /** Status elements placed in with <input> part of the block */
-  protected inputStatus() {
+  protected inputStatus(input: string) {
     return (
       <React.Fragment>
         {this.experimentalTag()}
         {this.timestamp()}
-        {this.dropdown()}
+        {this.dropdown(input)}
       </React.Fragment>
     )
   }


### PR DESCRIPTION
This PR adds two new dropdown items to the Repl Block: Copy and Rerun. Copy button allows users to copy the command-line. Rerun button allows users to rerun the command. 

<img width="1392" alt="Screen Shot 2020-08-27 at 6 03 01 PM" src="https://user-images.githubusercontent.com/21212160/91499523-8e161280-e88f-11ea-8e82-6bdf7dedd16b.png">


Fixes #4570

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
