### PR TITLE
fix: pty output has different indentation than kui command output

### DIFF
--- a/plugins/plugin-bash-like/web/scss/xterm.scss
+++ b/plugins/plugin-bash-like/web/scss/xterm.scss
@@ -64,6 +64,7 @@ disabled see https://github.com/IBM/kui/issues/3939
       .kui--input-stripe,
       .repl-input,
       .repl-result,
+      .repl-context,
       .repl-result-spinner {
         display: none;
       }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
@@ -252,7 +252,9 @@ export default class Output extends React.PureComponent<Props, State> {
 
     return (
       <div className={'repl-output ' + (hasContent ? ' repl-result-has-content' : '')}>
-        {!this.props.isPartOfMiniSplit && isFinished(this.props.model) && this.ctx()}
+        {!this.props.isPartOfMiniSplit &&
+          (isProcessing(this.props.model) || isFinished(this.props.model)) &&
+          this.ctx()}
         <div className="result-vertical">
           {this.stream()}
           {this.result()}


### PR DESCRIPTION
Fixes #5542

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
