### PR TITLE
fix(plugins/plugin-client-common): clicking on table or radio table m…

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -429,6 +429,10 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
         const rerunIdx = curState.blocks.findIndex(_ => hasUUID(_) && _.execUUID === event.execUUID)
 
         if (rerunIdx >= 0) {
+          // The use case here is that the user clicked the Rerun
+          // button in the UI; the onclick logic seems to reuse the
+          // execUUID, hence the `findIndex` logic just above, which
+          // scans the blocks for an existing execUUID. So: we
           // Transform the rerun block to Processing
           return {
             blocks: curState.blocks
@@ -436,8 +440,18 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
               .concat(processing(curState.blocks[rerunIdx], true))
               .concat(curState.blocks.slice(rerunIdx + 1)) // everything after
           }
-        } else if (curState.focusedBlockIdx !== undefined && curState.focusedBlockIdx !== idx) {
-          // Transform the active block to Processing
+        } else if (
+          curState.focusedBlockIdx !== undefined &&
+          curState.focusedBlockIdx !== idx &&
+          isActive(curState.blocks[idx])
+        ) {
+          // The use case here is that the user clicked to edit, and
+          // then hit return; Note: for not great reasons, this
+          // "rerun" path is different than the path in the just-prior
+          // clause, which also handles reruns, but for the case where
+          // ht euser clicked the rerun button; i think because in the
+          // button click case, we reuse the execUUID, whereas in the
+          // hit-return rerun case we don't :( :( :(
           const activeBlockIdx = curState.focusedBlockIdx
           const blocks = curState.blocks
             .slice(0, activeBlockIdx)


### PR DESCRIPTION
…ay cause block to disappear

Re: the fix, see the comments in the changeset. There are two code paths for rerun: one for clicking the rerun button and the other for clicking the input to edit and hitting return; the latter path was buggy w.r.t. normal command execution when a block was focused.

Fixes #5783
Closes #5784

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
