### PR TITLE
feat: snapshot freshening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ keys
 *flycheck*.js
 *flycheck*.js.map
 /build
+*.bak.json
 
 # these seem to come from node-pty or xterm.js
 .swp

--- a/packages/core/src/core/events.ts
+++ b/packages/core/src/core/events.ts
@@ -41,6 +41,11 @@ export type StatusStripeChangeEvent = {
   message?: string
 }
 
+export type SnapshotRequestEvent = {
+  cb: (snapshot: SnapshotBlock[]) => void
+  filter?: (evt: CommandStartEvent) => boolean
+}
+
 export type TabLayoutChangeEvent = { isSidecarNowHidden: boolean }
 type TabLayoutChangeHandler = (evt: TabLayoutChangeEvent) => void
 
@@ -121,8 +126,8 @@ class WriteEventBus extends EventBusBase {
   }
 
   /** Request a Snapshot of the given Tab */
-  public emitSnapshotRequest(cb: (snapshot: SnapshotBlock[]) => void): void {
-    this.eventBus.emit('/snapshot/request', cb)
+  public emitSnapshotRequest(evt: SnapshotRequestEvent): void {
+    this.eventBus.emit('/snapshot/request', evt)
   }
 
   /** Request a status stripe change */
@@ -161,12 +166,12 @@ class ReadEventBus extends WriteEventBus {
   }
 
   /** Snapshot the Block state of the given Tab */
-  public onSnapshotRequest(listener: (cb: (snapshot: SnapshotBlock[]) => void) => void) {
+  public onSnapshotRequest(listener: (evt: SnapshotRequestEvent) => void) {
     this.eventBus.on(`/snapshot/request`, listener)
   }
 
   /** Snapshot the Block state of the given Tab */
-  public offSnapshotRequest(listener: (cb: (snapshot: SnapshotBlock[]) => void) => void) {
+  public offSnapshotRequest(listener: (evt: SnapshotRequestEvent) => void) {
     this.eventBus.off('/snapshot', listener)
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,6 +80,7 @@ export {
   unwireToTabEvents,
   unwireToStandardEvents,
   eventBus,
+  SnapshotRequestEvent,
   StatusStripeChangeEvent,
   TabLayoutChangeEvent
 } from './core/events'

--- a/plugins/plugin-bash-like/fs/src/vfs/local.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/local.ts
@@ -39,7 +39,7 @@ class LocalVFS implements VFS {
       `sendtopty ${opts.command.replace(/^vfs/, '')}`,
       undefined,
       undefined,
-      Object.assign(opts.execOptions, { quiet: false })
+      Object.assign(opts.execOptions, { quiet: opts.parsedOptions.i ? false : opts.execOptions.quiet })
     )
   }
 

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -315,6 +315,11 @@ export function isPresentedElsewhere(block: BlockModel) {
   return isOk(block) && block.completeEvent && block.completeEvent.responseType !== 'ScalarResponse'
 }
 
+/** @return whether the block as a startEvent trait */
+export function hasStartEvent(block: BlockModel): block is BlockModel & WithCommandStart {
+  return !isAnnouncement(block) && (isProcessing(block) || isOk(block) || isOops(block))
+}
+
 /** @return whether the block has a completeEvent trait */
 export function isWithCompleteEvent(block: BlockModel): block is CompleteBlock {
   return isOk(block) || isOops(block)


### PR DESCRIPTION
This PR adds a --freshen option to the replay command, which regenerates the notebook using the current version of Kui

Fixes #5522

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
