### PR TITLE
fix(plugins/plugin-client-common): improved focus behavior of terminals

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
@@ -69,28 +69,6 @@ export default class TabContainer extends React.PureComponent<Props, State> {
     })
   }
 
-  /**
-   * Temporary hack to regrab focus to the repl. The hack part is the
-   * querySelector. This really needs to be done in TabContent, which
-   * owns the Tab impl.
-   *
-   */
-  private hackFocus() {
-    setTimeout(() => {
-      try {
-        const selector = `.kui--tab-content.visible .repl-active[data-is-focused] input`
-        const selector2 = `.kui--tab-content.visible .repl-active input`
-        const input =
-          (document.querySelector(selector) as HTMLElement) || (document.querySelector(selector2) as HTMLElement)
-        if (input) {
-          input.focus()
-        }
-      } catch (err) {
-        console.error(err)
-      }
-    })
-  }
-
   /** save tab state such as CWD prior to a tab switch */
   private captureState() {
     try {
@@ -118,8 +96,6 @@ export default class TabContainer extends React.PureComponent<Props, State> {
       this.setState({
         activeIdx: idx
       })
-
-      this.hackFocus()
     }
 
     setTimeout(() => eventBus.emit('/tab/switch/request/done', idx))
@@ -142,8 +118,6 @@ export default class TabContainer extends React.PureComponent<Props, State> {
         tabs: residualTabs,
         activeIdx
       })
-
-      this.hackFocus()
     }
   }
 

--- a/plugins/plugin-client-common/src/components/Client/TabContent.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContent.tsx
@@ -66,6 +66,9 @@ type State = Partial<WithTab> & {
   sidecarHasContent: boolean
 
   activeView: CurrentlyShowing
+
+  /** grab a ref (below) so that we can maintain focus */
+  _terminal: ScrollableTerminal
 }
 
 /**
@@ -88,9 +91,6 @@ export default class TabContent extends React.PureComponent<Props, State> {
   /** switching back or away from this tab */
   private activateHandlers: ((isActive: boolean) => void)[] = []
 
-  /** grab a ref (below) so that we can maintain focus */
-  private _terminal: ScrollableTerminal
-
   public constructor(props: Props) {
     super(props)
 
@@ -101,7 +101,8 @@ export default class TabContent extends React.PureComponent<Props, State> {
       sidecarWidth: Width.Closed,
       priorSidecarWidth: Width.Closed,
       sidecarHasContent: false,
-      activeView: 'TerminalOnly'
+      activeView: 'TerminalOnly',
+      _terminal: undefined
     }
   }
 
@@ -177,6 +178,9 @@ export default class TabContent extends React.PureComponent<Props, State> {
         console.error(err)
       }
     } else {
+      if (props.active && state._terminal) {
+        state._terminal.doFocus()
+      }
       return state
     }
   }
@@ -225,9 +229,9 @@ export default class TabContent extends React.PureComponent<Props, State> {
                   // eslint-disable-next-line react/no-direct-mutation-state
                   this.state.tab.state.desiredStatusStripeDecoration = { type: 'default' }
                 }}
-                ref={c => {
+                ref={_terminal => {
                   // so that we can refocus/blur
-                  this._terminal = c
+                  this.setState({ _terminal })
                 }}
               >
                 {this.children()}
@@ -284,8 +288,8 @@ export default class TabContent extends React.PureComponent<Props, State> {
   }
 
   private onWillLoseFocus() {
-    if (this._terminal) {
-      this._terminal.doFocus()
+    if (this.state._terminal) {
+      this.state._terminal.doFocus()
     }
   }
 

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
@@ -118,6 +118,7 @@ export default class Block extends React.PureComponent<Props, State> {
     if (isFinished(this.props.model) || isProcessing(this.props.model)) {
       return (
         <Output
+          key={`Output-${this.props.idx}`}
           uuid={this.props.uuid}
           tab={this.props.tab}
           idx={this.props.idx}

--- a/plugins/plugin-client-common/src/components/Views/Terminal/visible.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/visible.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Is the given `elm` on visible in the current viewport? */
+export default function isInViewport(elm: HTMLElement) {
+  const rect = elm.getBoundingClientRect()
+  const viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight)
+  return !(rect.bottom < 0 || rect.top - viewHeight >= 0)
+}


### PR DESCRIPTION
1) avoid spurious scrolling: when clicking on a table entry while the active prompt is not in view
2) ibid: when switching tabs while the active prompt is not in view

this PR removes the old hackFocus() hack in TabContainer, which did ugly querySelectors

Fixes #5615

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
