### PR TITLE
fix(plugins/plugin-client-common): Editing Commentary should require …

### DIFF
--- a/plugins/plugin-client-common/notebooks/welcome.json
+++ b/plugins/plugin-client-common/notebooks/welcome.json
@@ -138,7 +138,7 @@
                   "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
                   "route": "/#",
                   "startTime": 1599579412335,
-                  "command": "#                                # Notebooks with Kui!\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application.",
+                  "command": "#                                # Notebooks with Kui!\\n\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application.",
                   "evaluatorOptions": {
                     "usage": {
                       "command": "commentary",
@@ -169,15 +169,15 @@
                   "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
                   "execType": 1,
                   "completeTime": 1599579412351,
-                  "command": "#                               # Notebooks with Kui!\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application.",
+                  "command": "#                               # Notebooks with Kui!\\n\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application.",
                   "argvNoOptions": [
                     "#",
-                    "                                # Notebooks with Kui!\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
+                    "                                # Notebooks with Kui!\\n\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
                   ],
                   "parsedOptions": {
                     "_": [
                       "#",
-                      "                                # Notebooks with Kui!\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
+                      "                                # Notebooks with Kui!\\n\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
                     ]
                   },
                   "execUUID": "9d2b87ec-16af-4fe9-aeab-49e6f1f2c1e2",
@@ -198,7 +198,7 @@
                     "apiVersion": "kui-shell/v1",
                     "kind": "CommentaryResponse",
                     "props": {
-                      "children": "# Notebooks with Kui!\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
+                      "children": "# Notebooks with Kui!\n\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
                     }
                   },
                   "responseType": "ScalarResponse",

--- a/plugins/plugin-client-common/src/components/Content/Commentary.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Commentary.tsx
@@ -159,17 +159,17 @@ export default class Commentary extends React.PureComponent<Props, State> {
 
   private card() {
     return (
-      <Card
-        {...this.props}
-        className="kui--commentary-card"
-        data-is-editing={this.state.isEdit || undefined}
-        onCardClick={this._setEdit}
-        header={this.state.isEdit && strings('Editing Comment as Markdown')}
-        footer={this.state.isEdit && this.toolbar()}
-      >
-        {this.state.textValue}
-        {this.state.isEdit && this.editor()}
-      </Card>
+      <span className="kui--commentary-card" onDoubleClick={this._setEdit}>
+        <Card
+          {...this.props}
+          data-is-editing={this.state.isEdit || undefined}
+          header={this.state.isEdit && strings('Editing Comment as Markdown')}
+          footer={this.state.isEdit && this.toolbar()}
+        >
+          {this.state.textValue}
+          {this.state.isEdit && this.editor()}
+        </Card>
+      </span>
     )
   }
 
@@ -194,7 +194,6 @@ export default class Commentary extends React.PureComponent<Props, State> {
         content={this.state.textValue}
         className="kui--source-ref-editor kui--inverted-color-context"
         readonly={false}
-        fontSize={12}
         simple
         onContentChange={this._onContentChange}
         contentType="markdown"

--- a/plugins/plugin-client-common/src/components/Content/Editor/SimpleEditor.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/SimpleEditor.tsx
@@ -103,7 +103,7 @@ export default class SimpleEditor extends React.PureComponent<Props, State> {
       const providedOptions = {
         value: props.content,
         readOnly: props.readonly !== undefined ? props.readonly : true,
-        fontSize: props.fontSize,
+        fontSize: props.fontSize || getKuiFontSize(),
         language: props.contentType,
         simple: props.simple
       }

--- a/plugins/plugin-client-common/src/components/Content/Editor/lib/defaults.ts
+++ b/plugins/plugin-client-common/src/components/Content/Editor/lib/defaults.ts
@@ -33,7 +33,7 @@ export default (options: Options): editor.IEditorConstructionOptions => ({
   contextmenu: false,
   scrollBeyondLastLine: false,
   scrollBeyondLastColumn: 2,
-  // cursorStyle: 'block',
+  cursorStyle: 'block',
   fontFamily: 'var(--font-monospace)',
   fontSize: options.fontSize || getKuiFontSize(),
 
@@ -42,6 +42,7 @@ export default (options: Options): editor.IEditorConstructionOptions => ({
 
   // simplify the UI?
   links: !options.simple,
+  folding: !options.simple,
   lineNumbers: options.simple ? 'off' : 'on',
   wordWrap: options.simple ? 'on' : undefined,
   lineDecorationsWidth: options.simple ? 0 : undefined

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Commentary.scss
@@ -126,10 +126,13 @@
 }
 
 @include Commentary {
-  font-family: var(--font-sans-serif);
+  display: flex;
 
   &[data-is-editing] {
     flex: 1;
     max-width: 60rem;
   }
+}
+@include Card {
+  display: flex;
 }

--- a/plugins/plugin-core-support/src/test/core-support/commentary.ts
+++ b/plugins/plugin-core-support/src/test/core-support/commentary.ts
@@ -116,7 +116,7 @@ describe('edit commentary and replay', function(this: Common.ISuite) {
   const openEditor = (expect: string) => {
     it('should open editor by clicking', async () => {
       try {
-        await this.app.client.click(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD}`)
+        await this.app.client.doubleClick(`${Selectors.OUTPUT_LAST} ${Selectors.TERMINAL_CARD}`)
         await verifyTextInMonaco(expect)
       } catch (err) {
         await Common.oops(this, true)(err)


### PR DESCRIPTION
…double click

This PR also has a few small refinements to the editing UI: full removal of the glyph gutter in monaco-editor; a trivial update to welcome.json so have two newlines after the header (cosmetic improvement when editing); use the default Kui font size when editing Commentary rather than the previous 0.75rem.

Fixes #5686

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
