### PR TITLE
fix(plugins/plugin-client-common): StatusStripe is blank for second+ …

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/StatusStripe/index.tsx
+++ b/plugins/plugin-client-common/src/components/Client/StatusStripe/index.tsx
@@ -29,17 +29,31 @@ const strings = i18n('plugin-client-common')
 type State = StatusStripeChangeEvent
 export type Props = Partial<State>
 
+/** see https://github.com/microsoft/TypeScript/issues/10485 */
+function hasType(evt: Partial<StatusStripeChangeEvent>): evt is Pick<Required<StatusStripeChangeEvent>, 'type'> {
+  return evt.type !== undefined
+}
+
 export default class StatusStripe extends React.PureComponent<Props, State> {
   public constructor(props: Props) {
     super(props)
     eventBus.onStatusStripeChangeRequest(this.onChangeRequest.bind(this))
 
-    this.state = Object.assign({ type: 'default' }, props)
+    this.state = this.withStateDefaults(props)
+  }
+
+  /** Overlay default values for required state variables */
+  private withStateDefaults(evt: Partial<StatusStripeChangeEvent>): Omit<Required<StatusStripeChangeEvent>, 'message'> {
+    if (hasType(evt)) {
+      return evt
+    } else {
+      return Object.assign({}, evt, { type: 'default' })
+    }
   }
 
   /** Status Stripe change request */
   private onChangeRequest(evt: StatusStripeChangeEvent) {
-    this.setState(evt)
+    this.setState(this.withStateDefaults(evt))
   }
 
   /**


### PR DESCRIPTION
…tabs

Fixes #5546

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
