### PR TITLE
fix: don't show the `open` command for clicking files in `ls` table

### DIFF
--- a/plugins/plugin-bash-like/fs/src/lib/ls.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/ls.ts
@@ -192,6 +192,7 @@ function toTable(entries: GlobStats[], args: Arguments<LsOptions>): HTMLElement 
     css: cssOf(_),
     onclickExec: 'pexec' as const,
     onclick: `${_.dirent.isDirectory ? 'ls' : 'open'} ${args.REPL.encodeComponent(_.path)}`,
+    onclickSilence: !_.dirent.isDirectory,
     attributes: attrs(_, args, hasPermissions, hasSize, hasUid, hasGid, hasMtime)
   }))
 
@@ -206,7 +207,7 @@ function toTable(entries: GlobStats[], args: Arguments<LsOptions>): HTMLElement 
         cell.classList.add(_.css)
       }
       cell.classList.add('clickable')
-      cell.onclick = () => args.REPL.pexec(_.onclick)
+      cell.onclick = () => args.REPL.pexec(_.onclick, { echo: !_.onclickSilence })
       frag.appendChild(cell)
 
       longest = _.name.length >= longest.length ? _.name : longest

--- a/plugins/plugin-client-common/notebooks/welcome.json
+++ b/plugins/plugin-client-common/notebooks/welcome.json
@@ -464,6 +464,7 @@
                         "css": "",
                         "onclickExec": "pexec",
                         "onclick": "open /kui/kubernetes/list-resources.json",
+                        "onclickSilence": true,
                         "attributes": [],
                         "key": "Name"
                       },
@@ -472,6 +473,7 @@
                         "css": "",
                         "onclickExec": "pexec",
                         "onclick": "open /kui/kubernetes/create-jobs.json",
+                        "onclickSilence": true,
                         "attributes": [],
                         "key": "Name"
                       },
@@ -480,6 +482,7 @@
                         "css": "",
                         "onclickExec": "pexec",
                         "onclick": "open /kui/iter8/welcome.json",
+                        "onclickSilence": true,
                         "attributes": [],
                         "key": "Name"
                       },
@@ -488,6 +491,7 @@
                         "css": "",
                         "onclickExec": "pexec",
                         "onclick": "open /kui/welcome.json",
+                        "onclickSilence": true,
                         "attributes": [],
                         "key": "Name"
                       }


### PR DESCRIPTION
Fixes #5748

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
