### PR TITLE
fix(plugins/plugin-client-common): StatusStripe widgets can emit reac…

### DIFF
--- a/packages/core/src/core/events.ts
+++ b/packages/core/src/core/events.ts
@@ -77,6 +77,7 @@ class WriteEventBus extends EventBusBase {
   public emit(channel: '/tab/new' | '/tab/close' | '/tab/offline', tab: Tab): void
   public emit(channel: '/tab/new/request', evt?: NewTabRequestEvent): void
   public emit(channel: '/tab/switch/request', idx: number): void
+  public emit(channel: '/tab/switch/request/done', idx: number): void
   public emit(channel: string, args?: any) {
     return this.eventBus.emit(channel, args)
   }
@@ -157,6 +158,7 @@ class ReadEventBus extends WriteEventBus {
 
   public on(channel: '/tab/new/request', listener: (evt: NewTabRequestEvent) => void): void
   public on(channel: '/tab/switch/request', listener: (tabId: number) => void): void
+  public on(channel: '/tab/switch/request/done', listener: (tabId: number) => void): void
   public on(channel: string, listener: any) {
     return this.eventBus.on(channel, listener)
   }
@@ -403,7 +405,7 @@ export const eventBus = new EventBus()
  */
 export function wireToTabEvents(listener: (tab?: Tab | number) => void) {
   eventBus.on('/tab/new', listener)
-  eventBus.on('/tab/switch/request', listener)
+  eventBus.on('/tab/switch/request/done', listener)
   eventBus.onSplitSwitch(listener)
 }
 
@@ -413,7 +415,7 @@ export function wireToTabEvents(listener: (tab?: Tab | number) => void) {
  */
 export function unwireToTabEvents(listener: (tab?: Tab | number) => void) {
   eventBus.off('/tab/new', listener)
-  eventBus.off('/tab/switch/request', listener)
+  eventBus.off('/tab/switch/request/done', listener)
   eventBus.offSplitSwitch(listener)
 }
 


### PR DESCRIPTION
…t error when switching to notebook tab

This PR also does a small bit of code tidying in TabContainer.tsx

Fixes #5639

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
