### PR TITLE
fix: avoid excessive status stripe overheads when replaying Notebooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,11 @@ jobs:
     - os: osx
       env: N="Mac core" CLIENT="default" TEST_FROM_BUILD=`[ "$TRAVIS_OS_NAME" = linux ] && echo "${TRAVIS_BUILD_DIR}/dist/electron/Kui-linux-x64/Kui" || echo "${TRAVIS_BUILD_DIR}/dist/electron/Kui-darwin-x64/Kui.app/Contents/MacOS/Kui"` HOMEBREW_NO_AUTO_UPDATE=1 NEEDS_MINIO=true
       before_install: which jq || brew install jq
-      script: concurrently -n CORE,SUP1,EDIT,SUP2 'npm run test1 core' 'npm run test2 core-support' 'npm run test3 editor' 'npm run test4 core-support2'
+      script:
+        - npm run test1 core
+        - npm run test2 core-support
+        - npm run test3 editor
+        - npm run test4 core-support2
 
     # CLIENT=default | os=Linux | targets=webpack | core, core-support, editor, core-support2
     - env: N="Webpack core" CLIENT="default" MOCHA_RUN_TARGET="webpack" KUI_USE_PROXY="true" NEEDS_MINIO=true

--- a/plugins/plugin-core-support/src/lib/cmds/replay.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/replay.ts
@@ -140,13 +140,13 @@ function withNewTabUUID(tab: Tab, uuid: string) {
 /** Re-emit prior start event in new tab */
 function reEmitStartInTab(tab: Tab, uuid: string, startEvent: SnapshotBlock['startEvent']) {
   const evt = Object.assign({}, startEvent, withNewTabUUID(tab, uuid))
-  eventBus.emitCommandStart(evt)
+  eventBus.emitCommandStart(evt, true)
 }
 
 /** Re-emit prior complete event in new tab */
 function reEmitCompleteInTab(tab: Tab, uuid: string, completeEvent: SnapshotBlock['completeEvent']) {
   const evt = Object.assign({}, completeEvent, withNewTabUUID(tab, uuid))
-  eventBus.emitCommandComplete(evt)
+  eventBus.emitCommandComplete(evt, true)
 }
 
 /** Re-execute command line in new tab */

--- a/plugins/plugin-core-support/src/test/core-support/replay.ts
+++ b/plugins/plugin-core-support/src/test/core-support/replay.ts
@@ -51,7 +51,7 @@ describe(`snapshot and replay ${process.env.MOCHA_RUN_TARGET || ''}`, function(t
       await this.app.client.waitUntil(async () => {
         const txt = await this.app.client.getText(Selectors.OUTPUT_N(count))
         if (++idx > 5) {
-          console.error(`still waiting for expected=${txt}; actual=${txt}`)
+          console.error(`still waiting for expected=${base64Output}; actual=${txt}`)
         }
         return txt === base64Output
       }, CLI.waitTimeout)

--- a/plugins/plugin-core-support/src/test/core-support2/history.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/history.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corporation
+ * Copyright 2017,2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,15 +30,20 @@ describe('command history plain', function(this: Common.ISuite) {
   it('should list local files', () =>
     CLI.command(listCommand, this.app)
       .then(ReplExpect.okWith('README.md'))
-      .catch(Common.oops(this)))
+      .catch(Common.oops(this, true)))
 
   it('should hit the up arrow and see previous command', async () => {
     try {
       await this.app.client.keys(Keys.ctrlP)
+
+      let idx = 0
       await this.app.client.waitUntil(async () => {
         const promptValue = await this.app.client.getValue(Selectors.PROMPT_FINAL)
+        if (++idx > 5) {
+          console.error(`still waiting for expectedPromptValue=${listCommand}; actualPromptValue=${promptValue}`)
+        }
         return promptValue === listCommand
-      })
+      }, CLI.waitTimeout)
     } catch (err) {
       await Common.oops(this, true)(err)
     }
@@ -47,10 +52,15 @@ describe('command history plain', function(this: Common.ISuite) {
   it('should hit the down arrow and see previous command', async () => {
     try {
       await this.app.client.keys(Keys.ctrlN)
+
+      let idx = 0
       await this.app.client.waitUntil(async () => {
         const promptValue = await this.app.client.getValue(Selectors.PROMPT_FINAL)
+        if (++idx > 5) {
+          console.error(`still waiting for empty prompt; actualPromptValue=${promptValue}`)
+        }
         return promptValue.length === 0
-      })
+      }, CLI.waitTimeout)
     } catch (err) {
       await Common.oops(this, true)(err)
     }
@@ -60,18 +70,18 @@ describe('command history plain', function(this: Common.ISuite) {
   it(`should list history with filter 1`, () =>
     CLI.command(`history 1 lls`, this.app)
       .then(ReplExpect.okWithOnly(listCommand))
-      .catch(Common.oops(this)))
+      .catch(Common.oops(this, true)))
 
   it(`should list history 2 and show the list command`, () =>
     CLI.command(`history 2`, this.app)
       .then(ReplExpect.okWith(listCommand))
-      .catch(Common.oops(this)))
+      .catch(Common.oops(this, true)))
 
   // get something on the screen
   it(`should list local files again`, () =>
     CLI.command(listCommand, this.app)
       .then(ReplExpect.okWith('README.md'))
-      .catch(Common.oops(this)))
+      .catch(Common.oops(this, true)))
 
   it('should re-execte from history via mouse click', async () => {
     try {
@@ -91,30 +101,30 @@ describe('command history plain', function(this: Common.ISuite) {
   it(`should list history with filter, expect nothing`, () =>
     CLI.command(`history gumbogumbo`, this.app)
       .then(ReplExpect.justOK) // some random string that won't be in the command history
-      .catch(Common.oops(this)))
+      .catch(Common.oops(this, true)))
 
   it(`should delete command history`, () =>
     CLI.command(`history -c`, this.app)
       .then(ReplExpect.justOK)
-      .catch(Common.oops(this)))
+      .catch(Common.oops(this, true)))
 
   it(`should list history with no args after delete and expect nothing`, () =>
     CLI.command(`history`, this.app)
       .then(ReplExpect.justOK)
-      .catch(Common.oops(this)))
+      .catch(Common.oops(this, true)))
 
   it(`should list history with idx arg after delete and expect only the previous`, () =>
     CLI.command(`history 10`, this.app)
       .then(ReplExpect.okWithOnly('history'))
-      .catch(Common.oops(this)))
+      .catch(Common.oops(this, true)))
 
   it(`should delete command history again`, () =>
     CLI.command(`history -c`, this.app)
       .then(ReplExpect.justOK)
-      .catch(Common.oops(this)))
+      .catch(Common.oops(this, true)))
 
   it(`should list history with idx and filter args after delete and expect nothing`, () =>
     CLI.command(`history 10 lls`, this.app)
       .then(ReplExpect.justOK) // some random string that won't be in the command history
-      .catch(Common.oops(this)))
+      .catch(Common.oops(this, true)))
 })

--- a/plugins/plugin-core-support/src/test/core-support2/split-terminals.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/split-terminals.ts
@@ -99,7 +99,35 @@ describe(`split terminals created split check ${process.env.MOCHA_RUN_TARGET || 
   verifyBlockCount.is(1) // the "created split" message should be gone!
 })
 
-describe(`split terminals ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+describe(`split terminals close all ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+  Util.closeAllExceptFirstTab.bind(this)()
+
+  const splitTheTerminalViaCommand = splitViaCommand.bind(this)
+  const count = expectSplits.bind(this)
+  const showVersion = version.bind(this)
+
+  it('should create a new tab via command', () =>
+    CLI.command('tab new', this.app)
+      .then(() => this.app.client.waitForVisible(Selectors.TAB_SELECTED_N(2)))
+      .then(() => CLI.waitForSession(this)) // should have an active repl
+      .catch(Common.oops(this, true)))
+
+  splitTheTerminalViaCommand(2)
+
+  count(2)
+
+  it('should close that new tab entirely, i.e. all splits plus the tab should be closed', () =>
+    CLI.command('tab close -A', this.app)
+      .then(() => this.app.client.waitForExist(Selectors.TAB_N(2), 5000, true))
+      .then(() => this.app.client.waitForVisible(Selectors.TAB_SELECTED_N(1)))
+      .catch(Common.oops(this, true)))
+
+  showVersion(1)
+})
+
+describe(`split terminals general ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
   before(Common.before(this))
   after(Common.after(this))
   Util.closeAllExceptFirstTab.bind(this)()
@@ -114,19 +142,6 @@ describe(`split terminals ${process.env.MOCHA_RUN_TARGET || ''}`, function(this:
   const cwdIs = inDir.bind(this)
 
   // here come the tests
-
-  it('should create a new tab via command', () =>
-    CLI.command('tab new', this.app)
-      .then(() => this.app.client.waitForVisible(Selectors.TAB_SELECTED_N(2)))
-      .then(() => CLI.waitForSession(this)) // should have an active repl
-      .catch(Common.oops(this, true)))
-  splitTheTerminalViaCommand(2)
-  count(2)
-  it('should close that new tab entirely, i.e. all splits plus the tab should be closed', () =>
-    CLI.command('tab close -A', this.app)
-      .then(() => this.app.client.waitForExist(Selectors.TAB_N(2), 5000, true))
-      .then(() => this.app.client.waitForVisible(Selectors.TAB_SELECTED_N(1)))
-      .catch(Common.oops(this, true)))
 
   const { fullpath: dir1, clean: clean1 } = dir('aaa')
   const { fullpath: dir2, clean: clean2 } = dir('bbb')

--- a/plugins/plugin-kubectl/components/src/CurrentContext.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentContext.tsx
@@ -78,12 +78,24 @@ export default class CurrentContext extends React.PureComponent<{}, State> {
     return context
   }
 
+  /** Avoid recomputation for a flurry of events */
+  private last: number
+  private debounce(): boolean {
+    const now = Date.now()
+    const last = this.last
+    this.last = now
+
+    return last && now - last < 250
+  }
+
   private async reportCurrentContext(idx?: Tab | number) {
     const tab = getTab(idx)
     if (!tab || !tab.REPL) {
       if (tab && !tab.REPL) {
         eventChannelUnsafe.once(`/tab/new/${tab.uuid}`, () => this.reportCurrentContext())
       }
+      return
+    } else if (this.debounce()) {
       return
     }
 
@@ -95,6 +107,7 @@ export default class CurrentContext extends React.PureComponent<{}, State> {
       })
     } catch (err) {
       console.error(err)
+      this.last = undefined
       this.setState({
         text: '',
         viewLevel: 'hidden'

--- a/plugins/plugin-kubectl/src/controller/kubectl/contexts.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/contexts.ts
@@ -155,7 +155,9 @@ export async function getCurrentContextName({ REPL }: { REPL: REPLType }) {
 /** Extract the namespace from the current context */
 export async function getCurrentDefaultNamespace({ REPL }: { REPL: REPLType }) {
   const ns = await REPL.qexec<string>(`kubectl config view --minify --output "jsonpath={..namespace}"`).catch(err => {
-    console.error('error determining default namespace', err)
+    if (err.code !== 404 && !/command not found/.test(err.message)) {
+      console.error('error determining default namespace', err)
+    }
     return 'default'
   })
 


### PR DESCRIPTION
Fixes #5635

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
