### PR TITLE
fix: avoiding reopening the Welcome to Kui tab even after the user ha…

### DIFF
--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -30,6 +30,14 @@ import { productName } from '@kui-shell/client/config.d/name.json'
 const strings = i18n('plugin-client-default')
 
 /**
+ * We will set this bit when the user dismisses the Welcome to Kui
+ * tab, so as to avoid opening it again and bothering that user for
+ * every new Kui window.
+ *
+ */
+const welcomeBit = 'plugin-client-default.welcome-was-dismissed'
+
+/**
  * Format our body, with extra status stripe widgets
  *   - <CurrentGitBranch />
  *   - <ProxyOfflineIndicator />
@@ -57,7 +65,11 @@ export default function renderMain(props: KuiProps) {
           '--status-stripe-type',
           'blue',
           '--status-stripe-message',
-          title
+          title,
+          '--if',
+          `kuiconfig not set ${welcomeBit}`,
+          '--onClose',
+          `kuiconfig set ${welcomeBit}`
         ]
       }
     >


### PR DESCRIPTION
…s closed it

Fixes #5673

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
