### PR TITLE
Fix references in tsconfig.json of example application AnimalApp

### DIFF
--- a/docs/example/AnimalApp/tsconfig.json
+++ b/docs/example/AnimalApp/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "./node_modules/@kui-shell/builder/tsconfig-base.json",
   "references": [
-    {
-      "path": "./plugins/plugin-example",
-      "path": "./plugins/plugin-client-default"
-    }
+    { "path": "./plugins/plugin-example" },
+    { "path": "./plugins/plugin-client-default" }
   ]
 }


### PR DESCRIPTION
#### Description of what you did:

The tsconfig.json of the example application AnimalApp was wrong

```
"references": { "path": "./plugins/plugin-example", "path": "./plugins/plugin-client-default" }
```

fixed as:

```
"references": [
    { "path": "./plugins/plugin-example" },
    { "path": "./plugins/plugin-client-default" }
  ]
```

#### My PR is a:

- [ ] 💥 Breaking change
- [X] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [X] Multiple commits are squashed into one commit.
- [X] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [X] All npm dependencies are pinned.
