### PR TITLE
fix(plugins/plugin-client-common): don't show `isTabLayoutModificationResponse` and PresentedElseWhere response in MiniSplit

### DIFF
--- a/plugins/plugin-core-support/src/test/core-support2/split-terminals.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/split-terminals.ts
@@ -127,6 +127,38 @@ describe(`split terminals close all ${process.env.MOCHA_RUN_TARGET || ''}`, func
   showVersion(1)
 })
 
+describe(`split terminals output ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  it('verify the version still shown in the first split', async () => {
+    try {
+      const res = await CLI.command('version', this.app)
+      await ReplExpect.okWithCustom({ expect: Common.expectedVersion })(res)
+      const N = res.count
+
+      await this.app.client.click(Selectors.NEW_SPLIT_BUTTON)
+      await ReplExpect.splitCount(2)(this.app)
+
+      await this.app.client.click(Selectors.NEW_SPLIT_BUTTON)
+      await ReplExpect.splitCount(3)(this.app)
+
+      let idx = 0
+      await this.app.client.waitUntil(async () => {
+        console.error('test', `${Selectors.OUTPUT_N(N, 1)} .repl-result`)
+        const actualVersion = await this.app.client.getText(Selectors.OUTPUT_N(N, 1))
+
+        if (++idx > 5) {
+          console.error(`still waiting for expected=${Common.expectedVersion}; actual=${actualVersion}`)
+        }
+        return actualVersion === Common.expectedVersion
+      }, CLI.waitTimeout)
+    } catch (err) {
+      await Common.oops(this, true)(err)
+    }
+  })
+})
+
 describe(`split terminals general ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
   before(Common.before(this))
   after(Common.after(this))


### PR DESCRIPTION
Fixes #5690

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
