### PR TITLE
User should be able to tab navigate through blocks

### DIFF
--- a/plugins/plugin-client-alternate/web/scss/CustomInput.scss
+++ b/plugins/plugin-client-alternate/web/scss/CustomInput.scss
@@ -17,3 +17,8 @@
 .kui--tab-completions {
   bottom: 4.25rem;
 }
+
+body.kui--alternate .repl-prompt {
+  display: flex;
+  align-items: center;
+}

--- a/plugins/plugin-client-common/src/components/Content/Table/Bar.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/Bar.tsx
@@ -27,7 +27,7 @@ interface Props {
   widthOverlay?: string
   titleOverlay?: string
 
-  onClick?: () => void
+  onClick?: (evt: React.MouseEvent) => void
 }
 
 export default class Bar extends React.PureComponent<Props> {

--- a/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
@@ -37,19 +37,22 @@ export function onClickForCell(
   if (handler === false) {
     return () => handler
   } else if (typeof handler === 'function') {
-    return () => {
+    return (evt: React.MouseEvent) => {
+      evt.stopPropagation()
       selectRow()
       handler()
     }
   } else {
     const opts = { tab, echo: !row.onclickSilence }
     if (!row.onclickExec || row.onclickExec === 'pexec') {
-      return () => {
+      return (evt: React.MouseEvent) => {
+        evt.stopPropagation()
         selectRow()
         repl.pexec(handler, opts)
       }
     } else {
-      return () => {
+      return (evt: React.MouseEvent) => {
+        evt.stopPropagation()
         selectRow()
         repl.qexec(handler, undefined, undefined, { tab })
       }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
@@ -53,6 +53,7 @@ import {
 import Else from './Else'
 import Actions from './Actions'
 import Scalar from '../../../Content/Scalar/'
+import KuiContext from '../../../Client/context'
 
 const strings = i18n('plugin-client-common')
 
@@ -254,9 +255,15 @@ export default class Output extends React.PureComponent<Props, State> {
 
   private ctx(insideBrackets: React.ReactNode = this.props.displayedIdx || this.props.idx + 1) {
     return (
-      <span className="repl-context" onClick={this.props.willFocusBlock}>
-        Out[{insideBrackets}]
-      </span>
+      <KuiContext.Consumer>
+        {config =>
+          !config.noPromptContext && (
+            <span className="repl-context" onClick={this.props.willFocusBlock}>
+              Out[{insideBrackets}]
+            </span>
+          )
+        }
+      </KuiContext.Consumer>
     )
   }
 

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
@@ -40,6 +40,9 @@ export type BlockViewTraits = {
 
   /** Handler for: User clicked to focus on this block */
   willFocusBlock?: (evt: React.SyntheticEvent) => void
+
+  /** Handler for <li> focus */
+  onFocus?: (evt: React.FocusEvent) => void
 }
 
 export interface BlockOperationTraits {
@@ -192,7 +195,7 @@ export default class Block extends React.PureComponent<Props, State> {
   public render() {
     return (
       (!this.props.noActiveInput || !isActive(this.props.model)) && (
-        <div
+        <li
           className={'repl-block kui--maximize-candidate ' + this.props.model.state.toString()}
           data-is-output-only={isOutputOnly(this.props.model) || undefined}
           data-is-quietly-elsewhere={isQuietlyPresentedElsewhere(this.props.model) || undefined}
@@ -202,6 +205,9 @@ export default class Block extends React.PureComponent<Props, State> {
           data-is-focused={this.props.isFocused || undefined}
           data-is-visible-in-minisplit={this.props.isVisibleInMiniSplit || undefined}
           ref={c => this.setState({ _block: c })}
+          tabIndex={isActive(this.props.model) ? -1 : 1}
+          onClick={this.props.willFocusBlock}
+          onFocus={this.props.onFocus}
         >
           {isAnnouncement(this.props.model) || isOutputOnly(this.props.model) ? (
             this.output()
@@ -213,7 +219,7 @@ export default class Block extends React.PureComponent<Props, State> {
               {this.output()}
             </React.Fragment>
           )}
-        </div>
+        </li>
       )
     )
   }

--- a/plugins/plugin-client-common/web/css/static/InputStripe.scss
+++ b/plugins/plugin-client-common/web/css/static/InputStripe.scss
@@ -1,7 +1,7 @@
 .kui--input-stripe {
   display: flex;
   flex-grow: 0;
-  flex-basis: 2rem;
+  flex-basis: 2.125rem;
   background-color: var(--color-stripe-01);
   box-shadow: 0 -3px 10px 0 rgba(60, 60, 60, 0.1);
 
@@ -11,11 +11,14 @@
     padding: 0;
     margin: 0;
 
+    .repl-input {
+      padding: 0;
+    }
     .repl-input .kui--input-and-context {
-      font-size: 0.875em;
+      font-size: 0.875rem;
       flex: 1;
       background-color: var(--color-base03);
-      padding: 0.5em 0.375em;
+      padding: 0.5rem 0.375rem;
 
       input {
         background-color: transparent;
@@ -24,7 +27,7 @@
 
     .repl-prompt {
       border: none;
-      padding: 0.5em 0.375em;
+      padding: 0.5rem 0.375rem;
       background-color: var(--color-base03);
     }
 

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -26,6 +26,9 @@ $action-padding: 3px;
 /** Hover hysteresis for showing action buttons */
 $action-hover-delay: 140ms;
 
+/** Color to indicate focused block */
+$focus-color: var(--color-brand-01);
+
 .repl-input,
 .repl-input-sourceref,
 .repl-output {
@@ -34,10 +37,13 @@ $action-hover-delay: 140ms;
 
 @mixin show-block-action-buttons {
   .kui--block-actions-buttons {
-    width: auto;
     opacity: 1;
-    right: 0;
   }
+}
+
+/** We are using <li> for the blocks, but don't want any standard browser styling */
+li.repl-block {
+  list-style: none;
 }
 
 /** Coloring the context border by status of the block */
@@ -71,40 +77,61 @@ $action-hover-delay: 140ms;
       border-top-right-radius: 1px;
       border-bottom-right-radius: 1px;
     }
-    &[data-is-output-only]:not([data-is-focused]):before {
-      background-color: transparent;
-    }
     &:not([data-is-output-only]) .repl-output.repl-result-has-content {
       margin-top: 0.5rem;
     }
-    .repl-output:not(.repl-result-has-content) {
+    /* .repl-output:not(.repl-result-has-content) {
       .repl-context {
         display: none;
       }
-    }
-    &[data-is-focused]:before {
-      opacity: 1;
-    }
-    &[data-is-focused]:before,
-    &:hover:before {
-      background-color: var(--color-brand-01);
-    }
+    } */
     &.error:before {
       opacity: 1;
       background-color: var(--color-error);
-    }
-    &[data-is-focused] .repl-context {
-      opacity: 1;
     }
     &:hover .repl-output .repl-context:after {
       border-color: var(--color-base03);
     }
   }
 
-  .repl-block {
-    padding: 0.875rem 0;
+  /** focus */
+  & > li:focus {
+    outline: none;
+  }
+  li:focus.repl-block,
+  li:hover.repl-block[data-is-focused],
+  .repl-block.repl-active[data-is-focused] {
+    @include show-block-action-buttons;
+
+    &:before {
+      opacity: 1;
+    }
+    &:before {
+      background-color: $focus-color;
+    }
+    .repl-input .repl-context {
+      opacity: 1;
+    }
+  }
+  li:hover.repl-block:before {
+    background-color: $focus-color;
+  }
+  li:not(:focus) {
+    &.repl-block {
+      &[data-is-output-only]:before {
+        background-color: transparent;
+      }
+      .repl-context:hover,
+      .repl-input-element:hover {
+        cursor: pointer;
+      }
+    }
+  }
+
+  & > li.repl-block {
     display: flex;
     flex-direction: column;
+    padding: 0.875rem 0;
 
     &[data-is-quietly-elsewhere] {
       padding-top: 0;
@@ -124,23 +151,18 @@ $action-hover-delay: 140ms;
     .kui--block-actions-buttons {
       align-items: center;
       display: flex;
-      width: 0;
       opacity: 0;
       border-radius: 1px;
 
       position: absolute;
       top: 0; /* this with bottom:0 gives 1) vertical center; 2) occluding of repl-input-element content */
       bottom: 0;
-      right: -100rem; /* we will change this on hover */
+      right: 0;
 
       padding-left: 0.5rem;
       transition-property: right;
       transition-delay: $action-hover-delay;
       transition-duration: 140ms;
-    }
-
-    &[data-is-focused] {
-      @include show-block-action-buttons;
     }
 
     .kui--block-action {
@@ -196,12 +218,6 @@ $action-hover-delay: 140ms;
       margin-right: 0.5rem;
       position: relative;
       opacity: 0.75;
-    }
-    &:not([data-is-focused]) {
-      .repl-context:hover,
-      .repl-input-element:hover {
-        cursor: pointer;
-      }
     }
 
     .repl-input .repl-context:before {

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Layout.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Layout.scss
@@ -15,19 +15,19 @@
  */
 
 /** Grid assignments for terminals */
-div.kui--scrollback:nth-of-type(1) {
+.kui--scrollback:nth-of-type(1) {
   grid-area: T1;
 }
-div.kui--scrollback:nth-of-type(2) {
+.kui--scrollback:nth-of-type(2) {
   grid-area: T2;
 }
-div.kui--scrollback:nth-of-type(3) {
+.kui--scrollback:nth-of-type(3) {
   grid-area: T3;
 }
-div.kui--scrollback:nth-of-type(4) {
+.kui--scrollback:nth-of-type(4) {
   grid-area: T4;
 }
-div.kui--scrollback:nth-of-type(5) {
+.kui--scrollback:nth-of-type(5) {
   grid-area: T5;
 }
 
@@ -98,7 +98,7 @@ div.kui--scrollback:nth-of-type(5) {
 @mixin sidecar-maximized {
   grid-template: repeat(1, 1fr) / repeat(1, 1fr);
   grid-template-areas: 'S';
-  div.kui--scrollback {
+  .kui--scrollback {
     display: none;
   }
 }


### PR DESCRIPTION
This PR may break some external tests. It introduces an `<li>` around each repl-block.

Fixes #5717


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
