### PR TITLE
fix(plugins/plugin-bash-like): when clicking directory in ls -l outpu…

### DIFF
--- a/plugins/plugin-bash-like/fs/src/lib/ls.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/ls.ts
@@ -191,7 +191,9 @@ function toTable(entries: GlobStats[], args: Arguments<LsOptions>): HTMLElement 
     name: nameOf(_, args.parsedOptions.l),
     css: cssOf(_),
     onclickExec: 'pexec' as const,
-    onclick: `${_.dirent.isDirectory ? 'ls' : 'open'} ${args.REPL.encodeComponent(_.path)}`,
+    onclick: `${_.dirent.isDirectory ? (args.parsedOptions.l ? 'ls -l' : 'ls') : 'open'} ${args.REPL.encodeComponent(
+      _.path
+    )}`,
     onclickSilence: !_.dirent.isDirectory,
     attributes: attrs(_, args, hasPermissions, hasSize, hasUid, hasGid, hasMtime)
   }))


### PR DESCRIPTION
…t, response is an ls (not ls -l) of that clicked directory

Fixes #5796

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
