### PR TITLE
fix(plugins/plugin-client-common): After reordering blocks, saving no…

### DIFF
--- a/plugins/plugin-core-support/src/lib/cmds/replay.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/replay.ts
@@ -464,9 +464,6 @@ export default function(registrar: Registrar) {
             nSplits++
 
             if (nSplits === nSnapshotable) {
-              // sort blocks by startTime
-              blocks.sort((a, b) => (a.startTime > b.startTime ? 1 : -1))
-
               // if needed, we could optimize this by recording per
               // blocksInSplit, as they arrive
               const clicks = parsedOptions.shallow ? undefined : await new FlightRecorder(tab, blocks).record()


### PR DESCRIPTION
…tebook does not reflect new block order.

This was due to a leftover sort of the blocks on snapshot.

Fixes #5738

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
