### PR TITLE
fix: tab new command should respond with ElsewhereCommentary response

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Commentary.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Commentary.tsx
@@ -16,12 +16,18 @@
 
 import * as React from 'react'
 import { CommentaryResponse } from '@kui-shell/core'
+
 import Card from '../spi/Card'
+import Markdown from './Markdown'
 
 export default class Commentary extends React.PureComponent<CommentaryResponse['props']> {
   public render() {
     if (this.props.elsewhere) {
-      return <span className="kui--repl-result-else">{this.props.children}</span>
+      return (
+        <span className="kui--repl-result-else">
+          <Markdown source={this.props.children} />
+        </span>
+      )
     } else {
       return <Card {...this.props} className="kui--commentary-card" />
     }

--- a/plugins/plugin-core-support/i18n/resources_en_US.json
+++ b/plugins/plugin-core-support/i18n/resources_en_US.json
@@ -7,6 +7,8 @@
   "helpUsageHeader": "A summary of the top-level command structure",
   "Tab": "Tab",
   "New Tab": "New Tab",
+  "Created a new tab": "Created a new tab",
+  "Created a new tab named X": "Created a new tab **{0}**",
   "Theme": "Theme",
   "Provider": "Provider",
   "Style": "Style",

--- a/plugins/plugin-core-support/src/lib/cmds/tab-management.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/tab-management.ts
@@ -18,6 +18,7 @@ import {
   eventBus,
   eventChannelUnsafe,
   getPrimaryTabId,
+  i18n,
   pexecInCurrentTab,
   KResponse,
   Registrar,
@@ -28,6 +29,7 @@ import {
 // TODO fixme; this is needed by a few tests
 export const tabButtonSelector = '#new-tab-button'
 
+const strings = i18n('plugin-core-support')
 const usage = {
   strict: 'switch',
   command: 'switch',
@@ -80,6 +82,19 @@ export default function plugin(commandTree: Registrar) {
         (args.execOptions.data ? args.execOptions.data['status-stripe-message'] : undefined)
       const statusStripeDecoration = { type: args.parsedOptions['status-stripe-type'], message }
 
+      const ok = {
+        apiVersion: 'kui-shell/v1',
+        kind: 'CommentaryResponse',
+        props: {
+          elsewhere: true,
+          tabUUID: '0',
+          tab: undefined,
+          children: args.parsedOptions.title
+            ? strings('Created a new tab named X', args.parsedOptions.title)
+            : strings('Created a new tab')
+        }
+      }
+
       if (args.parsedOptions.cmdline) {
         const { allocateTabUUID } = await import('@kui-shell/plugin-client-common')
 
@@ -94,7 +109,7 @@ export default function plugin(commandTree: Registrar) {
 
           eventChannelUnsafe.once(`/tab/new/${uuid}`, (tab: Tab) => {
             pexecInCurrentTab(args.parsedOptions.cmdline, tab)
-            resolve(true)
+            resolve(ok)
           })
         })
       } else {
@@ -103,10 +118,11 @@ export default function plugin(commandTree: Registrar) {
           title: args.parsedOptions.title,
           background: args.parsedOptions.bg
         })
-        return true
+        return ok
       }
     },
     {
+      outputOnly: true,
       usage: {
         optional: [
           { name: '--cmdline', alias: '-c', docs: 'Invoke a command in the new tab' },


### PR DESCRIPTION
Fixes #5602

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
