### PR TITLE
fix: replay --freshen does not support multi-split notebooks

### DIFF
--- a/packages/core/src/models/CommentaryResponse.ts
+++ b/packages/core/src/models/CommentaryResponse.ts
@@ -16,11 +16,13 @@
 
 import { Entity } from './entity'
 import REPL from './repl'
+import Tab from '../webapp/tab'
 
 /** Commentary describing actions in a different tab/split */
 type Elsewhere = {
   elsewhere: true
   tabUUID: string
+  tab?: () => Tab
 }
 
 type DefaultProps = Partial<Elsewhere> & {

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -515,6 +515,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
       return new Error(strings('No more splits allowed'))
     } else {
       const newScrollback = this.scrollback(undefined, undefined, request.spec.options)
+      request.spec.ok.props.tab = () => newScrollback.facade
       request.spec.ok.props.tabUUID = newScrollback.uuid
 
       this.setState(({ splits }) => {

--- a/plugins/plugin-client-common/src/controller/split.ts
+++ b/plugins/plugin-client-common/src/controller/split.ts
@@ -47,6 +47,7 @@ export default function split(args?: Arguments<Options>): string | TabLayoutModi
         props: {
           elsewhere: true,
           tabUUID: '0',
+          tab: undefined,
           children: strings(args.parsedOptions.inverse ? 'Created a split with inverted colors' : 'Created a split')
         }
       }

--- a/plugins/plugin-core-support/src/lib/cmds/tab-management.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/tab-management.ts
@@ -17,6 +17,7 @@
 import {
   eventBus,
   eventChannelUnsafe,
+  getPrimaryTabId,
   pexecInCurrentTab,
   KResponse,
   Registrar,
@@ -37,8 +38,9 @@ const usage = {
  * Close the current tab
  *
  */
-function closeTab(tab: Tab) {
-  eventBus.emitWithTabId('/tab/close/request', tab.uuid, tab)
+function closeTab(tab: Tab, closeAllSplits: boolean) {
+  const uuid = closeAllSplits ? getPrimaryTabId(tab) : tab.uuid
+  eventBus.emitWithTabId('/tab/close/request', uuid, tab)
   return true
 }
 
@@ -120,5 +122,11 @@ export default function plugin(commandTree: Registrar) {
     }
   )
 
-  commandTree.listen('/tab/close', ({ tab }) => closeTab(tab))
+  commandTree.listen<KResponse, { A: boolean }>(
+    '/tab/close',
+    ({ tab, parsedOptions }) => {
+      return closeTab(tab, parsedOptions.A)
+    },
+    { flags: { boolean: ['A'] } }
+  )
 }


### PR DESCRIPTION
Fixes #5571

this also fixes a related problem with tab close, which does not support fully closing all splits in a tab
Fixes #5572

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
