### PR TITLE
fix: improve the replayability of terminal splitting

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -165,6 +165,14 @@ export {
   isCommentaryResponse,
   isElsewhereCommentaryResponse
 } from './models/CommentaryResponse'
+
+export {
+  default as TabLayoutModificationResponse,
+  isTabLayoutModificationResponse,
+  NewSplitRequest,
+  isNewSplitRequest
+} from './models/TabLayoutModificationResponse'
+
 export {
   ModeOrButton as Mode,
   Button,

--- a/packages/core/src/models/TabLayoutModificationResponse.ts
+++ b/packages/core/src/models/TabLayoutModificationResponse.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from './entity'
+import { ElsewhereCommentaryResponse } from './CommentaryResponse'
+
+/**
+ * If your controller wants to manipulate the tab layout, this is your
+ * response type!
+ *
+ */
+type TabLayoutModificationResponse<Request extends ModificationRequest = ModificationRequest> = {
+  apiVersion: 'kui-shell/v1'
+  kind: 'TabLayoutModificationResponse'
+  spec: Request & {
+    ok: ElsewhereCommentaryResponse
+  }
+}
+
+export type NewSplitRequest = {
+  modification: 'NewSplit'
+  options?: {
+    inverseColors?: boolean
+  }
+}
+
+type ModificationRequest = NewSplitRequest /* TODO: | NewTabRequest | ClearConsoleRequest | ... */
+
+export function isNewSplitRequest(
+  req: TabLayoutModificationResponse
+): req is TabLayoutModificationResponse<NewSplitRequest> {
+  return req.spec.modification === 'NewSplit'
+}
+
+export function isTabLayoutModificationResponse(entity: Entity): entity is TabLayoutModificationResponse {
+  const response = entity as TabLayoutModificationResponse
+  return response && response.apiVersion === 'kui-shell/v1' && response.kind === 'TabLayoutModificationResponse'
+}
+
+export default TabLayoutModificationResponse

--- a/packages/core/src/models/entity.ts
+++ b/packages/core/src/models/entity.ts
@@ -25,6 +25,7 @@ import { CommentaryResponse } from './CommentaryResponse'
 import RadioTable from './RadioTable'
 import Presentation from '../webapp/views/presentation'
 import { ReactNode, isValidElement } from 'react'
+import TabLayoutModificationResponse from './TabLayoutModificationResponse'
 
 export interface MessageBearingEntity {
   message: string
@@ -188,6 +189,7 @@ export type ScalarResponse<RowType extends Row = Row> =
   | (Table<RowType> & Partial<WithSourceReferences>)
   | MixedResponse
   | CommentaryResponse
+  | TabLayoutModificationResponse
 
 export function isScalarResponse(response: Entity): response is ScalarResponse {
   return !isMultiModalResponse(response) && !isNavResponse(response)

--- a/plugins/plugin-client-common/notebooks/welcome.json
+++ b/plugins/plugin-client-common/notebooks/welcome.json
@@ -11,27 +11,32 @@
             "uuid": "0",
             "blocks": [
               {
-                "startTime": 1599240322884,
+                "startTime": 1599579392573,
                 "startEvent": {
-                  "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
+                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
                   "route": "/split",
+                  "startTime": 1599579392573,
                   "command": "split",
                   "evaluatorOptions": {
                     "outputOnly": true,
+                    "flags": {
+                      "boolean": ["debug", "inverse"]
+                    },
                     "plugin": "plugin-client-common"
                   },
                   "execType": 0,
-                  "execUUID": "e4d65c71-5ba4-442a-a3a6-d64f62afa65b"
+                  "execUUID": "88affb15-b90f-419a-a910-4f314b14b1e4"
                 },
                 "completeEvent": {
-                  "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
+                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
                   "execType": 0,
+                  "completeTime": 1599579392611,
                   "command": "split",
                   "argvNoOptions": ["split"],
                   "parsedOptions": {
                     "_": ["split"]
                   },
-                  "execUUID": "e4d65c71-5ba4-442a-a3a6-d64f62afa65b",
+                  "execUUID": "88affb15-b90f-419a-a910-4f314b14b1e4",
                   "cancelled": false,
                   "evaluatorOptions": {
                     "outputOnly": true,
@@ -40,47 +45,59 @@
                   "execOptions": {
                     "type": 0,
                     "language": "en-US",
-                    "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "e4d65c71-5ba4-442a-a3a6-d64f62afa65b",
-                    "history": 61,
+                    "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
+                    "execUUID": "88affb15-b90f-419a-a910-4f314b14b1e4",
+                    "history": 250,
                     "env": {}
                   },
                   "response": {
                     "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "elsewhere": true,
-                      "tabUUID": "3_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                      "children": "Created a new split"
+                    "kind": "TabLayoutModificationResponse",
+                    "spec": {
+                      "modification": "NewSplit",
+                      "ok": {
+                        "apiVersion": "kui-shell/v1",
+                        "kind": "CommentaryResponse",
+                        "props": {
+                          "elsewhere": true,
+                          "tabUUID": "1_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
+                          "children": "Created a split"
+                        }
+                      }
                     }
                   },
                   "responseType": "ScalarResponse",
-                  "historyIdx": 61
+                  "historyIdx": 250
                 }
               },
               {
-                "startTime": 1599240324195,
+                "startTime": 1599579398762,
                 "startEvent": {
-                  "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
+                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
                   "route": "/split",
+                  "startTime": 1599579398762,
                   "command": "split --inverse",
                   "evaluatorOptions": {
                     "outputOnly": true,
+                    "flags": {
+                      "boolean": ["debug", "inverse"]
+                    },
                     "plugin": "plugin-client-common"
                   },
                   "execType": 0,
-                  "execUUID": "45576d3b-3a21-4120-a358-bc2801cfdcb1"
+                  "execUUID": "39696ae8-4fb6-4eb4-931f-97b1d1eb8ac4"
                 },
                 "completeEvent": {
-                  "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
+                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
                   "execType": 0,
+                  "completeTime": 1599579398777,
                   "command": "split --inverse",
                   "argvNoOptions": ["split"],
                   "parsedOptions": {
-                    "inverse": true,
-                    "_": ["split"]
+                    "_": ["split"],
+                    "inverse": true
                   },
-                  "execUUID": "45576d3b-3a21-4120-a358-bc2801cfdcb1",
+                  "execUUID": "39696ae8-4fb6-4eb4-931f-97b1d1eb8ac4",
                   "cancelled": false,
                   "evaluatorOptions": {
                     "outputOnly": true,
@@ -89,30 +106,115 @@
                   "execOptions": {
                     "type": 0,
                     "language": "en-US",
-                    "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "45576d3b-3a21-4120-a358-bc2801cfdcb1",
-                    "history": 62,
+                    "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
+                    "execUUID": "39696ae8-4fb6-4eb4-931f-97b1d1eb8ac4",
+                    "history": 251,
                     "env": {}
                   },
                   "response": {
                     "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "elsewhere": true,
-                      "tabUUID": "3_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                      "children": "Created a new split"
+                    "kind": "TabLayoutModificationResponse",
+                    "spec": {
+                      "modification": "NewSplit",
+                      "options": {
+                        "inverseColors": true
+                      },
+                      "ok": {
+                        "apiVersion": "kui-shell/v1",
+                        "kind": "CommentaryResponse",
+                        "props": {
+                          "elsewhere": true,
+                          "tabUUID": "1_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
+                          "children": "Created a split with inverted colors"
+                        }
+                      }
                     }
                   },
                   "responseType": "ScalarResponse",
-                  "historyIdx": 62
+                  "historyIdx": 251
                 }
               },
               {
-                "startTime": 1599240346337,
+                "startTime": 1599579412335,
                 "startEvent": {
-                  "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
+                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
                   "route": "/#",
-                  "command": "#                           # Notebooks with Kui!\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application.",
+                  "startTime": 1599579412335,
+                  "command": "#                                # Notebooks with Kui!\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application.",
+                  "evaluatorOptions": {
+                    "usage": {
+                      "command": "commentary",
+                      "strict": "commentary",
+                      "example": "commentary -f [<markdown file path>]",
+                      "docs": "Commentary",
+                      "optional": [
+                        {
+                          "name": "--title",
+                          "alias": "-t",
+                          "docs": "Title for the commentary"
+                        },
+                        {
+                          "name": "--file",
+                          "alias": "-f",
+                          "docs": "File that contains the texts"
+                        }
+                      ]
+                    },
+                    "outputOnly": true,
+                    "plugin": "plugin-client-common"
+                  },
+                  "execType": 1,
+                  "execUUID": "9d2b87ec-16af-4fe9-aeab-49e6f1f2c1e2",
+                  "echo": true
+                },
+                "completeEvent": {
+                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
+                  "execType": 1,
+                  "completeTime": 1599579412351,
+                  "command": "#                               # Notebooks with Kui!\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application.",
+                  "argvNoOptions": [
+                    "#",
+                    "                                # Notebooks with Kui!\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
+                  ],
+                  "parsedOptions": {
+                    "_": [
+                      "#",
+                      "                                # Notebooks with Kui!\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
+                    ]
+                  },
+                  "execUUID": "9d2b87ec-16af-4fe9-aeab-49e6f1f2c1e2",
+                  "cancelled": false,
+                  "echo": true,
+                  "evaluatorOptions": {
+                    "outputOnly": true,
+                    "plugin": "plugin-client-common"
+                  },
+                  "execOptions": {
+                    "echo": true,
+                    "type": 1,
+                    "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
+                    "execUUID": "9d2b87ec-16af-4fe9-aeab-49e6f1f2c1e2",
+                    "history": 252,
+                    "env": {}
+                  },
+                  "response": {
+                    "apiVersion": "kui-shell/v1",
+                    "kind": "CommentaryResponse",
+                    "props": {
+                      "children": "# Notebooks with Kui!\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
+                    }
+                  },
+                  "responseType": "ScalarResponse",
+                  "historyIdx": 252
+                }
+              },
+              {
+                "startTime": 1599579430932,
+                "startEvent": {
+                  "tab": "1_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
+                  "route": "/#",
+                  "startTime": 1599579430932,
+                  "command": "#       If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, please join us!\\n\\nhttps://github.com/IBM/kui",
                   "evaluatorOptions": {
                     "usage": {
                       "command": "commentary",
@@ -136,23 +238,24 @@
                     "plugin": "plugin-client-common"
                   },
                   "execType": 0,
-                  "execUUID": "c0d2c1cb-2274-4509-8af2-60f39efb924e"
+                  "execUUID": "1a0ecd6d-e61d-40f0-a966-44fe043068e2"
                 },
                 "completeEvent": {
-                  "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
+                  "tab": "1_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
                   "execType": 0,
-                  "command": "#                          # Notebooks with Kui!\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application.",
+                  "completeTime": 1599579430951,
+                  "command": "#      If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, please join us!\\n\\nhttps://github.com/IBM/kui",
                   "argvNoOptions": [
                     "#",
-                    "                           # Notebooks with Kui!\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
+                    "       If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, please join us!\\n\\nhttps://github.com/IBM/kui"
                   ],
                   "parsedOptions": {
                     "_": [
                       "#",
-                      "                           # Notebooks with Kui!\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
+                      "       If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, please join us!\\n\\nhttps://github.com/IBM/kui"
                     ]
                   },
-                  "execUUID": "c0d2c1cb-2274-4509-8af2-60f39efb924e",
+                  "execUUID": "1a0ecd6d-e61d-40f0-a966-44fe043068e2",
                   "cancelled": false,
                   "evaluatorOptions": {
                     "outputOnly": true,
@@ -161,27 +264,28 @@
                   "execOptions": {
                     "type": 0,
                     "language": "en-US",
-                    "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "c0d2c1cb-2274-4509-8af2-60f39efb924e",
-                    "history": 63,
+                    "tab": "1_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
+                    "execUUID": "1a0ecd6d-e61d-40f0-a966-44fe043068e2",
+                    "history": 90,
                     "env": {}
                   },
                   "response": {
                     "apiVersion": "kui-shell/v1",
                     "kind": "CommentaryResponse",
                     "props": {
-                      "children": "# Notebooks with Kui!\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
+                      "children": "If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, please join us!\n\nhttps://github.com/IBM/kui"
                     }
                   },
                   "responseType": "ScalarResponse",
-                  "historyIdx": 63
+                  "historyIdx": 90
                 }
               },
               {
-                "startTime": 1599240367683,
+                "startTime": 1599579459491,
                 "startEvent": {
-                  "tab": "3_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
+                  "tab": "1_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
                   "route": "/#",
+                  "startTime": 1599579459491,
                   "command": "#  To start, click on one of these notebooks. You will then be able to browse your selected notebook in a new Kui tab.",
                   "evaluatorOptions": {
                     "usage": {
@@ -206,11 +310,12 @@
                     "plugin": "plugin-client-common"
                   },
                   "execType": 0,
-                  "execUUID": "8ffdb073-793c-4ce3-808c-5ebd0f5d1bd9"
+                  "execUUID": "df451c89-a2cd-44a6-828d-e4e590f7a5d5"
                 },
                 "completeEvent": {
-                  "tab": "3_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
+                  "tab": "1_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
                   "execType": 0,
+                  "completeTime": 1599579459509,
                   "command": "# To start, click on one of these notebooks. You will then be able to browse your selected notebook in a new Kui tab.",
                   "argvNoOptions": [
                     "#",
@@ -222,7 +327,7 @@
                       "  To start, click on one of these notebooks. You will then be able to browse your selected notebook in a new Kui tab."
                     ]
                   },
-                  "execUUID": "8ffdb073-793c-4ce3-808c-5ebd0f5d1bd9",
+                  "execUUID": "df451c89-a2cd-44a6-828d-e4e590f7a5d5",
                   "cancelled": false,
                   "evaluatorOptions": {
                     "outputOnly": true,
@@ -231,9 +336,9 @@
                   "execOptions": {
                     "type": 0,
                     "language": "en-US",
-                    "tab": "3_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                    "execUUID": "8ffdb073-793c-4ce3-808c-5ebd0f5d1bd9",
-                    "history": 1,
+                    "tab": "1_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
+                    "execUUID": "df451c89-a2cd-44a6-828d-e4e590f7a5d5",
+                    "history": 250,
                     "env": {}
                   },
                   "response": {
@@ -244,15 +349,16 @@
                     }
                   },
                   "responseType": "ScalarResponse",
-                  "historyIdx": 1
+                  "historyIdx": 250
                 }
               },
               {
-                "startTime": 1599240376850,
+                "startTime": 1599579462583,
                 "startEvent": {
-                  "tab": "3_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
+                  "tab": "1_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
                   "route": "/ls",
-                  "command": "ls -l /kui/kubernetes/",
+                  "startTime": 1599579462583,
+                  "command": "ls -l /kui",
                   "evaluatorOptions": {
                     "usage": {
                       "command": "ls",
@@ -329,18 +435,19 @@
                     "plugin": "plugin-bash-like/fs"
                   },
                   "execType": 0,
-                  "execUUID": "acd77c44-ed6b-4616-b8e2-fab037653d3c"
+                  "execUUID": "0f986173-841f-4090-bef5-762a5bc4ed9b"
                 },
                 "completeEvent": {
-                  "tab": "3_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
+                  "tab": "1_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
                   "execType": 0,
-                  "command": "ls -l /kui/kubernetes/",
-                  "argvNoOptions": ["ls", "/kui/kubernetes/"],
+                  "completeTime": 1599579462608,
+                  "command": "ls -l /kui",
+                  "argvNoOptions": ["ls", "/kui"],
                   "parsedOptions": {
-                    "_": ["ls", "/kui/kubernetes/"],
+                    "_": ["ls", "/kui"],
                     "l": true
                   },
-                  "execUUID": "acd77c44-ed6b-4616-b8e2-fab037653d3c",
+                  "execUUID": "0f986173-841f-4090-bef5-762a5bc4ed9b",
                   "cancelled": false,
                   "evaluatorOptions": {
                     "plugin": "plugin-bash-like/fs"
@@ -348,9 +455,9 @@
                   "execOptions": {
                     "type": 0,
                     "language": "en-US",
-                    "tab": "3_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                    "execUUID": "acd77c44-ed6b-4616-b8e2-fab037653d3c",
-                    "history": 2,
+                    "tab": "1_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
+                    "execUUID": "0f986173-841f-4090-bef5-762a5bc4ed9b",
+                    "history": 251,
                     "env": {}
                   },
                   "response": {
@@ -360,18 +467,26 @@
                     },
                     "body": [
                       {
-                        "name": "Kubernetes &mdash; `Listing Resources`",
-                        "css": "",
+                        "name": "kubernetes/",
+                        "css": "dir-listing-is-directory",
                         "onclickExec": "pexec",
-                        "onclick": "open /kui/kubernetes/list-resources.json",
+                        "onclick": "ls -l /kui/kubernetes",
                         "attributes": [],
                         "key": "Name"
                       },
                       {
-                        "name": "Kubernetes &mdash; `Working with Jobs`",
+                        "name": "s3/",
+                        "css": "dir-listing-is-directory",
+                        "onclickExec": "pexec",
+                        "onclick": "ls -l /kui/s3",
+                        "attributes": [],
+                        "key": "Name"
+                      },
+                      {
+                        "name": "Welcome to Kui",
                         "css": "",
                         "onclickExec": "pexec",
-                        "onclick": "open /kui/kubernetes/create-jobs.json",
+                        "onclick": "open /kui/welcome.json",
                         "attributes": [],
                         "key": "Name"
                       }
@@ -381,77 +496,7 @@
                     "noEntityColors": true
                   },
                   "responseType": "ScalarResponse",
-                  "historyIdx": 2
-                }
-              },
-              {
-                "startTime": 1599240405282,
-                "startEvent": {
-                  "tab": "3_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "route": "/#",
-                  "command": "#    If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, join us!\\n\\nhttps://github.com/IBM/kui",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "8213e543-6b21-47ed-98ae-c5df3d3457a1"
-                },
-                "completeEvent": {
-                  "tab": "3_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "execType": 0,
-                  "command": "#   If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, join us!\\n\\nhttps://github.com/IBM/kui",
-                  "argvNoOptions": [
-                    "#",
-                    "    If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, join us!\\n\\nhttps://github.com/IBM/kui"
-                  ],
-                  "parsedOptions": {
-                    "_": [
-                      "#",
-                      "    If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, join us!\\n\\nhttps://github.com/IBM/kui"
-                    ]
-                  },
-                  "execUUID": "8213e543-6b21-47ed-98ae-c5df3d3457a1",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "3_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                    "execUUID": "8213e543-6b21-47ed-98ae-c5df3d3457a1",
-                    "history": 1,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "If you would like to contribute to Kui, either by contributing new Notebooks or new core features, join us!\n\nhttps://github.com/IBM/kui"
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 1
+                  "historyIdx": 251
                 }
               }
             ]

--- a/plugins/plugin-client-common/src/components/Content/Scalar/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Scalar/index.tsx
@@ -26,6 +26,7 @@ import {
   isReactResponse,
   isRadioTable,
   isTable,
+  isTabLayoutModificationResponse,
   isMixedResponse,
   isUsageError
 } from '@kui-shell/core'
@@ -94,6 +95,8 @@ export default class Scalar extends React.PureComponent<Props, State> {
         )
       } else if (isCommentaryResponse(response)) {
         return <Commentary {...response.props} />
+      } else if (isTabLayoutModificationResponse(response)) {
+        return <Commentary {...response.spec.ok.props} />
       } else if (isRadioTable(response)) {
         return (
           <KuiContext.Consumer>

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
@@ -20,6 +20,7 @@ import {
   i18n,
   isCodedError,
   isCommentaryResponse,
+  isTabLayoutModificationResponse,
   isHTML,
   isReactResponse,
   isMarkdownResponse,
@@ -208,6 +209,7 @@ export default class Output extends React.PureComponent<Props, State> {
       const { response } = block
       return (
         isCommentaryResponse(response) ||
+        isTabLayoutModificationResponse(response) ||
         isReactResponse(response) ||
         isHTML(response) ||
         isMarkdownResponse(response) ||

--- a/plugins/plugin-client-common/src/controller/split.ts
+++ b/plugins/plugin-client-common/src/controller/split.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Arguments, ParsedOptions, getCurrentTab, i18n } from '@kui-shell/core'
+import { Arguments, ParsedOptions, TabLayoutModificationResponse, NewSplitRequest, i18n } from '@kui-shell/core'
 
 const strings = i18n('plugin-client-common')
 
@@ -27,24 +27,29 @@ interface Options extends ParsedOptions {
  * This plugin introduces the /split command
  *
  */
-export default async function split(args?: Arguments<Options>) {
+export default function split(args?: Arguments<Options>): string | TabLayoutModificationResponse<NewSplitRequest> {
   if (args && args.parsedOptions.debug) {
     // for debugging, this returns the tab uuid of the current split
     return args.tab.uuid
   }
 
-  const { doSplitView } = await import('../components/Views/Terminal/ScrollableTerminal')
-
-  const opts = args.parsedOptions.inverse ? { inverseColors: true } : undefined
-  const tabUUID = await doSplitView(args ? args.tab : getCurrentTab(), opts)
+  const options = args.parsedOptions.inverse ? { inverseColors: true } : undefined
 
   return {
     apiVersion: 'kui-shell/v1',
-    kind: 'CommentaryResponse',
-    props: {
-      elsewhere: true,
-      tabUUID,
-      children: strings(args.parsedOptions.inverse ? 'Created a split with inverted colors' : 'Created a split')
+    kind: 'TabLayoutModificationResponse',
+    spec: {
+      modification: 'NewSplit',
+      options,
+      ok: {
+        apiVersion: 'kui-shell/v1',
+        kind: 'CommentaryResponse',
+        props: {
+          elsewhere: true,
+          tabUUID: '0',
+          children: strings(args.parsedOptions.inverse ? 'Created a split with inverted colors' : 'Created a split')
+        }
+      }
     }
   }
 }

--- a/plugins/plugin-core-support/src/lib/cmds/replay.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/replay.ts
@@ -25,7 +25,8 @@ import {
   CodedError,
   CommandStartEvent,
   CommandCompleteEvent,
-  ElsewhereCommentaryResponse,
+  TabLayoutModificationResponse,
+  NewSplitRequest,
   KResponse,
   ParsedOptions,
   Registrar,
@@ -353,20 +354,39 @@ export default function(registrar: Registrar) {
           // splitAlignment[startEvent.tab] = splits[splits.length - 1]
           // }
 
-          // NOTE: work around the replayability issue of split command not returning a replayable model: https://github.com/IBM/kui/issues/5399
-          if (startEvent.route === '/split') {
-            const ourUUID = (await REPL.qexec<ElsewhereCommentaryResponse>(startEvent.command)).props.tabUUID
-            const theirUUID = (completeEvent.response as ElsewhereCommentaryResponse).props.tabUUID
-            splitAlignment[theirUUID] = ourUUID
-          } else if (!splitAlignment[startEvent.tab]) {
+          if (!splitAlignment[startEvent.tab]) {
             const ourUUID = tab.uuid
             const theirUUID = startEvent.tab
             splitAlignment[theirUUID] = ourUUID
           }
 
+          // in order to maintain tab-index-invariance, we need to
+          // remember the mapping from the new split's ID at the time
+          // of replay (`tabUUIDOfNewSplitBefore`); then, after
+          // re-issuing the complete event, just below, we will tie
+          // this together with the split ID in this current world
+          const tabUUIDOfNewSplitBefore =
+            startEvent.route === '/split'
+              ? (completeEvent.response as TabLayoutModificationResponse<NewSplitRequest>).spec.ok.props.tabUUID
+              : undefined
+
           const uuid = splitAlignment[startEvent.tab]
-          reEmitStartInTab(tab, uuid, startEvent)
-          reEmitCompleteInTab(tab, uuid, completeEvent)
+          try {
+            reEmitStartInTab(tab, uuid, startEvent)
+            reEmitCompleteInTab(tab, uuid, completeEvent)
+          } catch (err) {
+            console.error(err)
+          }
+
+          // here is where we update the tabUUID mapping for that new
+          // split; after re-issuing the complete event, we should
+          // have the split's tabUUID in this new world
+          if (tabUUIDOfNewSplitBefore !== undefined) {
+            const theirUUID = tabUUIDOfNewSplitBefore
+            const ourUUID = (completeEvent.response as TabLayoutModificationResponse<NewSplitRequest>).spec.ok.props
+              .tabUUID
+            splitAlignment[theirUUID] = ourUUID
+          }
         })
 
         setTimeout(() => tab.scrollToTop())

--- a/plugins/plugin-kubectl/src/non-headless-preload.ts
+++ b/plugins/plugin-kubectl/src/non-headless-preload.ts
@@ -62,7 +62,7 @@ export default async (registrar: PreloadRegistrar) => {
   // register badges
   await registrar.registerBadges(eventsBadge)
 
-  // mount notebookss
+  // mount notebooks
   notebookVFS.mkdir({ argvNoOptions: ['mkdir', '/kui/kubernetes'] })
   notebookVFS.cp(
     undefined,


### PR DESCRIPTION
This PR introduces the TabLayoutModificationResponse type, which allows controllers to specify the intent to create a new split (as opposed to how it worked prior to this PR: the split controller talked directly to the view, and its response was only a signifier of result of the split, not the desire to create a split)

Fixes #5564

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
