### PR TITLE
fix(plugins/plugin-client-common): Output-only blocks probably don't …

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Actions.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Actions.tsx
@@ -18,9 +18,9 @@ import * as React from 'react'
 import { Tab, i18n, inBrowser } from '@kui-shell/core'
 
 import { InputOptions } from './Input'
-import BlockModel, { hasUUID } from './BlockModel'
 import { SupportedIcon } from '../../../spi/Icons'
 import TwoFaceIcon from '../../../spi/Icons/TwoFaceIcon'
+import BlockModel, { hasUUID, isOutputOnly } from './BlockModel'
 
 const strings = i18n('plugin-client-common')
 const strings2 = i18n('plugin-client-common', 'screenshot')
@@ -54,7 +54,9 @@ export default class Actions extends React.PureComponent<Props> {
         : this.props.tab.REPL.pexec(this.props.command)
 
     return (
-      this.props.tab && this.props.command && <Action icon="Retry" onClick={handler} title="Re-execute this command" />
+      !isOutputOnly(this.props.model) &&
+      this.props.tab &&
+      this.props.command && <Action icon="Retry" onClick={handler} title="Re-execute this command" />
     )
   }
 


### PR DESCRIPTION
…need a re-execute button

Fixes #5662

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
