### PR TITLE
feat: add a prefer-re-execution option to snapshot

### DIFF
--- a/plugins/plugin-client-common/notebooks/settings.json
+++ b/plugins/plugin-client-common/notebooks/settings.json
@@ -3,6 +3,7 @@
   "kind": "Snapshot",
   "spec": {
     "title": "Kui Settings",
+    "preferReExecute": true,
     "clicks": {
       "startEvents": {},
       "completeEvents": {}


### PR DESCRIPTION
This PR introduces `snapshot --exec` and `snapshot -x` options to auto re-execute commands when replaying the snapshot.

Fix #5622

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
