### PR TITLE
BREAKING CHANGE: introduce final v1 serialized form of notebooks

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -136,7 +136,7 @@ export { split, _split, Split } from './repl/split'
 export { ReplEval, DirectReplEval } from './repl/types'
 export { default as encodeComponent } from './repl/encode'
 export { exec as internalBeCarefulExec, pexec as internalBeCarefulPExec, setEvaluatorImpl, doEval } from './repl/exec'
-export { CommandStartEvent, CommandCompleteEvent, Snapshot, SnapshotBlock, SnapshottedEvent } from './repl/events'
+export { CommandStartEvent, CommandCompleteEvent, Notebook, isNotebook, SnapshottedEvent } from './repl/events'
 
 // Tabs
 export { Tab, getTab, getCurrentTab, pexecInCurrentTab, getTabId, getPrimaryTabId, sameTab } from './webapp/tab'

--- a/packages/core/src/main/menu.ts
+++ b/packages/core/src/main/menu.ts
@@ -41,23 +41,26 @@ const closeTab = () => tellRendererToExecute('tab close')
 const isDarwin = process.platform === 'darwin'
 const closeAccelerator = isDarwin ? 'Command+W' : 'Control+Shift+W'
 
+/** Open a new window or tab and replay the contents of the given `filepath` */
+export function replay(filepath: string, createWindow: (executeThisArgvPlease?: string[]) => void) {
+  try {
+    // if we have no open kui windows, open a new one; otherwise,
+    // use a tab in an existing window
+    if (webContents.getAllWebContents().length === 0) {
+      createWindow(['replay', filepath])
+    } else {
+      tellRendererToExecute(`replay ${encodeComponent(filepath)}`, 'pexec')
+    }
+  } catch (err) {
+    console.log(err)
+  }
+}
+
 /** @return a menu item that opens the given notebook */
 function openNotebook(createWindow: (executeThisArgvPlease?: string[]) => void, label: string, filepath: string) {
   return {
     label,
-    click: () => {
-      try {
-        // if we have no open kui windows, open a new one; otherwise,
-        // use a tab in an existing window
-        if (webContents.getAllWebContents().length === 0) {
-          createWindow(['replay', '--new-tab', filepath])
-        } else {
-          tellRendererToExecute(`replay --new-tab ${encodeComponent(filepath)}`, 'pexec')
-        }
-      } catch (err) {
-        console.log(err)
-      }
-    }
+    click: () => replay(filepath, createWindow)
   }
 }
 

--- a/packages/core/src/main/open.ts
+++ b/packages/core/src/main/open.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-/** Open a new window and replay the contents of the given `filepath` */
-export function replay(filepath: string, createWindow: (executeThisArgvPlease?: string[]) => void) {
-  createWindow(['replay', filepath])
-}
+import { replay } from './menu'
 
 export const filters = [{ name: 'Kui snapshot', extensions: ['kui', 'json'] }]
 

--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -586,7 +586,7 @@ export async function initElectron(
 
   // See menu.ts; Open Recent leads here
   app.on('open-file', async (evt: Event, filepath: string) => {
-    const { replay } = await import('./open')
+    const { replay } = await import('./menu')
     replay(filepath, createWindowWithArgv)
   })
 

--- a/packages/core/src/repl/events.ts
+++ b/packages/core/src/repl/events.ts
@@ -61,32 +61,17 @@ export type SnapshottedEvent<E extends CommandStartEvent | CommandCompleteEvent>
   tab: E['tab']['uuid']
 }
 
-/**
- * SnapshotBlock: captures the start and complete of the command
- * execution.
- *
- */
-export type SnapshotBlock = {
-  startTime: number
-  startEvent: SnapshottedEvent<CommandStartEvent>
-  completeEvent: SnapshottedEvent<CommandCompleteEvent>
+export interface Notebook {
+  apiVersion: 'kui-shell/v1'
+  kind: 'Notebook'
+  metadata?: {
+    name?: string
+    description?: string
+  }
 }
 
-export type SnapshotTab = {
-  uuid: string
-  blocks: SnapshotBlock[]
-}
-
-export type SnapshotWindow = {
-  uuid: string
-  tabs: SnapshotTab[]
-}
-
-/**
- * Snapshot: captures the block-level snapshots across the entire
- * session.
- *
- */
-export type Snapshot = {
-  windows: SnapshotWindow[]
+/** @return wether or not the given `raw` json is an instance of Notebook */
+export function isNotebook(raw: Record<string, any>): raw is Notebook {
+  const model = raw as Notebook
+  return model.apiVersion === 'kui-shell/v1' && model.kind === 'Notebook'
 }

--- a/plugins/plugin-client-common/notebooks/settings.json
+++ b/plugins/plugin-client-common/notebooks/settings.json
@@ -1,579 +1,719 @@
 {
   "apiVersion": "kui-shell/v1",
-  "kind": "Snapshot",
+  "kind": "Notebook",
+  "metadata": {
+    "name": "Kui Setting",
+    "preferReExecute": true
+  },
   "spec": {
-    "title": "Kui Settings",
-    "preferReExecute": true,
-    "clicks": {
-      "startEvents": {},
-      "completeEvents": {}
-    },
-    "windows": [
+    "splits": [
       {
-        "uuid": "0",
-        "tabs": [
+        "uuid": "1_c57e811f-2da8-557e-a402-9f0950407675",
+        "blocks": [
           {
-            "uuid": "0",
-            "blocks": [
-              {
-                "startTime": 1599752321923,
-                "startEvent": {
-                  "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/split",
-                  "command": "split",
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "flags": {
-                      "boolean": ["debug", "inverse"]
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "# Kui Settings\nFrom this notebook, you may configure Kui. Try out some of the Kui themes on the right."
+              }
+            },
+            "historyIdx": 251,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
                     },
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 1,
-                  "execUUID": "a4e52722-8367-4f06-b2de-914a94d34b97",
-                  "echo": true
-                },
-                "completeEvent": {
-                  "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 1,
-                  "command": "split",
-                  "argvNoOptions": ["split"],
-                  "parsedOptions": {
-                    "_": ["split"]
-                  },
-                  "execUUID": "a4e52722-8367-4f06-b2de-914a94d34b97",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "a4e52722-8367-4f06-b2de-914a94d34b97",
-                    "history": 215,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "TabLayoutModificationResponse",
-                    "spec": {
-                      "modification": "NewSplit",
-                      "ok": {
-                        "apiVersion": "kui-shell/v1",
-                        "kind": "CommentaryResponse",
-                        "props": {
-                          "elsewhere": true,
-                          "tabUUID": "3_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                          "children": "Created a split"
-                        }
-                      }
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
                     }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 215
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "391834fe-c312-45db-a2c6-27ab91180eec"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "391834fe-c312-45db-a2c6-27ab91180eec",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "391834fe-c312-45db-a2c6-27ab91180eec",
+                "history": 251,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "# Kui Settings\nFrom this notebook, you may configure Kui. Try out some of the Kui themes on the right."
                 }
               },
-              {
-                "startTime": 1599752321966,
-                "startEvent": {
-                  "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/split",
-                  "command": "split --inverse",
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "flags": {
-                      "boolean": ["debug", "inverse"]
+              "responseType": "ScalarResponse",
+              "historyIdx": 251
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "391834fe-c312-45db-a2c6-27ab91180eec",
+            "startTime": "2020-09-30T18:44:26.160Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          }
+        ]
+      },
+      {
+        "uuid": "1_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
+        "blocks": [
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "If you would like to deveop your own themes, check out the source for some of our themes:\n\n\n- Carbon Themes: https://github.com/IBM/kui/tree/master/plugins/plugin-carbon-themes\n- PatternFly themes: https://github.com/IBM/kui/tree/master/plugins/plugin-patternfly4-themes\n\n- Community themes: https://github.com/IBM/kui/tree/master/plugins/plugin-core-themes"
+              }
+            },
+            "historyIdx": 97,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
                     },
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 1,
-                  "execUUID": "e06b4411-a261-461e-9331-765141933606",
-                  "echo": true
-                },
-                "completeEvent": {
-                  "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 1,
-                  "command": "split --inverse",
-                  "argvNoOptions": ["split"],
-                  "parsedOptions": {
-                    "_": ["split"],
-                    "inverse": true
-                  },
-                  "execUUID": "e06b4411-a261-461e-9331-765141933606",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "e06b4411-a261-461e-9331-765141933606",
-                    "history": 216,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "TabLayoutModificationResponse",
-                    "spec": {
-                      "modification": "NewSplit",
-                      "options": {
-                        "inverseColors": true
-                      },
-                      "ok": {
-                        "apiVersion": "kui-shell/v1",
-                        "kind": "CommentaryResponse",
-                        "props": {
-                          "elsewhere": true,
-                          "tabUUID": "3_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                          "children": "Created a split with inverted colors"
-                        }
-                      }
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
                     }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 216
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "f1a0c00d-b0a1-418d-86d6-a91778aa8ee3"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "f1a0c00d-b0a1-418d-86d6-a91778aa8ee3",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "f1a0c00d-b0a1-418d-86d6-a91778aa8ee3",
+                "history": 97,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "If you would like to deveop your own themes, check out the source for some of our themes:\n\n\n- Carbon Themes: https://github.com/IBM/kui/tree/master/plugins/plugin-carbon-themes\n- PatternFly themes: https://github.com/IBM/kui/tree/master/plugins/plugin-patternfly4-themes\n\n- Community themes: https://github.com/IBM/kui/tree/master/plugins/plugin-core-themes"
                 }
               },
-              {
-                "startTime": 1599752322013,
-                "startEvent": {
-                  "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/#",
-                  "command": "#             # Kui Settings\\nFrom this notebook, you may configure Kui. Try out some of the Kui themes on the right.",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
+              "responseType": "ScalarResponse",
+              "historyIdx": 97
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "f1a0c00d-b0a1-418d-86d6-a91778aa8ee3",
+            "startTime": "2020-09-30T18:45:24.152Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          }
+        ]
+      },
+      {
+        "uuid": "1_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
+        "inverseColors": true,
+        "blocks": [
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "RadioTable",
+              "title": "Available Themes",
+              "header": {
+                "cells": [
+                  "Theme",
+                  {
+                    "value": "Style",
+                    "hints": "hide-with-narrow-window"
                   },
-                  "execType": 1,
-                  "execUUID": "f8340aa4-5353-43ec-8944-f1df4ac4ac3b",
-                  "echo": true
-                },
-                "completeEvent": {
-                  "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 1,
-                  "command": "#            # Kui Settings\\nFrom this notebook, you may configure Kui. Try out some of the Kui themes on the right.",
-                  "argvNoOptions": [
-                    "#",
-                    "             # Kui Settings\\nFrom this notebook, you may configure Kui. Try out some of the Kui themes on the right."
+                  {
+                    "value": "Provider",
+                    "hints": "hide-with-sidecar"
+                  }
+                ]
+              },
+              "body": [
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "Carbon Gray10",
+                    {
+                      "value": "light",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-carbon-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
                   ],
-                  "parsedOptions": {
-                    "_": [
-                      "#",
-                      "             # Kui Settings\\nFrom this notebook, you may configure Kui. Try out some of the Kui themes on the right."
-                    ]
-                  },
-                  "execUUID": "f8340aa4-5353-43ec-8944-f1df4ac4ac3b",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "tab": "3_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "f8340aa4-5353-43ec-8944-f1df4ac4ac3b",
-                    "history": 217,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "# Kui Settings\nFrom this notebook, you may configure Kui. Try out some of the Kui themes on the right."
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 217
-                }
-              },
-              {
-                "startTime": 1599752322041,
-                "startEvent": {
-                  "tab": "3_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                  "route": "/themes",
-                  "command": "themes",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "themes",
-                      "strict": "themes",
-                      "docs": "List available themes"
-                    },
-                    "plugin": "plugin-core-support"
-                  },
-                  "execType": 1,
-                  "execUUID": "1c63fc5a-1419-4d5a-9172-ab47a4b47cb5",
-                  "echo": true
+                  "onSelect": "theme set \"Carbon Gray10\""
                 },
-                "completeEvent": {
-                  "tab": "3_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                  "execType": 1,
-                  "command": "themes",
-                  "argvNoOptions": ["themes"],
-                  "parsedOptions": {
-                    "_": ["themes"]
-                  },
-                  "execUUID": "1c63fc5a-1419-4d5a-9172-ab47a4b47cb5",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {
-                    "plugin": "plugin-core-support"
-                  },
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "tab": "3_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                    "execUUID": "1c63fc5a-1419-4d5a-9172-ab47a4b47cb5",
-                    "history": 13,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "RadioTable",
-                    "title": "Available Themes",
-                    "header": {
-                      "cells": [
-                        "Theme",
-                        {
-                          "value": "Style",
-                          "hints": "hide-with-narrow-window"
-                        },
-                        {
-                          "value": "Provider",
-                          "hints": "hide-with-sidecar"
-                        }
-                      ]
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "Carbon Gray90",
+                    {
+                      "value": "dark",
+                      "hints": "hide-with-narrow-window"
                     },
-                    "body": [
+                    {
+                      "value": "plugin-carbon-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set \"Carbon Gray90\""
+                },
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "Light",
+                    {
+                      "value": "light",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-core-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set Light"
+                },
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "Dark",
+                    {
+                      "value": "dark",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-core-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set Dark"
+                },
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "Atelier",
+                    {
+                      "value": "dark",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-core-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set Atelier"
+                },
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "Dracula",
+                    {
+                      "value": "dark",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-core-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set Dracula"
+                },
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "Gruvbox",
+                    {
+                      "value": "dark",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-core-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set Gruvbox"
+                },
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "Lucario",
+                    {
+                      "value": "dark",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-core-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set Lucario"
+                },
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "Monokai",
+                    {
+                      "value": "dark",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-core-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set Monokai"
+                },
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "Nord",
+                    {
+                      "value": "dark",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-core-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set Nord"
+                },
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "Paraiso",
+                    {
+                      "value": "dark",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-core-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set Paraiso"
+                },
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "Solarized",
+                    {
+                      "value": "dark",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-core-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set Solarized"
+                },
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "tomorrow-night",
+                    {
+                      "value": "dark",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-core-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set tomorrow-night"
+                },
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "PatternFly4 Light",
+                    {
+                      "value": "light",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-patternfly4-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set \"PatternFly4 Light\""
+                },
+                {
+                  "nameIdx": 0,
+                  "cells": [
+                    "PatternFly4 Dark",
+                    {
+                      "value": "dark",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "plugin-patternfly4-themes",
+                      "hints": ["hide-with-sidecar", "sub-text"]
+                    }
+                  ],
+                  "onSelect": "theme set \"PatternFly4 Dark\""
+                }
+              ],
+              "defaultSelectedIdx": 0
+            },
+            "historyIdx": 250,
+            "cwd": "~/Workspace7/kui",
+            "command": "themes",
+            "startEvent": {
+              "route": "/themes",
+              "command": "themes",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "themes",
+                  "strict": "themes",
+                  "docs": "List available themes"
+                },
+                "plugin": "plugin-core-support"
+              },
+              "execType": 0,
+              "execUUID": "6866f2f4-e4b5-4321-a23e-745feb2bbb20"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "themes",
+              "argvNoOptions": ["themes"],
+              "parsedOptions": {
+                "_": ["themes"]
+              },
+              "execUUID": "6866f2f4-e4b5-4321-a23e-745feb2bbb20",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "plugin": "plugin-core-support"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "6866f2f4-e4b5-4321-a23e-745feb2bbb20",
+                "history": 250,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "RadioTable",
+                "title": "Available Themes",
+                "header": {
+                  "cells": [
+                    "Theme",
+                    {
+                      "value": "Style",
+                      "hints": "hide-with-narrow-window"
+                    },
+                    {
+                      "value": "Provider",
+                      "hints": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                "body": [
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "Carbon Gray10",
                       {
-                        "nameIdx": 0,
-                        "cells": [
-                          "Carbon Gray10",
-                          {
-                            "value": "light",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-carbon-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set \"Carbon Gray10\""
+                        "value": "light",
+                        "hints": "hide-with-narrow-window"
                       },
                       {
-                        "nameIdx": 0,
-                        "cells": [
-                          "Carbon Gray90",
-                          {
-                            "value": "dark",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-carbon-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set \"Carbon Gray90\""
-                      },
-                      {
-                        "nameIdx": 0,
-                        "cells": [
-                          "Light",
-                          {
-                            "value": "light",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-core-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set Light"
-                      },
-                      {
-                        "nameIdx": 0,
-                        "cells": [
-                          "Dark",
-                          {
-                            "value": "dark",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-core-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set Dark"
-                      },
-                      {
-                        "nameIdx": 0,
-                        "cells": [
-                          "Atelier",
-                          {
-                            "value": "dark",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-core-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set Atelier"
-                      },
-                      {
-                        "nameIdx": 0,
-                        "cells": [
-                          "Dracula",
-                          {
-                            "value": "dark",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-core-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set Dracula"
-                      },
-                      {
-                        "nameIdx": 0,
-                        "cells": [
-                          "Gruvbox",
-                          {
-                            "value": "dark",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-core-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set Gruvbox"
-                      },
-                      {
-                        "nameIdx": 0,
-                        "cells": [
-                          "Lucario",
-                          {
-                            "value": "dark",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-core-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set Lucario"
-                      },
-                      {
-                        "nameIdx": 0,
-                        "cells": [
-                          "Monokai",
-                          {
-                            "value": "dark",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-core-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set Monokai"
-                      },
-                      {
-                        "nameIdx": 0,
-                        "cells": [
-                          "Nord",
-                          {
-                            "value": "dark",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-core-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set Nord"
-                      },
-                      {
-                        "nameIdx": 0,
-                        "cells": [
-                          "Paraiso",
-                          {
-                            "value": "dark",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-core-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set Paraiso"
-                      },
-                      {
-                        "nameIdx": 0,
-                        "cells": [
-                          "Solarized",
-                          {
-                            "value": "dark",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-core-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set Solarized"
-                      },
-                      {
-                        "nameIdx": 0,
-                        "cells": [
-                          "tomorrow-night",
-                          {
-                            "value": "dark",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-core-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set tomorrow-night"
-                      },
-                      {
-                        "nameIdx": 0,
-                        "cells": [
-                          "PatternFly4 Light",
-                          {
-                            "value": "light",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-patternfly4-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set \"PatternFly4 Light\""
-                      },
-                      {
-                        "nameIdx": 0,
-                        "cells": [
-                          "PatternFly4 Dark",
-                          {
-                            "value": "dark",
-                            "hints": "hide-with-narrow-window"
-                          },
-                          {
-                            "value": "plugin-patternfly4-themes",
-                            "hints": ["hide-with-sidecar", "sub-text"]
-                          }
-                        ],
-                        "onSelect": "theme set \"PatternFly4 Dark\""
+                        "value": "plugin-carbon-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
                       }
                     ],
-                    "defaultSelectedIdx": 0
+                    "onSelect": "theme set \"Carbon Gray10\""
                   },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 13
-                }
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "Carbon Gray90",
+                      {
+                        "value": "dark",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-carbon-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set \"Carbon Gray90\""
+                  },
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "Light",
+                      {
+                        "value": "light",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-core-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set Light"
+                  },
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "Dark",
+                      {
+                        "value": "dark",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-core-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set Dark"
+                  },
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "Atelier",
+                      {
+                        "value": "dark",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-core-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set Atelier"
+                  },
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "Dracula",
+                      {
+                        "value": "dark",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-core-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set Dracula"
+                  },
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "Gruvbox",
+                      {
+                        "value": "dark",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-core-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set Gruvbox"
+                  },
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "Lucario",
+                      {
+                        "value": "dark",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-core-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set Lucario"
+                  },
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "Monokai",
+                      {
+                        "value": "dark",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-core-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set Monokai"
+                  },
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "Nord",
+                      {
+                        "value": "dark",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-core-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set Nord"
+                  },
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "Paraiso",
+                      {
+                        "value": "dark",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-core-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set Paraiso"
+                  },
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "Solarized",
+                      {
+                        "value": "dark",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-core-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set Solarized"
+                  },
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "tomorrow-night",
+                      {
+                        "value": "dark",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-core-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set tomorrow-night"
+                  },
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "PatternFly4 Light",
+                      {
+                        "value": "light",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-patternfly4-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set \"PatternFly4 Light\""
+                  },
+                  {
+                    "nameIdx": 0,
+                    "cells": [
+                      "PatternFly4 Dark",
+                      {
+                        "value": "dark",
+                        "hints": "hide-with-narrow-window"
+                      },
+                      {
+                        "value": "plugin-patternfly4-themes",
+                        "hints": ["hide-with-sidecar", "sub-text"]
+                      }
+                    ],
+                    "onSelect": "theme set \"PatternFly4 Dark\""
+                  }
+                ],
+                "defaultSelectedIdx": 0
               },
-              {
-                "startTime": 1599752322187,
-                "startEvent": {
-                  "tab": "3_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "route": "/#",
-                  "command": "#     If you would like to deveop your own themes, check out the source for some of our themes:\\n\\n- Carbon Themes: https://github.com/IBM/kui/tree/master/plugins/plugin-carbon-themes\\n- PatternFly themes: https://github.com/IBM/kui/tree/master/plugins/plugin-patternfly4-themes\\n- Community themes: https://github.com/IBM/kui/tree/master/plugins/plugin-core-themes",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 1,
-                  "execUUID": "a1977d06-fa2c-4d08-b03c-a1c79cdc6627",
-                  "echo": true
-                },
-                "completeEvent": {
-                  "tab": "3_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "execType": 1,
-                  "command": "#    If you would like to deveop your own themes, check out the source for some of our themes:\\n\\n- Carbon Themes: https://github.com/IBM/kui/tree/master/plugins/plugin-carbon-themes\\n- PatternFly themes: https://github.com/IBM/kui/tree/master/plugins/plugin-patternfly4-themes\\n- Community themes: https://github.com/IBM/kui/tree/master/plugins/plugin-core-themes",
-                  "argvNoOptions": [
-                    "#",
-                    "     If you would like to deveop your own themes, check out the source for some of our themes:\\n\\n- Carbon Themes: https://github.com/IBM/kui/tree/master/plugins/plugin-carbon-themes\\n- PatternFly themes: https://github.com/IBM/kui/tree/master/plugins/plugin-patternfly4-themes\\n- Community themes: https://github.com/IBM/kui/tree/master/plugins/plugin-core-themes"
-                  ],
-                  "parsedOptions": {
-                    "_": [
-                      "#",
-                      "     If you would like to deveop your own themes, check out the source for some of our themes:\\n\\n- Carbon Themes: https://github.com/IBM/kui/tree/master/plugins/plugin-carbon-themes\\n- PatternFly themes: https://github.com/IBM/kui/tree/master/plugins/plugin-patternfly4-themes\\n- Community themes: https://github.com/IBM/kui/tree/master/plugins/plugin-core-themes"
-                    ]
-                  },
-                  "execUUID": "a1977d06-fa2c-4d08-b03c-a1c79cdc6627",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "tab": "3_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                    "execUUID": "a1977d06-fa2c-4d08-b03c-a1c79cdc6627",
-                    "history": 8,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "If you would like to deveop your own themes, check out the source for some of our themes:\n\n- Carbon Themes: https://github.com/IBM/kui/tree/master/plugins/plugin-carbon-themes\n- PatternFly themes: https://github.com/IBM/kui/tree/master/plugins/plugin-patternfly4-themes\n- Community themes: https://github.com/IBM/kui/tree/master/plugins/plugin-core-themes"
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 8
-                }
-              }
-            ]
+              "responseType": "ScalarResponse",
+              "historyIdx": 250
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "6866f2f4-e4b5-4321-a23e-745feb2bbb20",
+            "startTime": "2020-09-30T18:44:50.744Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": false,
+            "state": "valid-response"
           }
         ]
       }

--- a/plugins/plugin-client-common/notebooks/welcome.json
+++ b/plugins/plugin-client-common/notebooks/welcome.json
@@ -1,513 +1,490 @@
 {
   "apiVersion": "kui-shell/v1",
-  "kind": "Snapshot",
+  "kind": "Notebook",
+  "metadata": {
+    "name": "Welcome to Kui"
+  },
   "spec": {
-    "title": "Welcome to Kui",
-    "windows": [
+    "splits": [
       {
-        "uuid": "0",
-        "tabs": [
+        "uuid": "1_c57e811f-2da8-557e-a402-9f0950407675",
+        "blocks": [
           {
-            "uuid": "0",
-            "blocks": [
-              {
-                "startTime": 1599673259804,
-                "startEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/split",
-                  "startTime": 1599579392573,
-                  "command": "split",
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "flags": {
-                      "boolean": ["debug", "inverse"]
-                    },
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "88affb15-b90f-419a-a910-4f314b14b1e4"
-                },
-                "completeEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 0,
-                  "completeTime": 1599579392611,
-                  "command": "split",
-                  "argvNoOptions": ["split"],
-                  "parsedOptions": {
-                    "_": ["split"]
-                  },
-                  "execUUID": "88affb15-b90f-419a-a910-4f314b14b1e4",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "execUUID": "88affb15-b90f-419a-a910-4f314b14b1e4",
-                    "history": 250,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "TabLayoutModificationResponse",
-                    "spec": {
-                      "modification": "NewSplit",
-                      "ok": {
-                        "apiVersion": "kui-shell/v1",
-                        "kind": "CommentaryResponse",
-                        "props": {
-                          "elsewhere": true,
-                          "tabUUID": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                          "children": "Created a split"
-                        }
-                      }
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 250
-                }
-              },
-              {
-                "startTime": 1599673259831,
-                "startEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/split",
-                  "startTime": 1599579398762,
-                  "command": "split --inverse",
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "flags": {
-                      "boolean": ["debug", "inverse"]
-                    },
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "39696ae8-4fb6-4eb4-931f-97b1d1eb8ac4"
-                },
-                "completeEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 0,
-                  "completeTime": 1599579398777,
-                  "command": "split --inverse",
-                  "argvNoOptions": ["split"],
-                  "parsedOptions": {
-                    "_": ["split"],
-                    "inverse": true
-                  },
-                  "execUUID": "39696ae8-4fb6-4eb4-931f-97b1d1eb8ac4",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "execUUID": "39696ae8-4fb6-4eb4-931f-97b1d1eb8ac4",
-                    "history": 251,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "TabLayoutModificationResponse",
-                    "spec": {
-                      "modification": "NewSplit",
-                      "options": {
-                        "inverseColors": true
-                      },
-                      "ok": {
-                        "apiVersion": "kui-shell/v1",
-                        "kind": "CommentaryResponse",
-                        "props": {
-                          "elsewhere": true,
-                          "tabUUID": "2_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                          "children": "Created a split with inverted colors"
-                        }
-                      }
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 251
-                }
-              },
-              {
-                "startTime": 1599673259860,
-                "startEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/#",
-                  "startTime": 1599579412335,
-                  "command": "#                                # Notebooks with Kui!\\n\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application.",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 1,
-                  "execUUID": "9d2b87ec-16af-4fe9-aeab-49e6f1f2c1e2",
-                  "echo": true
-                },
-                "completeEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 1,
-                  "completeTime": 1599579412351,
-                  "command": "#                               # Notebooks with Kui!\\n\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application.",
-                  "argvNoOptions": [
-                    "#",
-                    "                                # Notebooks with Kui!\\n\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
-                  ],
-                  "parsedOptions": {
-                    "_": [
-                      "#",
-                      "                                # Notebooks with Kui!\\n\\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
-                    ]
-                  },
-                  "execUUID": "9d2b87ec-16af-4fe9-aeab-49e6f1f2c1e2",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "execUUID": "9d2b87ec-16af-4fe9-aeab-49e6f1f2c1e2",
-                    "history": 252,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "# Notebooks with Kui!\n\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 252
-                }
-              },
-              {
-                "startTime": 1599673259878,
-                "startEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "route": "/#",
-                  "startTime": 1599579430932,
-                  "command": "#       If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, please join us!\\n\\nhttps://github.com/IBM/kui",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "1a0ecd6d-e61d-40f0-a966-44fe043068e2"
-                },
-                "completeEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "execType": 0,
-                  "completeTime": 1599579430951,
-                  "command": "#      If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, please join us!\\n\\nhttps://github.com/IBM/kui",
-                  "argvNoOptions": [
-                    "#",
-                    "       If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, please join us!\\n\\nhttps://github.com/IBM/kui"
-                  ],
-                  "parsedOptions": {
-                    "_": [
-                      "#",
-                      "       If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, please join us!\\n\\nhttps://github.com/IBM/kui"
-                    ]
-                  },
-                  "execUUID": "1a0ecd6d-e61d-40f0-a966-44fe043068e2",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "execUUID": "1a0ecd6d-e61d-40f0-a966-44fe043068e2",
-                    "history": 90,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, please join us!\n\nhttps://github.com/IBM/kui"
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 90
-                }
-              },
-              {
-                "startTime": 1599673259896,
-                "startEvent": {
-                  "tab": "2_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                  "route": "/#",
-                  "startTime": 1599579459491,
-                  "command": "#  To start, click on one of these notebooks. You will then be able to browse your selected notebook in a new Kui tab.",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "df451c89-a2cd-44a6-828d-e4e590f7a5d5"
-                },
-                "completeEvent": {
-                  "tab": "2_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                  "execType": 0,
-                  "completeTime": 1599579459509,
-                  "command": "# To start, click on one of these notebooks. You will then be able to browse your selected notebook in a new Kui tab.",
-                  "argvNoOptions": [
-                    "#",
-                    "  To start, click on one of these notebooks. You will then be able to browse your selected notebook in a new Kui tab."
-                  ],
-                  "parsedOptions": {
-                    "_": [
-                      "#",
-                      "  To start, click on one of these notebooks. You will then be able to browse your selected notebook in a new Kui tab."
-                    ]
-                  },
-                  "execUUID": "df451c89-a2cd-44a6-828d-e4e590f7a5d5",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "execUUID": "df451c89-a2cd-44a6-828d-e4e590f7a5d5",
-                    "history": 250,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "To start, click on one of these notebooks. You will then be able to browse your selected notebook in a new Kui tab."
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 250
-                }
-              },
-              {
-                "startTime": 1599673284918,
-                "startEvent": {
-                  "tab": "2_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                  "route": "/ls",
-                  "command": "ls -l /kui/**/*.json",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "ls",
-                      "title": "local file list",
-                      "header": "Directory listing of your local filesystem",
-                      "noHelpAlias": true,
-                      "optional": [
-                        {
-                          "name": "path",
-                          "docs": "local file path",
-                          "file": true,
-                          "positional": true
-                        },
-                        {
-                          "name": "-A",
-                          "boolean": true,
-                          "docs": "List all entries except for . and .."
-                        },
-                        {
-                          "name": "-a",
-                          "boolean": true,
-                          "docs": "Include directory entries whose names begin with a dot (.)"
-                        },
-                        {
-                          "name": "-d",
-                          "boolean": true,
-                          "docs": "Directories are listed as plain files"
-                        },
-                        {
-                          "name": "-c",
-                          "boolean": true,
-                          "docs": "Use time when file status was last changed for sorting"
-                        },
-                        {
-                          "name": "-C",
-                          "boolean": true,
-                          "hidden": true
-                        },
-                        {
-                          "name": "-l",
-                          "boolean": true,
-                          "hidden": true
-                        },
-                        {
-                          "name": "-h",
-                          "boolean": true,
-                          "hidden": true
-                        },
-                        {
-                          "name": "-t",
-                          "boolean": true,
-                          "docs": "Sort by time modified (most recently modified first)"
-                        },
-                        {
-                          "name": "-r",
-                          "boolean": true,
-                          "docs": "Reverse the natural sort order"
-                        },
-                        {
-                          "name": "-s",
-                          "boolean": true,
-                          "hidden": true
-                        },
-                        {
-                          "name": "-S",
-                          "boolean": true,
-                          "docs": "Sort files by size"
-                        }
-                      ]
-                    },
-                    "flags": {
-                      "boolean": ["A", "a", "d", "c", "C", "l", "h", "t", "r", "s", "S"]
-                    },
-                    "plugin": "plugin-bash-like/fs"
-                  },
-                  "execType": 0,
-                  "execUUID": "af602715-21a4-4faf-bdfb-c3bc479aa1a4"
-                },
-                "completeEvent": {
-                  "tab": "2_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                  "execType": 0,
-                  "command": "ls -l /kui/**/*.json",
-                  "argvNoOptions": ["ls", "/kui/**/*.json"],
-                  "parsedOptions": {
-                    "_": ["ls", "/kui/**/*.json"],
-                    "l": true
-                  },
-                  "execUUID": "af602715-21a4-4faf-bdfb-c3bc479aa1a4",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "plugin": "plugin-bash-like/fs"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "2_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                    "execUUID": "af602715-21a4-4faf-bdfb-c3bc479aa1a4",
-                    "history": 251,
-                    "env": {}
-                  },
-                  "response": {
-                    "header": {
-                      "name": "Name",
-                      "attributes": []
-                    },
-                    "body": [
-                      {
-                        "name": "Kubernetes &mdash; `Listing Resources`",
-                        "css": "",
-                        "onclickExec": "pexec",
-                        "onclick": "open /kui/kubernetes/list-resources.json",
-                        "onclickSilence": true,
-                        "attributes": [],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "Kubernetes &mdash; `Working with Jobs`",
-                        "css": "",
-                        "onclickExec": "pexec",
-                        "onclick": "open /kui/kubernetes/create-jobs.json",
-                        "onclickSilence": true,
-                        "attributes": [],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "Welcome to Iter8",
-                        "css": "",
-                        "onclickExec": "pexec",
-                        "onclick": "open /kui/iter8/welcome.json",
-                        "onclickSilence": true,
-                        "attributes": [],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "Welcome to Kui",
-                        "css": "",
-                        "onclickExec": "pexec",
-                        "onclick": "open /kui/welcome.json",
-                        "onclickSilence": true,
-                        "attributes": [],
-                        "key": "Name"
-                      }
-                    ],
-                    "markdown": true,
-                    "noSort": true,
-                    "noEntityColors": true
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 251
-                }
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "# Notebooks with Kui!\n\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
               }
-            ]
+            },
+            "historyIdx": 252,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "3285fd03-25c0-47aa-8d3a-494ed23bab43"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "3285fd03-25c0-47aa-8d3a-494ed23bab43",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "3285fd03-25c0-47aa-8d3a-494ed23bab43",
+                "history": 252,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "# Notebooks with Kui!\n\nUsing Kui, you may craft notebooks that intermix commentary (such as this) with command executions. The notebooks preserve the output of commands, so that you may share a full session with others. You can even serve up notebooks with a purely static single page web application."
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 252
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "3285fd03-25c0-47aa-8d3a-494ed23bab43",
+            "startTime": "2020-09-29T21:41:46.197Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          }
+        ]
+      },
+      {
+        "uuid": "1_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
+        "blocks": [
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, please join us!\n\nhttps://github.com/IBM/kui"
+              }
+            },
+            "historyIdx": 89,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "134ea483-00cd-4148-9b47-a4368ac97565"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "134ea483-00cd-4148-9b47-a4368ac97565",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "134ea483-00cd-4148-9b47-a4368ac97565",
+                "history": 89,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "If you would like to contribute to Kui, either by crafting new Notebooks or coding new core features, please join us!\n\nhttps://github.com/IBM/kui"
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 89
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "134ea483-00cd-4148-9b47-a4368ac97565",
+            "startTime": "2020-09-29T21:41:57.989Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          }
+        ]
+      },
+      {
+        "uuid": "1_8205f6b8-87bf-5679-ac83-e3519c17d89c",
+        "inverseColors": true,
+        "blocks": [
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "To start, click on one of these notebooks. You will then be able to browse your selected notebook in a new Kui tab."
+              }
+            },
+            "historyIdx": 22,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "5d6dc961-a02b-434e-8cdd-2d00a06d57b7"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "5d6dc961-a02b-434e-8cdd-2d00a06d57b7",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "5d6dc961-a02b-434e-8cdd-2d00a06d57b7",
+                "history": 22,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "To start, click on one of these notebooks. You will then be able to browse your selected notebook in a new Kui tab."
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 22
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "5d6dc961-a02b-434e-8cdd-2d00a06d57b7",
+            "startTime": "2020-09-29T21:42:06.652Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "header": {
+                "name": "Name",
+                "attributes": []
+              },
+              "body": [
+                {
+                  "name": "Kubernetes &mdash; `Listing Resources`",
+                  "css": "",
+                  "onclickExec": "pexec",
+                  "onclick": "open /kui/kubernetes/list-resources.json",
+                  "onclickSilence": true,
+                  "attributes": [],
+                  "key": "Name"
+                },
+                {
+                  "name": "Kubernetes &mdash; `Working with Jobs`",
+                  "css": "",
+                  "onclickExec": "pexec",
+                  "onclick": "open /kui/kubernetes/create-jobs.json",
+                  "onclickSilence": true,
+                  "attributes": [],
+                  "key": "Name"
+                },
+                {
+                  "name": "Kui Setting",
+                  "css": "",
+                  "onclickExec": "pexec",
+                  "onclick": "open /kui/settings.json",
+                  "onclickSilence": true,
+                  "attributes": [],
+                  "key": "Name"
+                },
+                {
+                  "name": "Welcome to Iter8",
+                  "css": "",
+                  "onclickExec": "pexec",
+                  "onclick": "open /kui/iter8/welcome.json",
+                  "onclickSilence": true,
+                  "attributes": [],
+                  "key": "Name"
+                },
+                {
+                  "name": "Welcome to Kui",
+                  "css": "",
+                  "onclickExec": "pexec",
+                  "onclick": "open /kui/welcome.json",
+                  "onclickSilence": true,
+                  "attributes": [],
+                  "key": "Name"
+                }
+              ],
+              "markdown": true,
+              "noSort": true,
+              "noEntityColors": true
+            },
+            "historyIdx": 251,
+            "cwd": "~/Workspace7/kui",
+            "command": "ls -l /kui/**/*.json",
+            "startEvent": {
+              "route": "/ls",
+              "command": "ls -l /kui/**/*.json",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "ls",
+                  "title": "local file list",
+                  "header": "Directory listing of your local filesystem",
+                  "noHelpAlias": true,
+                  "optional": [
+                    {
+                      "name": "path",
+                      "docs": "local file path",
+                      "file": true,
+                      "positional": true
+                    },
+                    {
+                      "name": "-A",
+                      "boolean": true,
+                      "docs": "List all entries except for . and .."
+                    },
+                    {
+                      "name": "-a",
+                      "boolean": true,
+                      "docs": "Include directory entries whose names begin with a dot (.)"
+                    },
+                    {
+                      "name": "-d",
+                      "boolean": true,
+                      "docs": "Directories are listed as plain files"
+                    },
+                    {
+                      "name": "-c",
+                      "boolean": true,
+                      "docs": "Use time when file status was last changed for sorting"
+                    },
+                    {
+                      "name": "-C",
+                      "boolean": true,
+                      "hidden": true
+                    },
+                    {
+                      "name": "-l",
+                      "boolean": true,
+                      "hidden": true
+                    },
+                    {
+                      "name": "-h",
+                      "boolean": true,
+                      "hidden": true
+                    },
+                    {
+                      "name": "-t",
+                      "boolean": true,
+                      "docs": "Sort by time modified (most recently modified first)"
+                    },
+                    {
+                      "name": "-r",
+                      "boolean": true,
+                      "docs": "Reverse the natural sort order"
+                    },
+                    {
+                      "name": "-s",
+                      "boolean": true,
+                      "hidden": true
+                    },
+                    {
+                      "name": "-S",
+                      "boolean": true,
+                      "docs": "Sort files by size"
+                    }
+                  ]
+                },
+                "flags": {
+                  "boolean": ["A", "a", "d", "c", "C", "l", "h", "t", "r", "s", "S"]
+                },
+                "plugin": "plugin-bash-like/fs"
+              },
+              "execType": 0,
+              "execUUID": "04f11a6b-eaa6-4749-97bd-e39378bf5a30"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "ls -l /kui/**/*.json",
+              "argvNoOptions": ["ls", "/kui/**/*.json"],
+              "parsedOptions": {
+                "_": ["ls", "/kui/**/*.json"],
+                "l": true
+              },
+              "execUUID": "04f11a6b-eaa6-4749-97bd-e39378bf5a30",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "plugin": "plugin-bash-like/fs"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "04f11a6b-eaa6-4749-97bd-e39378bf5a30",
+                "history": 251,
+                "env": {}
+              },
+              "response": {
+                "header": {
+                  "name": "Name",
+                  "attributes": []
+                },
+                "body": [
+                  {
+                    "name": "Kubernetes &mdash; `Listing Resources`",
+                    "css": "",
+                    "onclickExec": "pexec",
+                    "onclick": "open /kui/kubernetes/list-resources.json",
+                    "onclickSilence": true,
+                    "attributes": [],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "Kubernetes &mdash; `Working with Jobs`",
+                    "css": "",
+                    "onclickExec": "pexec",
+                    "onclick": "open /kui/kubernetes/create-jobs.json",
+                    "onclickSilence": true,
+                    "attributes": [],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "Kui Setting",
+                    "css": "",
+                    "onclickExec": "pexec",
+                    "onclick": "open /kui/settings.json",
+                    "onclickSilence": true,
+                    "attributes": [],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "Welcome to Iter8",
+                    "css": "",
+                    "onclickExec": "pexec",
+                    "onclick": "open /kui/iter8/welcome.json",
+                    "onclickSilence": true,
+                    "attributes": [],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "Welcome to Kui",
+                    "css": "",
+                    "onclickExec": "pexec",
+                    "onclick": "open /kui/welcome.json",
+                    "onclickSilence": true,
+                    "attributes": [],
+                    "key": "Name"
+                  }
+                ],
+                "markdown": true,
+                "noSort": true,
+                "noEntityColors": true
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 251
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "04f11a6b-eaa6-4749-97bd-e39378bf5a30",
+            "startTime": "2020-09-30T18:47:11.872Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": false,
+            "state": "valid-response"
           }
         ]
       }
-    ]
+    ],
+    "clicks": {
+      "startEvents": {},
+      "completeEvents": {}
+    }
   }
 }

--- a/plugins/plugin-client-common/src/components/Client/StatusStripe/index.tsx
+++ b/plugins/plugin-client-common/src/components/Client/StatusStripe/index.tsx
@@ -121,7 +121,7 @@ export default class StatusStripe extends React.PureComponent<Props, State> {
             title={strings('Click to view configuration options')}
             onClick={() =>
               pexecInCurrentTab(
-                `tab new --cmdline "replay /kui/settings.json" --title "${strings(
+                `tab new -s "/kui/settings.json" --title "${strings(
                   'Kui Settings'
                 )}" --status-stripe-type blue --status-stripe-message "${strings('Kui Settings')}"`
               )

--- a/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
@@ -147,7 +147,8 @@ export default class TabContainer extends React.PureComponent<Props, State> {
       undefined,
       evt.cmdline,
       evt.onClose,
-      evt.exec
+      evt.exec,
+      evt.snapshot
     )
     this.listenForTabClose(model)
     return model
@@ -276,6 +277,7 @@ export default class TabContainer extends React.PureComponent<Props, State> {
         {this.state.tabs.map((_, idx) => (
           <TabContent
             {...this.props}
+            snapshot={_.snapshot}
             key={_.uuid}
             uuid={_.uuid}
             active={idx === this.state.activeIdx}

--- a/plugins/plugin-client-common/src/components/Client/TabContent.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContent.tsx
@@ -50,6 +50,7 @@ type Props = TabContentOptions &
   WithTabUUID & {
     active: boolean
     state: TabState
+    snapshot?: Buffer
     willUpdateTopTabButtons?: (buttons: TopTabButton[]) => void
   }
 

--- a/plugins/plugin-client-common/src/components/Client/TabModel.ts
+++ b/plugins/plugin-client-common/src/components/Client/TabModel.ts
@@ -36,7 +36,8 @@ export default class TabModel {
     private readonly _buttons: TopTabButton[] = [],
     private readonly _initialCommandLine?: string,
     private readonly _onClose?: string,
-    private readonly _exec?: NewTabRequestEvent['exec']
+    private readonly _exec?: NewTabRequestEvent['exec'],
+    private readonly _snapshot?: Buffer
   ) {
     this._state.capture()
 
@@ -73,7 +74,22 @@ export default class TabModel {
     return this._exec
   }
 
+  public get snapshot() {
+    return this._snapshot
+  }
+
   public update(buttons: TopTabButton[]) {
-    return new TabModel(this.uuid, undefined, undefined, this.title, this.state, buttons, undefined, this.onClose)
+    return new TabModel(
+      this.uuid,
+      undefined,
+      undefined,
+      this.title,
+      this.state,
+      buttons,
+      undefined,
+      this.onClose,
+      undefined,
+      this._snapshot
+    )
   }
 }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -18,11 +18,9 @@ import {
   CommandStartEvent,
   CommandCompleteEvent,
   ScalarResponse,
-  SnapshotBlock,
   UsageError,
   ExecType,
   isElsewhereCommentaryResponse,
-  isWatchable,
   isXtermErrorResponse,
   inBrowser
 } from '@kui-shell/core'
@@ -258,44 +256,6 @@ export function Finished(
       prefersTerminalPresentation,
       outputOnly,
       state: BlockState.ValidResponse
-    }
-  }
-}
-
-export function snapshot(block: BlockModel): SnapshotBlock {
-  if (!isAnnouncement(block) && (isOops(block) || isOk(block))) {
-    const execOptions = Object.assign(
-      {},
-      block.completeEvent.execOptions,
-      { block: undefined },
-      { tab: block.completeEvent.execOptions.tab ? block.completeEvent.execOptions.tab.uuid : undefined }
-    )
-    const evaluatorOptions = Object.assign({}, block.completeEvent.evaluatorOptions, {
-      usage: undefined,
-      flags: undefined
-    })
-
-    /**
-     * We excluded watch for now since a `Watchable` instance is not serializable
-     * see issue: https://github.com/IBM/kui/issues/5399
-     * and issue: https://github.com/IBM/kui/issues/5452
-     *
-     */
-    const response =
-      block.completeEvent.response && isWatchable(block.completeEvent.response)
-        ? Object.assign({}, block.completeEvent.response, { watch: undefined })
-        : block.completeEvent.response
-
-    return {
-      startTime: new Date(block.startTime).getTime(),
-      startEvent: Object.assign({}, block.startEvent, { tab: block.startEvent.tab.uuid }),
-      completeEvent: Object.assign(
-        {},
-        block.completeEvent,
-        { execOptions, evaluatorOptions },
-        { tab: block.completeEvent.tab.uuid },
-        { response }
-      )
     }
   }
 }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -579,7 +579,7 @@ export default class Input extends InputProvider {
       return (
         this.props.model.startTime && (
           <span className="kui--repl-block-timestamp kui--repl-block-right-element">
-            {this.props.model.startTime.toLocaleTimeString()}
+            {new Date(this.props.model.startTime).toLocaleTimeString()}
           </span>
         )
       )

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Snapshot.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Snapshot.ts
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { v4 as uuid } from 'uuid'
+
+import {
+  CommandStartEvent,
+  CommandCompleteEvent,
+  Notebook,
+  isNotebook,
+  SnapshottedEvent,
+  isWatchable,
+  eventBus,
+  flatten,
+  Tab,
+  isTable
+} from '@kui-shell/core'
+
+import { CompleteBlock, isAnnouncement, isWithCompleteEvent, isOk, isOops } from './Block/BlockModel'
+
+/**
+ * Split: captures the split uuid and blocks in a split
+ *
+ */
+export type Split = {
+  uuid: string
+  blocks: CompleteBlock[]
+  inverseColors?: boolean
+}
+
+/** Schema for a record of onclick (startEvent, completeEvent) pairs */
+export interface PreRecordedClicks {
+  startEvents: Record<string, SnapshottedEvent<CommandStartEvent>[]>
+  completeEvents: Record<string, SnapshottedEvent<CommandCompleteEvent>[]>
+}
+
+type NotebookSpec = {
+  spec: {
+    splits: Split[]
+    preferReExecute?: boolean
+    clicks?: PreRecordedClicks
+  }
+}
+
+export type NotebookImpl = Notebook & NotebookSpec
+
+export function isNotebookImpl(raw: Record<string, any>): raw is NotebookImpl {
+  const model = raw as NotebookImpl
+  return isNotebook(model) && model.spec && Array.isArray(model.spec.splits)
+}
+
+export function snapshot(block: CompleteBlock): CompleteBlock {
+  if (!isAnnouncement(block) && (isOops(block) || isOk(block))) {
+    const execOptions = Object.assign(
+      {},
+      block.completeEvent.execOptions,
+      { block: undefined },
+      { tab: block.completeEvent.execOptions.tab ? block.completeEvent.execOptions.tab.uuid : undefined }
+    )
+    const evaluatorOptions = Object.assign({}, block.completeEvent.evaluatorOptions, {
+      usage: undefined,
+      flags: undefined
+    })
+
+    /**
+     * We excluded watch for now since a `Watchable` instance is not serializable
+     * see issue: https://github.com/IBM/kui/issues/5399
+     * and issue: https://github.com/IBM/kui/issues/5452
+     *
+     */
+    const excludeWatchable = (response: CommandCompleteEvent['response']) => {
+      if (response && isWatchable(response)) {
+        return Object.assign({}, response, { watch: undefined })
+      } else {
+        return response
+      }
+    }
+
+    const startEvent = Object.assign({}, block.startEvent, { tab: block.startEvent.tab.uuid })
+
+    const completeEvent = Object.assign(
+      {},
+      block.completeEvent,
+      { execOptions, evaluatorOptions },
+      { tab: block.completeEvent.tab.uuid },
+      { response: excludeWatchable(block.completeEvent.response) }
+    )
+
+    return Object.assign(block, { response: excludeWatchable(block.response), startEvent, completeEvent })
+  }
+}
+
+/**
+ * Record clicks
+ *
+ */
+type Click = {
+  completeEvent: CompleteBlock['completeEvent']
+  onClicks: { rowIdx: number; onClick: string; echo: boolean }[]
+}
+
+/**
+ * The command name we use to replay the click in a given block
+ * (`execUUID`) and table row (`rowIdx`).
+ *
+ */
+function replayClickFor(execUUID: string, rowIdx: number) {
+  return `replay-click-${execUUID}-${rowIdx}`
+}
+
+export class FlightRecorder {
+  // eslint-disable-next-line no-useless-constructor
+  public constructor(private readonly tab: Tab, private readonly splits: Split[]) {}
+
+  /** Find onclick handlers that we should crawl */
+  private collectOnClicks(): Click[] {
+    return flatten(
+      this.splits.map(split => {
+        return split.blocks
+          .map(_ =>
+            isWithCompleteEvent(_) && _.completeEvent && isTable(_.completeEvent.response)
+              ? {
+                  completeEvent: _.completeEvent,
+                  onClicks: _.completeEvent.response.body
+                    .map((row, rowIdx) =>
+                      row.onclickIdempotent && typeof row.onclick === 'string'
+                        ? { rowIdx, onClick: row.onclick, echo: !row.onclickSilence }
+                        : undefined
+                    )
+                    .filter(_ => _)
+                }
+              : undefined
+          )
+          .filter(_ => _)
+      })
+    )
+  }
+
+  /**
+   * Transform a E=Command*Event into the matching
+   * SnapshottedEvent<E>, by splicing in the tab uuid in place of the
+   * tab object. This allows us to replay in a repeatible way, since
+   * tab uuids are a v5 sequence. See ScrollableTerminal for the
+   * origin of the v5 sequence.
+   *
+   * Note: That we have to place this an a separate function is due to
+   * typescript
+   * limitations. https://github.com/microsoft/TypeScript/issues/35858
+   *
+   */
+  private static xform<E extends CommandStartEvent | CommandCompleteEvent>(
+    this: Pick<Click, 'completeEvent'>,
+    evt: E
+  ): SnapshottedEvent<E> {
+    return Object.assign(Object.assign({}, evt, { tab: undefined }), { tab: this.completeEvent.tab })
+  }
+
+  /**
+   * Accept a Command*Event pass it through `xform` (just above) and
+   * store the resulting SnapshottedEvent in the given `this`
+   * record. We should have an array of these, one per click handler
+   * in a table; this is where the T[] comes from: that array is
+   * parallel to the rows of the table being crawled.
+   *
+   */
+  private static handler<E extends CommandStartEvent | CommandCompleteEvent, T extends SnapshottedEvent<E>>(
+    this: Record<string, T[]>,
+    click: Pick<Click, 'completeEvent'>,
+    rowIdx: number,
+    xform: (evt: E) => T,
+    event: E
+  ) {
+    const events = this[click.completeEvent.execUUID] || []
+    if (events.length === 0) {
+      this[click.completeEvent.execUUID] = events
+    }
+
+    if (isTable(click.completeEvent.response)) {
+      const row = click.completeEvent.response.body[rowIdx]
+      row.onclick = replayClickFor(click.completeEvent.execUUID, rowIdx)
+      row.onclickExec = 'qexec'
+    }
+
+    events[rowIdx] = xform(event)
+  }
+
+  /**
+   * Run through the rows of a Table response, issue the onclick
+   * handler, and store the (start,complete) event pairs, indexed by
+   * row of the table; that's a ClickSnapshot.
+   *
+   */
+  public async record(): Promise<PreRecordedClicks> {
+    const fakeTab = Object.assign({}, this.tab, { uuid: uuid() })
+    const startEvents: Record<string, SnapshottedEvent<CommandStartEvent>[]> = {}
+    const completeEvents: Record<string, SnapshottedEvent<CommandCompleteEvent>[]> = {}
+
+    const onclicks = this.collectOnClicks()
+
+    await Promise.all(
+      onclicks.map(async click => {
+        await Promise.all(
+          click.onClicks.map(async _ => {
+            const xform = FlightRecorder.xform.bind(click)
+            const onCommandStart = FlightRecorder.handler.bind(startEvents, click, _.rowIdx, xform)
+            const onCommandComplete = FlightRecorder.handler.bind(completeEvents, click, _.rowIdx, xform)
+            eventBus.onCommandStart(fakeTab.uuid, onCommandStart)
+            eventBus.onCommandComplete(fakeTab.uuid, onCommandComplete)
+
+            try {
+              await fakeTab.REPL.pexec(_.onClick, { tab: fakeTab, echo: _.echo })
+            } finally {
+              eventBus.offCommandStart(fakeTab.uuid, onCommandStart)
+              eventBus.offCommandComplete(fakeTab.uuid, onCommandComplete)
+            }
+          })
+        )
+      })
+    )
+
+    return { startEvents, completeEvents }
+  }
+}

--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -57,8 +57,8 @@ export default function renderMain(props: KuiProps) {
         props.commandLine || [
           'tab',
           'new',
-          '--cmdline',
-          'replay /kui/welcome.json',
+          '-s',
+          '/kui/welcome.json',
           '-q', // qexec
           '--bg', // open in background
           '--title',

--- a/plugins/plugin-client-test/notebooks/ls.json
+++ b/plugins/plugin-client-test/notebooks/ls.json
@@ -1,624 +1,1333 @@
 {
   "apiVersion": "kui-shell/v1",
-  "kind": "Snapshot",
+  "kind": "Notebook",
+  "metadata": {},
   "spec": {
-    "windows": [
+    "splits": [
       {
-        "uuid": "0",
-        "tabs": [
+        "uuid": "1",
+        "blocks": [
           {
-            "uuid": "0",
-            "blocks": [
-              {
-                "startTime": 1598216885634,
-                "startEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/ls",
-                  "command": "ls -l",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "ls",
-                      "title": "local file list",
-                      "header": "Directory listing of your local filesystem",
-                      "noHelpAlias": true,
-                      "optional": [
-                        { "name": "path", "docs": "local file path", "file": true, "positional": true },
-                        { "name": "-A", "boolean": true, "docs": "List all entries except for . and .." },
-                        {
-                          "name": "-a",
-                          "boolean": true,
-                          "docs": "Include directory entries whose names begin with a dot (.)"
-                        },
-                        { "name": "-d", "boolean": true, "docs": "Directories are listed as plain files" },
-                        {
-                          "name": "-c",
-                          "boolean": true,
-                          "docs": "Use time when file status was last changed for sorting"
-                        },
-                        { "name": "-C", "boolean": true, "hidden": true },
-                        { "name": "-l", "boolean": true, "hidden": true },
-                        { "name": "-h", "boolean": true, "hidden": true },
-                        {
-                          "name": "-t",
-                          "boolean": true,
-                          "docs": "Sort by time modified (most recently modified first)"
-                        },
-                        { "name": "-r", "boolean": true, "docs": "Reverse the natural sort order" },
-                        { "name": "-s", "boolean": true, "hidden": true },
-                        { "name": "-S", "boolean": true, "docs": "Sort files by size" }
-                      ]
-                    },
-                    "flags": { "boolean": ["A", "a", "d", "c", "C", "l", "h", "t", "r", "s", "S"] },
-                    "plugin": "plugin-bash-like/fs"
+            "response": {
+              "header": {
+                "name": "Name",
+                "attributes": [
+                  {
+                    "value": "Permissions",
+                    "outerCSS": "hide-with-sidecar"
                   },
-                  "execType": 0,
-                  "execUUID": "b3712610-4ab2-4784-8845-f0876b9a1db3"
+                  {
+                    "value": "User",
+                    "outerCSS": "hide-with-sidecar"
+                  },
+                  {
+                    "value": "Group",
+                    "outerCSS": "hide-with-sidecar"
+                  },
+                  {
+                    "value": "Size",
+                    "outerCSS": "hide-with-sidecar text-right"
+                  },
+                  {
+                    "value": "Last Modified",
+                    "outerCSS": "hide-with-narrow-window",
+                    "css": "elide-with-narrow-window"
+                  }
+                ]
+              },
+              "body": [
+                {
+                  "name": "bin/",
+                  "css": "dir-listing-is-directory",
+                  "onclickExec": "pexec",
+                  "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/bin",
+                  "onclickSilence": false,
+                  "attributes": [
+                    {
+                      "value": "drwxr-xr-x",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "192B",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
                 },
-                "completeEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 0,
-                  "command": "ls -l",
-                  "argvNoOptions": ["ls"],
-                  "parsedOptions": { "_": ["ls"], "l": true },
-                  "execUUID": "b3712610-4ab2-4784-8845-f0876b9a1db3",
-                  "cancelled": false,
-                  "evaluatorOptions": { "plugin": "plugin-bash-like/fs" },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "b3712610-4ab2-4784-8845-f0876b9a1db3",
-                    "history": 250,
-                    "env": {}
-                  },
-                  "response": {
-                    "header": {
-                      "name": "Name",
-                      "attributes": [
-                        { "value": "Permissions", "outerCSS": "hide-with-sidecar" },
-                        { "value": "User", "outerCSS": "hide-with-sidecar" },
-                        { "value": "Group", "outerCSS": "hide-with-sidecar" },
-                        { "value": "Size", "outerCSS": "hide-with-sidecar text-right" },
-                        {
-                          "value": "Last Modified",
-                          "outerCSS": "hide-with-narrow-window",
-                          "css": "elide-with-narrow-window"
-                        }
-                      ]
+                {
+                  "name": "CHANGELOG.md",
+                  "css": "",
+                  "onclickExec": "pexec",
+                  "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/CHANGELOG.md",
+                  "onclickSilence": true,
+                  "attributes": [
+                    {
+                      "value": "-rw-r--r--",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
                     },
-                    "body": [
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "1.6M",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                },
+                {
+                  "name": "CONTRIBUTING.md",
+                  "css": "",
+                  "onclickExec": "pexec",
+                  "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/CONTRIBUTING.md",
+                  "onclickSilence": true,
+                  "attributes": [
+                    {
+                      "value": "-rw-r--r--",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "4.5K",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                },
+                {
+                  "name": "design/",
+                  "css": "dir-listing-is-directory",
+                  "onclickExec": "pexec",
+                  "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/design",
+                  "onclickSilence": false,
+                  "attributes": [
+                    {
+                      "value": "drwxr-xr-x",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "128B",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                },
+                {
+                  "name": "docs/",
+                  "css": "dir-listing-is-directory",
+                  "onclickExec": "pexec",
+                  "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/docs",
+                  "onclickSilence": false,
+                  "attributes": [
+                    {
+                      "value": "drwxr-xr-x",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "192B",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                },
+                {
+                  "name": "lerna.json",
+                  "css": "",
+                  "onclickExec": "pexec",
+                  "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/lerna.json",
+                  "onclickSilence": true,
+                  "attributes": [
+                    {
+                      "value": "-rw-r--r--",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "146B",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                },
+                {
+                  "name": "LICENSE",
+                  "css": "",
+                  "onclickExec": "pexec",
+                  "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/LICENSE",
+                  "onclickSilence": true,
+                  "attributes": [
+                    {
+                      "value": "-rw-r--r--",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "11.1K",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                },
+                {
+                  "name": "node_modules/",
+                  "css": "dir-listing-is-directory",
+                  "onclickExec": "pexec",
+                  "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/node_modules",
+                  "onclickSilence": false,
+                  "attributes": [
+                    {
+                      "value": "drwxr-xr-x",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "33.9K",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:56",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                },
+                {
+                  "name": "package-lock.json",
+                  "css": "",
+                  "onclickExec": "pexec",
+                  "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/package-lock.json",
+                  "onclickSilence": true,
+                  "attributes": [
+                    {
+                      "value": "-rw-r--r--",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "584.3K",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                },
+                {
+                  "name": "package.json",
+                  "css": "",
+                  "onclickExec": "pexec",
+                  "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/package.json",
+                  "onclickSilence": true,
+                  "attributes": [
+                    {
+                      "value": "-rw-r--r--",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "7.8K",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                },
+                {
+                  "name": "packages/",
+                  "css": "dir-listing-is-directory",
+                  "onclickExec": "pexec",
+                  "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/packages",
+                  "onclickSilence": false,
+                  "attributes": [
+                    {
+                      "value": "drwxr-xr-x",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "256B",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                },
+                {
+                  "name": "plugins/",
+                  "css": "dir-listing-is-directory",
+                  "onclickExec": "pexec",
+                  "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/plugins",
+                  "onclickSilence": false,
+                  "attributes": [
+                    {
+                      "value": "drwxr-xr-x",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "704B",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                },
+                {
+                  "name": "README.md",
+                  "css": "",
+                  "onclickExec": "pexec",
+                  "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/README.md",
+                  "onclickSilence": true,
+                  "attributes": [
+                    {
+                      "value": "-rw-r--r--",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "3.1K",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                },
+                {
+                  "name": "tools/",
+                  "css": "dir-listing-is-directory",
+                  "onclickExec": "pexec",
+                  "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/tools",
+                  "onclickSilence": false,
+                  "attributes": [
+                    {
+                      "value": "drwxr-xr-x",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "192B",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                },
+                {
+                  "name": "tsconfig.json",
+                  "css": "",
+                  "onclickExec": "pexec",
+                  "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/tsconfig.json",
+                  "onclickSilence": true,
+                  "attributes": [
+                    {
+                      "value": "-rw-r--r--",
+                      "outerCSS": "hide-with-sidecar",
+                      "key": "Permissions-0"
+                    },
+                    {
+                      "value": "mengting.yan1ibm.com",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "User-1"
+                    },
+                    {
+                      "value": "20",
+                      "outerCSS": "hide-with-sidecar",
+                      "css": "slightly-deemphasize",
+                      "key": "Group-2"
+                    },
+                    {
+                      "value": "1.2K",
+                      "outerCSS": "hide-with-sidecar text-right",
+                      "key": "Size-3"
+                    },
+                    {
+                      "value": "Sep 29 18:50",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                      "key": "Last Modified-4"
+                    }
+                  ],
+                  "key": "Name"
+                }
+              ],
+              "markdown": true,
+              "noSort": true,
+              "noEntityColors": true
+            },
+            "historyIdx": 250,
+            "cwd": "~/Workspace7/kui",
+            "command": "ls -l",
+            "startEvent": {
+              "route": "/ls",
+              "command": "ls -l",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "ls",
+                  "title": "local file list",
+                  "header": "Directory listing of your local filesystem",
+                  "noHelpAlias": true,
+                  "optional": [
+                    {
+                      "name": "path",
+                      "docs": "local file path",
+                      "file": true,
+                      "positional": true
+                    },
+                    {
+                      "name": "-A",
+                      "boolean": true,
+                      "docs": "List all entries except for . and .."
+                    },
+                    {
+                      "name": "-a",
+                      "boolean": true,
+                      "docs": "Include directory entries whose names begin with a dot (.)"
+                    },
+                    {
+                      "name": "-d",
+                      "boolean": true,
+                      "docs": "Directories are listed as plain files"
+                    },
+                    {
+                      "name": "-c",
+                      "boolean": true,
+                      "docs": "Use time when file status was last changed for sorting"
+                    },
+                    {
+                      "name": "-C",
+                      "boolean": true,
+                      "hidden": true
+                    },
+                    {
+                      "name": "-l",
+                      "boolean": true,
+                      "hidden": true
+                    },
+                    {
+                      "name": "-h",
+                      "boolean": true,
+                      "hidden": true
+                    },
+                    {
+                      "name": "-t",
+                      "boolean": true,
+                      "docs": "Sort by time modified (most recently modified first)"
+                    },
+                    {
+                      "name": "-r",
+                      "boolean": true,
+                      "docs": "Reverse the natural sort order"
+                    },
+                    {
+                      "name": "-s",
+                      "boolean": true,
+                      "hidden": true
+                    },
+                    {
+                      "name": "-S",
+                      "boolean": true,
+                      "docs": "Sort files by size"
+                    }
+                  ]
+                },
+                "flags": {
+                  "boolean": ["A", "a", "d", "c", "C", "l", "h", "t", "r", "s", "S"]
+                },
+                "plugin": "plugin-bash-like/fs"
+              },
+              "execType": 0,
+              "execUUID": "3cf815e4-b155-452b-8cdd-c9e45c53a5da"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "ls -l",
+              "argvNoOptions": ["ls"],
+              "parsedOptions": {
+                "_": ["ls"],
+                "l": true
+              },
+              "execUUID": "3cf815e4-b155-452b-8cdd-c9e45c53a5da",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "plugin": "plugin-bash-like/fs"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "3cf815e4-b155-452b-8cdd-c9e45c53a5da",
+                "history": 250,
+                "env": {}
+              },
+              "response": {
+                "header": {
+                  "name": "Name",
+                  "attributes": [
+                    {
+                      "value": "Permissions",
+                      "outerCSS": "hide-with-sidecar"
+                    },
+                    {
+                      "value": "User",
+                      "outerCSS": "hide-with-sidecar"
+                    },
+                    {
+                      "value": "Group",
+                      "outerCSS": "hide-with-sidecar"
+                    },
+                    {
+                      "value": "Size",
+                      "outerCSS": "hide-with-sidecar text-right"
+                    },
+                    {
+                      "value": "Last Modified",
+                      "outerCSS": "hide-with-narrow-window",
+                      "css": "elide-with-narrow-window"
+                    }
+                  ]
+                },
+                "body": [
+                  {
+                    "name": "bin/",
+                    "css": "dir-listing-is-directory",
+                    "onclickExec": "pexec",
+                    "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/bin",
+                    "onclickSilence": false,
+                    "attributes": [
                       {
-                        "name": "bin/",
-                        "css": "dir-listing-is-directory",
-                        "onclickExec": "pexec",
-                        "onclick": "ls /Users/nickm/git/whisk/nickm/kui/bin",
-                        "attributes": [
-                          { "value": "drwxr-xr-x", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "224B", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Apr 15 18:13",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
+                        "value": "drwxr-xr-x",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
                       },
                       {
-                        "name": "build/",
-                        "css": "dir-listing-is-directory",
-                        "onclickExec": "pexec",
-                        "onclick": "ls /Users/nickm/git/whisk/nickm/kui/build",
-                        "attributes": [
-                          { "value": "drwxr-xr-x", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "64B", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Apr  6 16:50",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
                       },
                       {
-                        "name": "CHANGELOG.md",
-                        "css": "",
-                        "onclickExec": "pexec",
-                        "onclick": "open /Users/nickm/git/whisk/nickm/kui/CHANGELOG.md",
-                        "attributes": [
-                          { "value": "-rw-r--r--", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "1.6M", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Aug 20 18:29",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
                       },
                       {
-                        "name": "CONTRIBUTING.md",
-                        "css": "",
-                        "onclickExec": "pexec",
-                        "onclick": "open /Users/nickm/git/whisk/nickm/kui/CONTRIBUTING.md",
-                        "attributes": [
-                          { "value": "-rw-r--r--", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "4.5K", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Feb 25 23:03",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
+                        "value": "192B",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
                       },
                       {
-                        "name": "design/",
-                        "css": "dir-listing-is-directory",
-                        "onclickExec": "pexec",
-                        "onclick": "ls /Users/nickm/git/whisk/nickm/kui/design",
-                        "attributes": [
-                          { "value": "drwxr-xr-x", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "128B", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Aug 19 15:23",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "dist/",
-                        "css": "dir-listing-is-directory",
-                        "onclickExec": "pexec",
-                        "onclick": "ls /Users/nickm/git/whisk/nickm/kui/dist",
-                        "attributes": [
-                          { "value": "drwxr-xr-x", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "160B", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Jun 25 18:14",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "Dockerfile~",
-                        "css": "",
-                        "onclickExec": "pexec",
-                        "onclick": "open /Users/nickm/git/whisk/nickm/kui/Dockerfile~",
-                        "attributes": [
-                          { "value": "-rw-r--r--", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "419B", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Apr  6 16:32",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "docs/",
-                        "css": "dir-listing-is-directory",
-                        "onclickExec": "pexec",
-                        "onclick": "ls /Users/nickm/git/whisk/nickm/kui/docs",
-                        "attributes": [
-                          { "value": "drwxr-xr-x", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "256B", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "May 14 11:33",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "lerna.json",
-                        "css": "",
-                        "onclickExec": "pexec",
-                        "onclick": "open /Users/nickm/git/whisk/nickm/kui/lerna.json",
-                        "attributes": [
-                          { "value": "-rw-r--r--", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "146B", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Aug 20 18:29",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "LICENSE",
-                        "css": "",
-                        "onclickExec": "pexec",
-                        "onclick": "open /Users/nickm/git/whisk/nickm/kui/LICENSE",
-                        "attributes": [
-                          { "value": "-rw-r--r--", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "11.1K", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Feb 25 23:03",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "node_modules/",
-                        "css": "dir-listing-is-directory",
-                        "onclickExec": "pexec",
-                        "onclick": "ls /Users/nickm/git/whisk/nickm/kui/node_modules",
-                        "attributes": [
-                          { "value": "drwxr-xr-x", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "33.8K", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Aug 21 23:41",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "package-lock.json",
-                        "css": "",
-                        "onclickExec": "pexec",
-                        "onclick": "open /Users/nickm/git/whisk/nickm/kui/package-lock.json",
-                        "attributes": [
-                          { "value": "-rw-r--r--", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "579.3K", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Aug 21 23:23",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "package.json",
-                        "css": "",
-                        "onclickExec": "pexec",
-                        "onclick": "open /Users/nickm/git/whisk/nickm/kui/package.json",
-                        "attributes": [
-                          { "value": "-rw-r--r--", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "7.7K", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Aug 20  0:17",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "packages/",
-                        "css": "dir-listing-is-directory",
-                        "onclickExec": "pexec",
-                        "onclick": "ls /Users/nickm/git/whisk/nickm/kui/packages",
-                        "attributes": [
-                          { "value": "drwxr-xr-x", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "256B", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Mar 21 22:06",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "plugins/",
-                        "css": "dir-listing-is-directory",
-                        "onclickExec": "pexec",
-                        "onclick": "ls /Users/nickm/git/whisk/nickm/kui/plugins",
-                        "attributes": [
-                          { "value": "drwxr-xr-x", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "704B", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Aug 19 21:51",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "README.md",
-                        "css": "",
-                        "onclickExec": "pexec",
-                        "onclick": "open /Users/nickm/git/whisk/nickm/kui/README.md",
-                        "attributes": [
-                          { "value": "-rw-r--r--", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "3.1K", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Jun 21 17:31",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "tools/",
-                        "css": "dir-listing-is-directory",
-                        "onclickExec": "pexec",
-                        "onclick": "ls /Users/nickm/git/whisk/nickm/kui/tools",
-                        "attributes": [
-                          { "value": "drwxr-xr-x", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "224B", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Apr 20 15:54",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
-                      },
-                      {
-                        "name": "tsconfig.json",
-                        "css": "",
-                        "onclickExec": "pexec",
-                        "onclick": "open /Users/nickm/git/whisk/nickm/kui/tsconfig.json",
-                        "attributes": [
-                          { "value": "-rw-r--r--", "outerCSS": "hide-with-sidecar", "key": "Permissions-0" },
-                          {
-                            "value": "nickm",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "User-1"
-                          },
-                          {
-                            "value": "20",
-                            "outerCSS": "hide-with-sidecar",
-                            "css": "slightly-deemphasize",
-                            "key": "Group-2"
-                          },
-                          { "value": "1.1K", "outerCSS": "hide-with-sidecar text-right", "key": "Size-3" },
-                          {
-                            "value": "Aug 19 21:51",
-                            "outerCSS": "hide-with-narrow-window",
-                            "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
-                            "key": "Last Modified-4"
-                          }
-                        ],
-                        "key": "Name"
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
                       }
                     ],
-                    "noSort": true,
-                    "noEntityColors": true,
-                    "style": 0
+                    "key": "Name"
                   },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 250
-                }
-              }
-            ]
+                  {
+                    "name": "CHANGELOG.md",
+                    "css": "",
+                    "onclickExec": "pexec",
+                    "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/CHANGELOG.md",
+                    "onclickSilence": true,
+                    "attributes": [
+                      {
+                        "value": "-rw-r--r--",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "1.6M",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "CONTRIBUTING.md",
+                    "css": "",
+                    "onclickExec": "pexec",
+                    "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/CONTRIBUTING.md",
+                    "onclickSilence": true,
+                    "attributes": [
+                      {
+                        "value": "-rw-r--r--",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "4.5K",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "design/",
+                    "css": "dir-listing-is-directory",
+                    "onclickExec": "pexec",
+                    "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/design",
+                    "onclickSilence": false,
+                    "attributes": [
+                      {
+                        "value": "drwxr-xr-x",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "128B",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "docs/",
+                    "css": "dir-listing-is-directory",
+                    "onclickExec": "pexec",
+                    "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/docs",
+                    "onclickSilence": false,
+                    "attributes": [
+                      {
+                        "value": "drwxr-xr-x",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "192B",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "lerna.json",
+                    "css": "",
+                    "onclickExec": "pexec",
+                    "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/lerna.json",
+                    "onclickSilence": true,
+                    "attributes": [
+                      {
+                        "value": "-rw-r--r--",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "146B",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "LICENSE",
+                    "css": "",
+                    "onclickExec": "pexec",
+                    "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/LICENSE",
+                    "onclickSilence": true,
+                    "attributes": [
+                      {
+                        "value": "-rw-r--r--",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "11.1K",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "node_modules/",
+                    "css": "dir-listing-is-directory",
+                    "onclickExec": "pexec",
+                    "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/node_modules",
+                    "onclickSilence": false,
+                    "attributes": [
+                      {
+                        "value": "drwxr-xr-x",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "33.9K",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:56",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "package-lock.json",
+                    "css": "",
+                    "onclickExec": "pexec",
+                    "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/package-lock.json",
+                    "onclickSilence": true,
+                    "attributes": [
+                      {
+                        "value": "-rw-r--r--",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "584.3K",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "package.json",
+                    "css": "",
+                    "onclickExec": "pexec",
+                    "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/package.json",
+                    "onclickSilence": true,
+                    "attributes": [
+                      {
+                        "value": "-rw-r--r--",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "7.8K",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "packages/",
+                    "css": "dir-listing-is-directory",
+                    "onclickExec": "pexec",
+                    "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/packages",
+                    "onclickSilence": false,
+                    "attributes": [
+                      {
+                        "value": "drwxr-xr-x",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "256B",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "plugins/",
+                    "css": "dir-listing-is-directory",
+                    "onclickExec": "pexec",
+                    "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/plugins",
+                    "onclickSilence": false,
+                    "attributes": [
+                      {
+                        "value": "drwxr-xr-x",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "704B",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "README.md",
+                    "css": "",
+                    "onclickExec": "pexec",
+                    "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/README.md",
+                    "onclickSilence": true,
+                    "attributes": [
+                      {
+                        "value": "-rw-r--r--",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "3.1K",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "tools/",
+                    "css": "dir-listing-is-directory",
+                    "onclickExec": "pexec",
+                    "onclick": "ls -l /Users/mengting.yan1ibm.com/Workspace7/kui/tools",
+                    "onclickSilence": false,
+                    "attributes": [
+                      {
+                        "value": "drwxr-xr-x",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "192B",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  },
+                  {
+                    "name": "tsconfig.json",
+                    "css": "",
+                    "onclickExec": "pexec",
+                    "onclick": "open /Users/mengting.yan1ibm.com/Workspace7/kui/tsconfig.json",
+                    "onclickSilence": true,
+                    "attributes": [
+                      {
+                        "value": "-rw-r--r--",
+                        "outerCSS": "hide-with-sidecar",
+                        "key": "Permissions-0"
+                      },
+                      {
+                        "value": "mengting.yan1ibm.com",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "User-1"
+                      },
+                      {
+                        "value": "20",
+                        "outerCSS": "hide-with-sidecar",
+                        "css": "slightly-deemphasize",
+                        "key": "Group-2"
+                      },
+                      {
+                        "value": "1.2K",
+                        "outerCSS": "hide-with-sidecar text-right",
+                        "key": "Size-3"
+                      },
+                      {
+                        "value": "Sep 29 18:50",
+                        "outerCSS": "hide-with-narrow-window",
+                        "css": "elide-with-narrow-window slightly-deemphasize pre-wrap",
+                        "key": "Last Modified-4"
+                      }
+                    ],
+                    "key": "Name"
+                  }
+                ],
+                "markdown": true,
+                "noSort": true,
+                "noEntityColors": true
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 250
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "3cf815e4-b155-452b-8cdd-c9e45c53a5da",
+            "startTime": "2020-09-30T18:57:27.998Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": false,
+            "state": "valid-response"
           }
         ]
       }

--- a/plugins/plugin-core-support/src/lib/cmds/replay.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/replay.ts
@@ -14,59 +14,20 @@
  * limitations under the License.
  */
 
-import { v4 as uuid } from 'uuid'
-import { basename, dirname, extname, join } from 'path'
-
 import {
   eventBus,
   expandHomeDir,
-  isTable,
   inElectron,
   Arguments,
-  CodedError,
   CommandStartEvent,
-  CommandCompleteEvent,
-  TabLayoutModificationResponse,
-  NewSplitRequest,
   KResponse,
   ParsedOptions,
   Registrar,
-  Snapshot,
-  SnapshotBlock,
-  SnapshottedEvent,
   StatusStripeChangeEvent,
-  Tab,
-  getPrimaryTabId,
-  isOfflineClient,
-  promiseEach
+  Notebook,
+  isNotebook,
+  getPrimaryTabId
 } from '@kui-shell/core'
-
-/** Schema for a record of onclick (startEvent, completeEvent) pairs */
-interface ClickSnapshot {
-  startEvents: Record<string, SnapshottedEvent<CommandStartEvent>[]>
-  completeEvents: Record<string, SnapshottedEvent<CommandCompleteEvent>[]>
-}
-
-/**
- * Schema for a serialized snapshot of the Inputs and Outputs of
- * command executions.
- */
-export interface SerializedSnapshot {
-  apiVersion: 'kui-shell/v1'
-  kind: 'Snapshot'
-  spec: Snapshot & {
-    clicks: ClickSnapshot
-    preferReExecute?: boolean
-    title?: string
-    description?: string
-  }
-}
-
-/** @return wether or not the given `raw` json is an instance of SerializedSnapshot */
-function isSerializedSnapshot(raw: Record<string, any>): raw is SerializedSnapshot {
-  const model = raw as SerializedSnapshot
-  return model.apiVersion === 'kui-shell/v1' && model.kind === 'Snapshot' && Array.isArray(model.spec.windows)
-}
 
 /** For the Kui command registration: enforce one mandatory positional parameter */
 const required = [{ name: '<filepath>', docs: 'path to saved snapshot' }]
@@ -79,12 +40,11 @@ const replayUsage = {
     optional: [
       { name: '--freshen', alias: '-f', boolean: true, docs: 'Regenerate snapshot' },
       { name: '--new-window', alias: '-w', boolean: true, docs: 'Replay in a new window (Electron only)' },
-      { name: '--new-tab', alias: '-t', boolean: true, docs: 'Replay in a tab' },
       { name: '--status-stripe', docs: 'Modify status stripe', allowed: ['default', 'blue', 'yellow', 'red'] }
     ]
   },
   flags: {
-    boolean: ['new-window', 'w', 'new-tab', 't', 'freshen', 'f']
+    boolean: ['new-window', 'w', 'freshen', 'f']
   }
 }
 
@@ -105,14 +65,7 @@ const snapshotUsage = {
   }
 }
 
-let nSnapshotable = 0
-export function preload() {
-  eventBus.onAddSnapshotable(() => nSnapshotable++)
-  eventBus.onRemoveSnapshotable(() => nSnapshotable--)
-}
-
 interface ReplayOptions extends ParsedOptions {
-  'new-tab': boolean
   'new-window': boolean
   'status-stripe': StatusStripeChangeEvent['type']
 }
@@ -129,189 +82,12 @@ interface SnapshotOptions extends ParsedOptions {
 }
 
 /** Format a Markdown string that describes the given snapshot */
-function formatMessage(snapshot: SerializedSnapshot) {
-  return `**Now Playing**: ${snapshot.spec.title || 'a snapshot'}`
-}
-
-/** Update the given tab to reflect a new uuid */
-function withNewTabUUID(tab: Tab, uuid: string) {
-  return { tab: Object.assign({}, tab, { uuid }) }
-}
-
-/** Re-emit prior start event in new tab */
-function reEmitStartInTab(tab: Tab, uuid: string, startEvent: SnapshotBlock['startEvent'], emitAsReplay = true) {
-  const evt = Object.assign({}, startEvent, withNewTabUUID(tab, uuid))
-  eventBus.emitCommandStart(evt, emitAsReplay)
-}
-
-/** Re-emit prior complete event in new tab */
-function reEmitCompleteInTab(
-  tab: Tab,
-  uuid: string,
-  completeEvent: SnapshotBlock['completeEvent'],
-  emitAsReplay = true
-) {
-  const evt = Object.assign({}, completeEvent, withNewTabUUID(tab, uuid))
-  eventBus.emitCommandComplete(evt, emitAsReplay)
-}
-
-/** Re-execute command line in new tab */
-function reExecuteInTab(tab: Tab, uuid: string, cmdline: string) {
-  return tab.REPL.pexec(cmdline, withNewTabUUID(tab, uuid))
-}
-
-/**
- * The command name we use to replay the click in a given block
- * (`execUUID`) and table row (`rowIdx`).
- *
- */
-function replayClickFor(execUUID: string, rowIdx: number) {
-  return `replay-click-${execUUID}-${rowIdx}`
-}
-
-/**
- * Record clicks
- *
- */
-type Click = {
-  completeEvent: SnapshotBlock['completeEvent']
-  onClicks: { rowIdx: number; onClick: string; echo: boolean }[]
-}
-class FlightRecorder {
-  // eslint-disable-next-line no-useless-constructor
-  public constructor(private readonly tab: Tab, private readonly blocks: SnapshotBlock[]) {}
-
-  /** Find onclick handlers that we should crawl */
-  private collectOnClicks(): Click[] {
-    return this.blocks
-      .map(_ =>
-        _.completeEvent && isTable(_.completeEvent.response)
-          ? {
-              completeEvent: _.completeEvent,
-              onClicks: _.completeEvent.response.body
-                .map((row, rowIdx) =>
-                  row.onclickIdempotent && typeof row.onclick === 'string'
-                    ? { rowIdx, onClick: row.onclick, echo: !row.onclickSilence }
-                    : undefined
-                )
-                .filter(_ => _)
-            }
-          : undefined
-      )
-      .filter(_ => _)
-  }
-
-  /**
-   * Transform a E=Command*Event into the matching
-   * SnapshottedEvent<E>, by splicing in the tab uuid in place of the
-   * tab object. This allows us to replay in a repeatible way, since
-   * tab uuids are a v5 sequence. See ScrollableTerminal for the
-   * origin of the v5 sequence.
-   *
-   * Note: That we have to place this an a separate function is due to
-   * typescript
-   * limitations. https://github.com/microsoft/TypeScript/issues/35858
-   *
-   */
-  private static xform<E extends CommandStartEvent | CommandCompleteEvent>(
-    this: Pick<Click, 'completeEvent'>,
-    evt: E
-  ): SnapshottedEvent<E> {
-    return Object.assign(Object.assign({}, evt, { tab: undefined }), { tab: this.completeEvent.tab })
-  }
-
-  /**
-   * Accept a Command*Event pass it through `xform` (just above) and
-   * store the resulting SnapshottedEvent in the given `this`
-   * record. We should have an array of these, one per click handler
-   * in a table; this is where the T[] comes from: that array is
-   * parallel to the rows of the table being crawled.
-   *
-   */
-  private static handler<E extends CommandStartEvent | CommandCompleteEvent, T extends SnapshottedEvent<E>>(
-    this: Record<string, T[]>,
-    click: Pick<Click, 'completeEvent'>,
-    rowIdx: number,
-    xform: (evt: E) => T,
-    event: E
-  ) {
-    const events = this[click.completeEvent.execUUID] || []
-    if (events.length === 0) {
-      this[click.completeEvent.execUUID] = events
-    }
-
-    if (isTable(click.completeEvent.response)) {
-      const row = click.completeEvent.response.body[rowIdx]
-      row.onclick = replayClickFor(click.completeEvent.execUUID, rowIdx)
-      row.onclickExec = 'qexec'
-    }
-
-    events[rowIdx] = xform(event)
-  }
-
-  /**
-   * Run through the rows of a Table response, issue the onclick
-   * handler, and store the (start,complete) event pairs, indexed by
-   * row of the table; that's a ClickSnapshot.
-   *
-   */
-  public async record(): Promise<ClickSnapshot> {
-    const fakeTab = Object.assign({}, this.tab, { uuid: uuid() })
-    const startEvents: Record<string, SnapshottedEvent<CommandStartEvent>[]> = {}
-    const completeEvents: Record<string, SnapshottedEvent<CommandCompleteEvent>[]> = {}
-
-    const onclicks = this.collectOnClicks()
-
-    await Promise.all(
-      onclicks.map(async click => {
-        await Promise.all(
-          click.onClicks.map(async _ => {
-            const xform = FlightRecorder.xform.bind(click)
-            const onCommandStart = FlightRecorder.handler.bind(startEvents, click, _.rowIdx, xform)
-            const onCommandComplete = FlightRecorder.handler.bind(completeEvents, click, _.rowIdx, xform)
-            eventBus.onCommandStart(fakeTab.uuid, onCommandStart)
-            eventBus.onCommandComplete(fakeTab.uuid, onCommandComplete)
-
-            try {
-              await fakeTab.REPL.pexec(_.onClick, { tab: fakeTab, echo: _.echo })
-            } finally {
-              eventBus.offCommandStart(fakeTab.uuid, onCommandStart)
-              eventBus.offCommandComplete(fakeTab.uuid, onCommandComplete)
-            }
-          })
-        )
-      })
-    )
-
-    return { startEvents, completeEvents }
-  }
-}
-
-/** @return name of backup file or void if backup not needed */
-function backup(REPL: Arguments['REPL'], filepath: string): Promise<string | void> {
-  const ext = extname(filepath)
-  const bak = join(dirname(filepath), basename(filepath, ext) + '.bak' + ext)
-  return REPL.rexec(`cp ${REPL.encodeComponent(filepath)} ${REPL.encodeComponent(bak)}`, { quiet: undefined })
-    .then(() => bak)
-    .catch((err: CodedError<string>) => {
-      if (err.code !== 'ENOENT') {
-        throw err
-      } else {
-      }
-    })
-}
-
-/** Regenerate snapshot */
-async function freshen(REPL: Arguments['REPL'], filepath: string) {
-  const bak = await backup(REPL, filepath)
-  await REPL.qexec(
-    `tab new --cmdline "kui-freshen ${filepath} --in-new-tab" --title "Freshening ${basename(filepath)}"`
-  )
-  return `Notebook has been freshened${bak ? `. Backup placed in ${bak}.` : ''}`
+function formatMessage(snapshot: Notebook) {
+  return `**Now Playing**: ${snapshot.metadata.name || 'a snapshot'}`
 }
 
 /** Load snapshot model from disk */
-async function loadSnapshot(REPL: Arguments['REPL'], filepath: string): Promise<SerializedSnapshot> {
+async function loadNotebook(REPL: Arguments['REPL'], filepath: string): Promise<Notebook> {
   return JSON.parse(
     (await REPL.rexec<{ data: string }>(`vfs fstat ${REPL.encodeComponent(filepath)} --with-data`)).content.data
   )
@@ -322,127 +98,30 @@ export default function(registrar: Registrar) {
   // register the `replay` command
   registrar.listen<KResponse, ReplayOptions>(
     '/replay',
-    async ({ argvNoOptions, parsedOptions, REPL, tab }) => {
+    async ({ argvNoOptions, parsedOptions, REPL }) => {
       const filepath = expandHomeDir(argvNoOptions[1])
+      const model = await loadNotebook(REPL, filepath)
 
-      if (parsedOptions.freshen) {
-        return freshen(REPL, filepath)
-      }
-
-      const model = await loadSnapshot(REPL, filepath)
-      if (!isSerializedSnapshot(model)) {
-        console.error('invalid snapshot', model)
-        throw new Error('Invalid snapshot')
+      if (!isNotebook(model)) {
+        console.error('invalid notebook', model)
+        throw new Error('Invalid notebook')
       } else {
         const message = formatMessage(model)
-        const titleOption = model.spec.title ? `--title "${model.spec.title}"` : ''
+        const titleOption = model.metadata.name ? `--title "${model.metadata.name}"` : ''
 
         if (parsedOptions['new-window'] && inElectron()) {
           // the electron bits are sequestered in plugin-electron, to
           // avoid pulling in electron for purely browser-based clients
-          return REPL.qexec(`replay-electron ${filepath} ${titleOption}`)
-        } else if (parsedOptions['new-tab']) {
+          return REPL.qexec(`replay-electron ${filepath}`)
+        } else {
           return REPL.qexec(
-            `tab new --cmdline "replay ${filepath}" --quiet --status-stripe-type ${parsedOptions['status-stripe'] ||
+            `tab new --snapshot "${filepath}" --quiet --status-stripe-type ${parsedOptions['status-stripe'] ||
               'blue'} ${titleOption}`,
             undefined,
             undefined,
             { data: { 'status-stripe-message': message } }
           )
-        } else if (parsedOptions['status-stripe']) {
-          tab.state.desiredStatusStripeDecoration = {
-            type: parsedOptions['status-stripe'],
-            message
-          }
         }
-
-        // we need to map the split uuids in the snapshot to those in
-        // the current tab
-        const splitAlignment: Record<string, string> = {}
-
-        if (model.spec.clicks) {
-          Object.keys(model.spec.clicks.startEvents).forEach(execUUID => {
-            const startEvents = model.spec.clicks.startEvents[execUUID]
-            const completeEvents = model.spec.clicks.completeEvents[execUUID]
-            if (startEvents && completeEvents && startEvents.length === completeEvents.length) {
-              startEvents.forEach((startEvent, rowIdx) => {
-                const completeEvent = completeEvents[rowIdx]
-                if (startEvent && completeEvent) {
-                  const channel = `/${replayClickFor(execUUID, rowIdx)}`
-                  registrar.listen(channel, async () => {
-                    const uuid = splitAlignment[startEvent.tab]
-                    reEmitStartInTab(tab, uuid, startEvent, false)
-                    reEmitCompleteInTab(tab, uuid, completeEvent, false)
-                    return true
-                  })
-                }
-              })
-            }
-          })
-        }
-
-        // is the client running in offline/disconnected mode?
-        const offline = isOfflineClient()
-
-        await promiseEach(model.spec.windows[0].tabs[0].blocks, async ({ startEvent, completeEvent }) => {
-          // if (!splitAlignment[startEvent.tab]) {
-          // splitAlignment[startEvent.tab] = splits[splits.length - 1]
-          // }
-
-          if (!splitAlignment[startEvent.tab]) {
-            const ourUUID = tab.uuid
-            const theirUUID = startEvent.tab
-            splitAlignment[theirUUID] = ourUUID
-          }
-
-          // in order to maintain tab-index-invariance, we need to
-          // remember the mapping from the new split's ID at the time
-          // of replay (`tabUUIDOfNewSplitBefore`); then, after
-          // re-issuing the complete event, just below, we will tie
-          // this together with the split ID in this current world
-          const tabUUIDOfNewSplitBefore =
-            startEvent.route === '/split'
-              ? (completeEvent.response as TabLayoutModificationResponse<NewSplitRequest>).spec.ok.props.tabUUID
-              : undefined
-
-          const uuid = splitAlignment[startEvent.tab]
-          try {
-            //
-            // Notes: we need to find a more general way to
-            // distinguish between the events we want to reExecute
-            // versus those we want to reEmit (i.e. just show the
-            // input and output of the execution at the time the
-            // notebook was saved).
-            //
-            // For now, we hard-code this to always reExecute
-            // RadioTable responses, under the premise that these
-            // responses are almost certainly going to be site- and
-            // user-specific. This is not to say we shouldn't figure
-            // out a better solution!
-            //
-            if (!offline && model.spec.preferReExecute) {
-              await reExecuteInTab(tab, uuid, startEvent.command)
-            } else {
-              reEmitStartInTab(tab, uuid, startEvent)
-              reEmitCompleteInTab(tab, uuid, completeEvent)
-            }
-          } catch (err) {
-            console.error(err)
-          }
-
-          // here is where we update the tabUUID mapping for that new
-          // split; after re-issuing the complete event, we should
-          // have the split's tabUUID in this new world
-          if (tabUUIDOfNewSplitBefore !== undefined) {
-            const theirUUID = tabUUIDOfNewSplitBefore
-            const ourUUID = (completeEvent.response as TabLayoutModificationResponse<NewSplitRequest>).spec.ok.props
-              .tabUUID
-            splitAlignment[theirUUID] = ourUUID
-          }
-        })
-
-        setTimeout(() => tab.scrollToTop())
-        return true
       }
     },
     replayUsage
@@ -453,144 +132,39 @@ export default function(registrar: Registrar) {
     '/snapshot',
     ({ argvNoOptions, parsedOptions, REPL, tab }) =>
       new Promise((resolve, reject) => {
-        let nSplits = 0
-        let blocks: SnapshotBlock[] = []
-
         // debounce block callbacks
         const seenExecUUIDs: Record<string, boolean> = {}
 
         const ourMainTab = getPrimaryTabId(tab)
-        eventBus.emitSnapshotRequest({
-          filter: (evt: CommandStartEvent) => {
-            if (
-              !/^kui-freshen/.test(evt.command) &&
-              getPrimaryTabId(evt.tab) === ourMainTab &&
-              !seenExecUUIDs[evt.execUUID]
-            ) {
-              seenExecUUIDs[evt.execUUID] = true
-              return true
-            }
-          },
-          cb: async (blocksInSplit: SnapshotBlock[]) => {
-            blocks = blocks.concat(blocksInSplit)
-            nSplits++
-
-            if (nSplits === nSnapshotable) {
-              // if needed, we could optimize this by recording per
-              // blocksInSplit, as they arrive
-              const clicks = parsedOptions.shallow ? undefined : await new FlightRecorder(tab, blocks).record()
-
+        eventBus.emitSnapshotRequest(
+          {
+            filter: (evt: CommandStartEvent) => {
+              if (!seenExecUUIDs[evt.execUUID]) {
+                seenExecUUIDs[evt.execUUID] = true
+                return true
+              }
+            },
+            cb: async (snapshot: Buffer) => {
               try {
                 const filepath = expandHomeDir(argvNoOptions[argvNoOptions.indexOf('snapshot') + 1])
-                const snapshot: SerializedSnapshot = {
-                  apiVersion: 'kui-shell/v1',
-                  kind: 'Snapshot',
-                  spec: {
-                    title: parsedOptions.t || parsedOptions.title,
-                    description: parsedOptions.d || parsedOptions.description,
-                    preferReExecute: parsedOptions.exec || parsedOptions.x,
-                    clicks,
-                    windows: [
-                      {
-                        uuid: '0',
-                        tabs: [
-                          {
-                            uuid: '0',
-                            blocks
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                }
-
-                /**
-                 * We have excluded block and replaced tab with uuid in the top level
-                 * completeEvent and startEvent of a snapshot,
-                 * but there are still some underlying properties have tab and block,
-                 * so we filter out HTML tab and block in the replacer,
-                 * see issue: https://github.com/IBM/kui/issues/5458
-                 *
-                 */
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const replacer = (key: string, value: any) => {
-                  if (key === 'tab' && typeof value === typeof tab) {
-                    return undefined
-                  } else if (key === 'block') {
-                    return undefined
-                  } else {
-                    return value
-                  }
-                }
-
-                const data = JSON.stringify(snapshot, replacer)
-                await REPL.rexec<{ data: string }>(`fwrite ${REPL.encodeComponent(filepath)}`, { data })
-
+                await REPL.rexec<{ data: string }>(`fwrite ${REPL.encodeComponent(filepath)}`, {
+                  data: Buffer.from(snapshot).toString()
+                })
                 resolve(true)
               } catch (err) {
                 reject(err)
               }
+            },
+            opts: {
+              name: parsedOptions.t || parsedOptions.title,
+              description: parsedOptions.d || parsedOptions.description,
+              preferReExecute: parsedOptions.exec || parsedOptions.x,
+              shallow: parsedOptions.shallow
             }
-          }
-        })
+          },
+          ourMainTab
+        )
       }),
     snapshotUsage
-  )
-
-  /** Freshen command handler */
-  registrar.listen<KResponse, { 'in-new-tab': boolean }>(
-    '/kui-freshen',
-    async args => {
-      const filepath = args.argvNoOptions[1]
-      const model = await loadSnapshot(args.REPL, filepath)
-
-      // some older snapshots have duplicates due to an earlier bug
-      const seenExecUUIDs: Record<string, boolean> = {}
-
-      // reexecute the commands
-      const splitAlignment: Record<string, Tab> = {}
-      await promiseEach(model.spec.windows[0].tabs[0].blocks, async ({ startEvent, completeEvent }) => {
-        try {
-          if (!seenExecUUIDs[startEvent.execUUID]) {
-            seenExecUUIDs[startEvent.execUUID] = true
-
-            if (!splitAlignment[startEvent.tab]) {
-              const theirUUID = startEvent.tab
-              splitAlignment[theirUUID] = args.tab
-            }
-
-            const tabUUIDOfNewSplitBefore =
-              startEvent.route === '/split'
-                ? (completeEvent.response as TabLayoutModificationResponse<NewSplitRequest>).spec.ok.props.tabUUID
-                : undefined
-
-            const tab = splitAlignment[startEvent.tab]
-            const response = await args.REPL.pexec(startEvent.command, { tab })
-
-            if (tabUUIDOfNewSplitBefore !== undefined) {
-              const theirUUID = tabUUIDOfNewSplitBefore
-              const ourTab = (response as TabLayoutModificationResponse<NewSplitRequest>).spec.ok.props.tab
-              splitAlignment[theirUUID] = ourTab()
-            }
-          }
-        } catch (err) {
-          console.error(`Error freshening: ${err.message}`, startEvent, err)
-        }
-      })
-
-      // save the snapshot
-      const titleOption = model.spec.title ? ` --title "${model.spec.title}"` : ''
-      const descrOption = model.spec.description ? ` --description "${model.spec.description}"` : ''
-      await args.REPL.qexec(`snapshot ${args.REPL.encodeComponent(filepath)} ${titleOption} ${descrOption}`)
-
-      // close our temporary tab
-      if (args.parsedOptions['in-new-tab']) {
-        // the -A asks to close all splits in the tab
-        await args.REPL.pexec('tab close -A')
-      }
-
-      return true
-    },
-    { flags: { boolean: ['in-new-tab'] } }
   )
 }

--- a/plugins/plugin-core-support/src/preload.ts
+++ b/plugins/plugin-core-support/src/preload.ts
@@ -29,7 +29,6 @@ const registration: PreloadRegistration = () => {
 
   if (!isHeadless()) {
     asyncs.push(import('./lib/cmds/zoom').then(_ => _.preload()))
-    asyncs.push(import('./lib/cmds/replay').then(_ => _.preload()))
   }
 
   asyncs.push(import('./notebooks/vfs').then(_ => _.preload()))

--- a/plugins/plugin-core-support/src/test/core-support/replay.ts
+++ b/plugins/plugin-core-support/src/test/core-support/replay.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { existsSync, unlinkSync, statSync } from 'fs'
 import { Common, CLI, ReplExpect, Selectors, SidecarExpect, testAbout } from '@kui-shell/test'
 
 import { splitViaCommand, focus } from '../core-support2/split-helpers'
@@ -42,14 +41,16 @@ describe(`snapshot and replay ${process.env.MOCHA_RUN_TARGET || ''}`, function(t
 
   it('should replay', async () => {
     try {
-      const { count } = await CLI.command('replay /tmp/test.kui --status-stripe blue', this.app)
+      await CLI.command('replay /tmp/test.kui --status-stripe blue', this.app)
 
       await this.app.client.waitForExist(Selectors.STATUS_STRIPE_TYPE('blue'), CLI.waitTimeout)
+
+      const count = await CLI.command('version', this.app).then(_ => _.count)
 
       // verify the base64 command replay
       let idx = 0
       await this.app.client.waitUntil(async () => {
-        const txt = await this.app.client.getText(Selectors.OUTPUT_N(count + 1))
+        const txt = await this.app.client.getText(Selectors.OUTPUT_N(count - 2))
         if (++idx > 5) {
           console.error(`still waiting for expected=${base64Output}; actual=${txt}`)
         }
@@ -67,43 +68,6 @@ describe(`snapshot and replay ${process.env.MOCHA_RUN_TARGET || ''}`, function(t
     await CLI.command('clear', this.app).then(() => ReplExpect.consoleToBeClear(this.app))
 
     await this.app.client.waitForExist(Selectors.STATUS_STRIPE_TYPE('default'))
-  })
-
-  it('should freshen the snapshot', async () => {
-    try {
-      unlinkSync('/tmp/test.bak.kui')
-    } catch (err) {
-      if (err.code !== 'ENOENT') {
-        throw err
-      }
-    }
-
-    const { mtimeMs } = statSync('/tmp/test.kui')
-
-    // wait a few seconds, so that the mtimeMs will change
-    await new Promise(resolve => setTimeout(resolve, 2000))
-
-    await CLI.command('replay --freshen /tmp/test.kui', this.app)
-
-    console.log('1')
-    // Snapshot backup file had better exist
-    await this.app.client.waitUntil(async () => {
-      console.log('1a')
-      const e1 = existsSync('/tmp/test.kui')
-      console.log('1b', e1)
-      const e2 = existsSync('/tmp/test.bak.kui')
-      console.log('1c', e2)
-      return e1 && e2
-    }, CLI.waitTimeout)
-    console.log('2')
-
-    // Snapshot file had better have been modified
-    await this.app.client.waitUntil(async () => {
-      const { mtimeMs: mtimeMs2 } = statSync('/tmp/test.kui')
-      console.log('3', mtimeMs2 - mtimeMs)
-
-      return mtimeMs2 > mtimeMs
-    }, CLI.waitTimeout)
   })
 })
 

--- a/plugins/plugin-electron-components/src/plugin.ts
+++ b/plugins/plugin-electron-components/src/plugin.ts
@@ -26,8 +26,7 @@ export default function(registrar: Registrar) {
         'synchronous-message',
         JSON.stringify({
           operation: 'new-window',
-          argv: ['replay', filepath, '--status-stripe', 'blue'],
-          title: args.parsedOptions.title
+          argv: ['replay', filepath, '--status-stripe', 'blue']
         })
       )
       return true

--- a/plugins/plugin-iter8/notebooks/welcome.json
+++ b/plugins/plugin-iter8/notebooks/welcome.json
@@ -1,751 +1,841 @@
 {
   "apiVersion": "kui-shell/v1",
-  "kind": "Snapshot",
+  "kind": "Notebook",
+  "metadata": {},
   "spec": {
-    "title": "Welcome to Iter8",
-    "windows": [
+    "splits": [
       {
-        "uuid": "0",
-        "tabs": [
+        "uuid": "1_c57e811f-2da8-557e-a402-9f0950407675",
+        "blocks": [
           {
-            "uuid": "0",
-            "blocks": [
-              {
-                "startTime": 1599574252027,
-                "startEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/#",
-                  "command": "# # Use the iter8 Plugin on Kui",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "5acb90ef-a857-461b-ad05-df4202a952e8"
-                },
-                "completeEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 0,
-                  "command": "## Use the iter8 Plugin on Kui",
-                  "argvNoOptions": ["#", " # Use the iter8 Plugin on Kui"],
-                  "parsedOptions": {
-                    "_": ["#", " # Use the iter8 Plugin on Kui"]
-                  },
-                  "execUUID": "5acb90ef-a857-461b-ad05-df4202a952e8",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "5acb90ef-a857-461b-ad05-df4202a952e8",
-                    "history": 250,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "# Use the iter8 Plugin on Kui"
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 250
-                }
-              },
-              {
-                "startTime": 1599574278756,
-                "startEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/#",
-                  "command": "# ### Iter8 is an open source toolkit for continuous experimentation on Kubernetes. Iter8 enables you to deliver high-impact code changes within your microservices applications in an agile manner while eliminating the risk. Using iter8’s machine learning (ML)-driven experimentation capabilities, you can safely and rapidly orchestrate various types of live experiments, gain key insights into the behavior of your microservices, and rollout the best versions of your microservices in an automated, principled, and statistically robust manner.",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "7d5454dd-9f9a-4330-80c0-4df1affce4af"
-                },
-                "completeEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 0,
-                  "command": "#### Iter8 is an open source toolkit for continuous experimentation on Kubernetes. Iter8 enables you to deliver high-impact code changes within your microservices applications in an agile manner while eliminating the risk. Using iter8’s machine learning (ML)-driven experimentation capabilities, you can safely and rapidly orchestrate various types of live experiments, gain key insights into the behavior of your microservices, and rollout the best versions of your microservices in an automated, principled, and statistically robust manner.",
-                  "argvNoOptions": [
-                    "#",
-                    " ### Iter8 is an open source toolkit for continuous experimentation on Kubernetes. Iter8 enables you to deliver high-impact code changes within your microservices applications in an agile manner while eliminating the risk. Using iter8’s machine learning (ML)-driven experimentation capabilities, you can safely and rapidly orchestrate various types of live experiments, gain key insights into the behavior of your microservices, and rollout the best versions of your microservices in an automated, principled, and statistically robust manner."
-                  ],
-                  "parsedOptions": {
-                    "_": [
-                      "#",
-                      " ### Iter8 is an open source toolkit for continuous experimentation on Kubernetes. Iter8 enables you to deliver high-impact code changes within your microservices applications in an agile manner while eliminating the risk. Using iter8’s machine learning (ML)-driven experimentation capabilities, you can safely and rapidly orchestrate various types of live experiments, gain key insights into the behavior of your microservices, and rollout the best versions of your microservices in an automated, principled, and statistically robust manner."
-                    ]
-                  },
-                  "execUUID": "7d5454dd-9f9a-4330-80c0-4df1affce4af",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "7d5454dd-9f9a-4330-80c0-4df1affce4af",
-                    "history": 251,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "### Iter8 is an open source toolkit for continuous experimentation on Kubernetes. Iter8 enables you to deliver high-impact code changes within your microservices applications in an agile manner while eliminating the risk. Using iter8’s machine learning (ML)-driven experimentation capabilities, you can safely and rapidly orchestrate various types of live experiments, gain key insights into the behavior of your microservices, and rollout the best versions of your microservices in an automated, principled, and statistically robust manner."
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 251
-                }
-              },
-              {
-                "startTime": 1599574347339,
-                "startEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/#",
-                  "command": "# ## Install iter8 using on your Kubernetes cluster",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "35b99fa5-9154-4eba-820c-8d9e9192bc19"
-                },
-                "completeEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 0,
-                  "command": "### Install iter8 using on your Kubernetes cluster",
-                  "argvNoOptions": ["#", " ## Install iter8 using on your Kubernetes cluster"],
-                  "parsedOptions": {
-                    "_": ["#", " ## Install iter8 using on your Kubernetes cluster"]
-                  },
-                  "execUUID": "35b99fa5-9154-4eba-820c-8d9e9192bc19",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "35b99fa5-9154-4eba-820c-8d9e9192bc19",
-                    "history": 252,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "## Install iter8 using on your Kubernetes cluster"
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 252
-                }
-              },
-              {
-                "startTime": 1599574348174,
-                "startEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "*",
-                  "command": "curl -L -s https://raw.githubusercontent.com/iter8-tools/iter8/v1.0.0-rc1/install/install.sh \\",
-                  "evaluatorOptions": {},
-                  "execType": 1,
-                  "execUUID": "8e8a47ba-a230-49c9-9e22-967a08281397",
-                  "echo": true
-                },
-                "completeEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 1,
-                  "command": "curl -L -s https://raw.githubusercontent.com/iter8-tools/iter8/v1.0.0-rc1/install/install.sh \\",
-                  "argvNoOptions": ["curl"],
-                  "parsedOptions": {
-                    "_": ["curl"],
-                    "L": true,
-                    "s": "https://raw.githubusercontent.com/iter8-tools/iter8/v1.0.0-rc1/install/install.sh"
-                  },
-                  "execUUID": "8e8a47ba-a230-49c9-9e22-967a08281397",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {},
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "8e8a47ba-a230-49c9-9e22-967a08281397",
-                    "history": 253,
-                    "env": {}
-                  },
-                  "response": true,
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 253
-                }
-              },
-              {
-                "startTime": 1599574363895,
-                "startEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/#",
-                  "command": "# ## Verify installation",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "b9c77682-8aa7-49e8-b1e4-fd4597a279d3"
-                },
-                "completeEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 0,
-                  "command": "### Verify installation",
-                  "argvNoOptions": ["#", " ## Verify installation"],
-                  "parsedOptions": {
-                    "_": ["#", " ## Verify installation"]
-                  },
-                  "execUUID": "b9c77682-8aa7-49e8-b1e4-fd4597a279d3",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "b9c77682-8aa7-49e8-b1e4-fd4597a279d3",
-                    "history": 254,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "## Verify installation"
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 254
-                }
-              },
-              {
-                "startTime": 1599574369500,
-                "startEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/iter8/config/verify",
-                  "command": "iter8 config verify",
-                  "evaluatorOptions": {
-                    "isExperimental": true,
-                    "plugin": "plugin-iter8"
-                  },
-                  "execType": 0,
-                  "execUUID": "8814744a-c010-48a8-8cd7-9e25b4cc6993"
-                },
-                "completeEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 0,
-                  "command": "iter8 config verify",
-                  "argvNoOptions": ["iter8", "config", "verify"],
-                  "parsedOptions": {
-                    "_": ["iter8", "config", "verify"]
-                  },
-                  "execUUID": "8814744a-c010-48a8-8cd7-9e25b4cc6993",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "isExperimental": true,
-                    "plugin": "plugin-iter8"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "8814744a-c010-48a8-8cd7-9e25b4cc6993",
-                    "history": 255,
-                    "env": {}
-                  },
-                  "response": "true",
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 255
-                }
-              },
-              {
-                "startTime": 1599574395901,
-                "startEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/kubeui/kubectl/get",
-                  "command": "kubectl get svc -n iter8",
-                  "evaluatorOptions": {
-                    "flags": {
-                      "configuration": {
-                        "short-option-groups": false,
-                        "duplicate-arguments-array": false
-                      },
-                      "narg": {
-                        "w": 0,
-                        "watch": 0,
-                        "watch-only": 0
-                      },
-                      "boolean": [
-                        "w",
-                        "watch",
-                        "watch-only",
-                        "A",
-                        "all-namespaces",
-                        "ignore-not-found",
-                        "no-headers",
-                        "i",
-                        "it",
-                        "ti",
-                        "stdin",
-                        "t",
-                        "tty",
-                        "R",
-                        "recursive",
-                        "server-print",
-                        "show-kind",
-                        "show-labels"
-                      ]
-                    },
-                    "plugin": "plugin-kubectl"
-                  },
-                  "execType": 0,
-                  "execUUID": "5e242ddd-adfa-46d5-a429-a52ac7341e85"
-                },
-                "completeEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 0,
-                  "command": "kubectl get svc -n iter8",
-                  "argvNoOptions": ["kubectl", "get", "svc"],
-                  "parsedOptions": {
-                    "_": ["kubectl", "get", "svc"],
-                    "n": "iter8"
-                  },
-                  "execUUID": "5e242ddd-adfa-46d5-a429-a52ac7341e85",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "plugin": "plugin-kubectl"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "5e242ddd-adfa-46d5-a429-a52ac7341e85",
-                    "history": 256,
-                    "env": {}
-                  },
-                  "response": {
-                    "header": {
-                      "key": "NAME",
-                      "name": "Name",
-                      "rowKey": "NAME",
-                      "fontawesome": false,
-                      "onclick": false,
-                      "onclickSilence": true,
-                      "css": " kui--table-cell-is-name",
-                      "rowCSS": [],
-                      "outerCSS": "header-cell entity-name-group",
-                      "attributes": [
-                        {
-                          "key": "TYPE",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell hide-with-sidecar",
-                          "css": "  ",
-                          "value": "Type"
-                        },
-                        {
-                          "key": "CLUSTER-IP",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell ",
-                          "css": "  ",
-                          "value": "Cluster-ip"
-                        },
-                        {
-                          "key": "EXTERNAL-IP",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell  hide-with-sidecar",
-                          "css": "  ",
-                          "value": "External-ip"
-                        },
-                        {
-                          "key": "PORT(S)",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell entity-name-group entity-name-group-narrow hide-with-sidecar hide-with-sidecar",
-                          "css": "  ",
-                          "value": "Port(s)"
-                        },
-                        {
-                          "key": "AGE",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell hide-with-sidecar hide-with-sidecar",
-                          "css": "  ",
-                          "value": "Age"
-                        }
-                      ]
-                    },
-                    "body": [
-                      {
-                        "key": "NAME",
-                        "name": "iter8-analytics",
-                        "rowKey": "iter8-analytics",
-                        "fontawesome": false,
-                        "onclick": "kubectl get Service iter8-analytics -o yaml -n iter8 ",
-                        "onclickSilence": true,
-                        "css": " kui--table-cell-is-name",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group",
-                        "attributes": [
-                          {
-                            "key": "TYPE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar",
-                            "css": "  ",
-                            "value": "ClusterIP"
-                          },
-                          {
-                            "key": "CLUSTER-IP",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  ",
-                            "value": "172.21.243.237"
-                          },
-                          {
-                            "key": "EXTERNAL-IP",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  yellow-background",
-                            "value": "<none>"
-                          },
-                          {
-                            "key": "PORT(S)",
-                            "onclick": false,
-                            "outerCSS": " entity-name-group entity-name-group-narrow hide-with-sidecar hide-with-sidecar",
-                            "css": "  ",
-                            "value": "8080/TCP"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "19d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAME",
-                        "name": "iter8-controller",
-                        "rowKey": "iter8-controller",
-                        "fontawesome": false,
-                        "onclick": "kubectl get Service iter8-controller -o yaml -n iter8 ",
-                        "onclickSilence": true,
-                        "css": " kui--table-cell-is-name",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group",
-                        "attributes": [
-                          {
-                            "key": "TYPE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar",
-                            "css": "  ",
-                            "value": "ClusterIP"
-                          },
-                          {
-                            "key": "CLUSTER-IP",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  ",
-                            "value": "172.21.245.193"
-                          },
-                          {
-                            "key": "EXTERNAL-IP",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  yellow-background",
-                            "value": "<none>"
-                          },
-                          {
-                            "key": "PORT(S)",
-                            "onclick": false,
-                            "outerCSS": " entity-name-group entity-name-group-narrow hide-with-sidecar hide-with-sidecar",
-                            "css": "  ",
-                            "value": "443/TCP"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "19d"
-                          }
-                        ]
-                      }
-                    ],
-                    "noSort": true,
-                    "title": "Service",
-                    "breadcrumbs": [
-                      {
-                        "label": "iter8"
-                      }
-                    ],
-                    "statusColumnIdx": -1
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 256
-                }
-              },
-              {
-                "startTime": 1599574432231,
-                "startEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/#",
-                  "command": "# ## Learn more about iter8 and how to use it",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "6e111183-4310-44bd-a571-08346c243955"
-                },
-                "completeEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 0,
-                  "command": "### Learn more about iter8 and how to use it",
-                  "argvNoOptions": ["#", " ## Learn more about iter8 and how to use it"],
-                  "parsedOptions": {
-                    "_": ["#", " ## Learn more about iter8 and how to use it"]
-                  },
-                  "execUUID": "6e111183-4310-44bd-a571-08346c243955",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "6e111183-4310-44bd-a571-08346c243955",
-                    "history": 257,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "## Learn more about iter8 and how to use it"
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 257
-                }
-              },
-              {
-                "startTime": 1599574435835,
-                "startEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/iter8/about",
-                  "command": "iter8 about",
-                  "evaluatorOptions": {
-                    "isExperimental": true,
-                    "plugin": "plugin-iter8"
-                  },
-                  "execType": 0,
-                  "execUUID": "7245ba00-b258-47db-bbed-e19fb21447cc"
-                },
-                "completeEvent": {
-                  "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 0,
-                  "command": "iter8 about",
-                  "argvNoOptions": ["iter8", "about"],
-                  "parsedOptions": {
-                    "_": ["iter8", "about"]
-                  },
-                  "execUUID": "7245ba00-b258-47db-bbed-e19fb21447cc",
-                  "cancelled": false,
-                  "evaluatorOptions": {
-                    "isExperimental": true,
-                    "plugin": "plugin-iter8"
-                  },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "1_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "7245ba00-b258-47db-bbed-e19fb21447cc",
-                    "history": 258,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "NavResponse",
-                    "breadcrumbs": [
-                      {
-                        "label": "iter8"
-                      },
-                      {
-                        "label": "about",
-                        "command": "iter8 about"
-                      }
-                    ],
-                    "menus": [
-                      {
-                        "label": "Iter8",
-                        "items": [
-                          {
-                            "mode": "About",
-                            "content": "#### Iter8\n\n[Iter8](https://github.com/iter8-tools/iter8) enables statistically robust continuous experimentation of microservices in your CI/CD pipelines\n\nIter8’s expressive model of cloud experimentation supports a variety of CI/CD scenarios. Using an iter8 experiment, you can:\n\n- Run a **_performance test_** with a single version of a microservice.\n\n- Perform a **_canary release_** with two versions, a baseline and a candidate. Iter8 will shift application traffic safely and gradually to the candidate, if it meets the criteria you specify in the experiment.\n\n- Perform an **_A/B test_** with two versions – a baseline and a candidate. Iter8 will identify and shift application traffic safely and gradually to the winner, where the winning version is defined by the criteria you specify in the experiment.\n\n- Perform an **_A/B/N_** test with multiple versions – a baseline and multiple candidates. Iter8 will identify and shift application traffic safely and gradually to the winner.\n\n[Learn more](https://iter8.tools/)\n",
-                            "contentType": "text/markdown"
-                          },
-                          {
-                            "mode": "Commands",
-                            "content": "\n#### Currently Available Commands:\n\nWe have implemented the following commands that can be used once the KUI terminal is up and running:\n#### 1. iter8 metrics\nThis command opens a KUI sidecar where the user can perform CRUD operations on the iter8 metric configmap. Specifically, users can add, edit, delete and restore metrics on the KUI sidecar that is opened.\n#### 2. iter8 create experiment\nThis command also opens a KUI sidecar and is used to create Human-In-The-Loop experiments with iter8. This command opens a sidecar with two tabs- one for creating the experiment and one for viewing the decision and metrics for the experiment from _iter8-analytics_. The sidecar options are interactive and can be experimented with by the user.\n#### 2. iter8 config verify\nThis command verifies if _iter8-analytics_ and _iter8-controller_ service is currently installed in the user's environment\n\nMore information on how to use these commands is available [here](http://iter8.tools/integrations/iter8-kui/)\n",
-                            "contentType": "text/markdown"
-                          }
-                        ]
-                      },
-                      {
-                        "label": "Components",
-                        "items": [
-                          {
-                            "mode": "Iter8 Controller",
-                            "content": "\n#### Iter8 Controller\n\nA Kubernetes controller that automates canary releases and A/B testing by adjusting the traffic across different versions of a microservice as recommended by _iter8-analytics_ until the canary replaces the baseline (previous) version.\n",
-                            "contentType": "text/markdown"
-                          },
-                          {
-                            "mode": "Iter8 Analytics",
-                            "content": "\n#### Iter8 Analytics\n\nA service that assesses the behavior of different microservice versions by analyzing metrics associated with each version using robust statistical techniques to determine which version is the winner with respect to the metrics of interest and which versions pass a set of success criteria.\n\nIt returns the result of the data analysis along with a recommendation for how the traffic should be split across all microservice versions. The iter8-analytics' REST API is used by _iter8-controller_.\n",
-                            "contentType": "text/markdown"
-                          }
-                        ]
-                      }
-                    ],
-                    "links": [
-                      {
-                        "label": "Github",
-                        "href": "https://github.com/iter8-tools/iter8"
-                      },
-                      {
-                        "label": "Join Slack",
-                        "href": "https://join.slack.com/t/iter8-tools/shared_invite/enQtODU0NTczMTQ5NDU4LTJmNGE1OTBhOWI4NzllZGE0ZjdhM2M3MzJlMjcxYjliMTJlM2YxMzQ4OWQ5NGViYTM2MTU4MWRkZTgxNzZiMzg"
-                      },
-                      {
-                        "label": "Learn More",
-                        "href": "https://iter8.tools/"
-                      }
-                    ]
-                  },
-                  "responseType": "NavResponse",
-                  "historyIdx": 258
-                }
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "# Use the iter8 Plugin on Kui\n\n### Iter8 is an open source toolkit for continuous experimentation on Kubernetes. Iter8 enables you to deliver high-impact code changes within your microservices applications in an agile manner while eliminating the risk. Using iter8’s machine learning (ML)-driven experimentation capabilities, you can safely and rapidly orchestrate various types of live experiments, gain key insights into the behavior of your microservices, and rollout the best versions of your microservices in an automated, principled, and statistically robust manner.\n\n## Install iter8 using on your Kubernetes cluster"
               }
-            ]
+            },
+            "historyIdx": 250,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "693795a3-d11d-4b81-99a0-ce90fffbfbe8"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "693795a3-d11d-4b81-99a0-ce90fffbfbe8",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "693795a3-d11d-4b81-99a0-ce90fffbfbe8",
+                "history": 250,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "# Use the iter8 Plugin on Kui\n\n### Iter8 is an open source toolkit for continuous experimentation on Kubernetes. Iter8 enables you to deliver high-impact code changes within your microservices applications in an agile manner while eliminating the risk. Using iter8’s machine learning (ML)-driven experimentation capabilities, you can safely and rapidly orchestrate various types of live experiments, gain key insights into the behavior of your microservices, and rollout the best versions of your microservices in an automated, principled, and statistically robust manner.\n\n## Install iter8 using on your Kubernetes cluster"
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 250
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "693795a3-d11d-4b81-99a0-ce90fffbfbe8",
+            "startTime": "2020-09-30T21:18:42.064Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          },
+          {
+            "response": true,
+            "historyIdx": 252,
+            "cwd": "~/Workspace7/kui",
+            "command": "curl -L -s https://raw.githubusercontent.com/iter8-tools/iter8/v1.0.0-rc1/install/install.sh \\",
+            "startEvent": {
+              "route": "*",
+              "command": "curl -L -s https://raw.githubusercontent.com/iter8-tools/iter8/v1.0.0-rc1/install/install.sh \\",
+              "evaluatorOptions": {},
+              "execType": 1,
+              "execUUID": "8020c215-49c0-49fc-9b60-23df7aa12297",
+              "echo": true
+            },
+            "completeEvent": {
+              "execType": 1,
+              "command": "curl -L -s https://raw.githubusercontent.com/iter8-tools/iter8/v1.0.0-rc1/install/install.sh \\",
+              "argvNoOptions": ["curl"],
+              "parsedOptions": {
+                "_": ["curl"],
+                "L": true,
+                "s": "https://raw.githubusercontent.com/iter8-tools/iter8/v1.0.0-rc1/install/install.sh"
+              },
+              "execUUID": "8020c215-49c0-49fc-9b60-23df7aa12297",
+              "cancelled": false,
+              "echo": true,
+              "evaluatorOptions": {},
+              "execOptions": {
+                "echo": true,
+                "type": 1,
+                "execUUID": "8020c215-49c0-49fc-9b60-23df7aa12297",
+                "history": 252,
+                "env": {}
+              },
+              "response": true,
+              "responseType": "ScalarResponse",
+              "historyIdx": 252
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "8020c215-49c0-49fc-9b60-23df7aa12297",
+            "startTime": "2020-09-30T21:19:02.733Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": false,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "# Verify installation"
+              }
+            },
+            "historyIdx": 253,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "b6211da0-59b2-40d4-9302-22c70ff284c7"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "b6211da0-59b2-40d4-9302-22c70ff284c7",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "b6211da0-59b2-40d4-9302-22c70ff284c7",
+                "history": 253,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "# Verify installation"
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 253
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "b6211da0-59b2-40d4-9302-22c70ff284c7",
+            "startTime": "2020-09-30T21:19:13.285Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          },
+          {
+            "response": "true",
+            "historyIdx": 254,
+            "cwd": "~/Workspace7/kui",
+            "command": "iter8 config verify",
+            "startEvent": {
+              "route": "/iter8/config/verify",
+              "command": "iter8 config verify",
+              "evaluatorOptions": {
+                "isExperimental": true,
+                "plugin": "plugin-iter8"
+              },
+              "execType": 0,
+              "execUUID": "cfc2cfa6-99e3-40cd-9001-6414bf8c89e3"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "iter8 config verify",
+              "argvNoOptions": ["iter8", "config", "verify"],
+              "parsedOptions": {
+                "_": ["iter8", "config", "verify"]
+              },
+              "execUUID": "cfc2cfa6-99e3-40cd-9001-6414bf8c89e3",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "isExperimental": true,
+                "plugin": "plugin-iter8"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "cfc2cfa6-99e3-40cd-9001-6414bf8c89e3",
+                "history": 254,
+                "env": {}
+              },
+              "response": "true",
+              "responseType": "ScalarResponse",
+              "historyIdx": 254
+            },
+            "isExperimental": true,
+            "isReplay": false,
+            "execUUID": "cfc2cfa6-99e3-40cd-9001-6414bf8c89e3",
+            "startTime": "2020-09-30T21:19:20.158Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": false,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "header": {
+                "key": "NAME",
+                "name": "Name",
+                "rowKey": "NAME",
+                "fontawesome": false,
+                "onclick": false,
+                "onclickSilence": true,
+                "css": " kui--table-cell-is-name",
+                "rowCSS": [],
+                "outerCSS": "header-cell entity-name-group",
+                "attributes": [
+                  {
+                    "key": "TYPE",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell hide-with-sidecar",
+                    "css": "  ",
+                    "value": "Type"
+                  },
+                  {
+                    "key": "CLUSTER-IP",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell ",
+                    "css": "  ",
+                    "value": "Cluster-ip"
+                  },
+                  {
+                    "key": "EXTERNAL-IP",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell  hide-with-sidecar",
+                    "css": "  ",
+                    "value": "External-ip"
+                  },
+                  {
+                    "key": "PORT(S)",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell entity-name-group entity-name-group-narrow hide-with-sidecar hide-with-sidecar",
+                    "css": "  ",
+                    "value": "Port(s)"
+                  },
+                  {
+                    "key": "AGE",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell hide-with-sidecar hide-with-sidecar",
+                    "css": "  ",
+                    "value": "Age"
+                  }
+                ]
+              },
+              "body": [
+                {
+                  "key": "NAME",
+                  "name": "iter8-analytics",
+                  "rowKey": "iter8-analytics",
+                  "fontawesome": false,
+                  "onclick": "kubectl get Service iter8-analytics -o yaml -n iter8 ",
+                  "onclickSilence": true,
+                  "css": " kui--table-cell-is-name",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group",
+                  "attributes": [
+                    {
+                      "key": "TYPE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar",
+                      "css": "  ",
+                      "value": "ClusterIP"
+                    },
+                    {
+                      "key": "CLUSTER-IP",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  ",
+                      "value": "172.21.243.237"
+                    },
+                    {
+                      "key": "EXTERNAL-IP",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  yellow-background",
+                      "value": "<none>"
+                    },
+                    {
+                      "key": "PORT(S)",
+                      "onclick": false,
+                      "outerCSS": " entity-name-group entity-name-group-narrow hide-with-sidecar hide-with-sidecar",
+                      "css": "  ",
+                      "value": "8080/TCP"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "19d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAME",
+                  "name": "iter8-controller",
+                  "rowKey": "iter8-controller",
+                  "fontawesome": false,
+                  "onclick": "kubectl get Service iter8-controller -o yaml -n iter8 ",
+                  "onclickSilence": true,
+                  "css": " kui--table-cell-is-name",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group",
+                  "attributes": [
+                    {
+                      "key": "TYPE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar",
+                      "css": "  ",
+                      "value": "ClusterIP"
+                    },
+                    {
+                      "key": "CLUSTER-IP",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  ",
+                      "value": "172.21.245.193"
+                    },
+                    {
+                      "key": "EXTERNAL-IP",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  yellow-background",
+                      "value": "<none>"
+                    },
+                    {
+                      "key": "PORT(S)",
+                      "onclick": false,
+                      "outerCSS": " entity-name-group entity-name-group-narrow hide-with-sidecar hide-with-sidecar",
+                      "css": "  ",
+                      "value": "443/TCP"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "19d"
+                    }
+                  ]
+                }
+              ],
+              "noSort": true,
+              "title": "Service",
+              "breadcrumbs": [
+                {
+                  "label": "iter8"
+                }
+              ],
+              "statusColumnIdx": -1
+            },
+            "historyIdx": 255,
+            "cwd": "~/Workspace7/kui",
+            "command": "kubectl get svc -n iter8",
+            "startEvent": {
+              "route": "/kubeui/kubectl/get",
+              "command": "kubectl get svc -n iter8",
+              "evaluatorOptions": {
+                "flags": {
+                  "configuration": {
+                    "short-option-groups": false,
+                    "duplicate-arguments-array": false
+                  },
+                  "narg": {
+                    "w": 0,
+                    "watch": 0,
+                    "watch-only": 0
+                  },
+                  "boolean": [
+                    "w",
+                    "watch",
+                    "watch-only",
+                    "A",
+                    "all-namespaces",
+                    "ignore-not-found",
+                    "no-headers",
+                    "i",
+                    "it",
+                    "ti",
+                    "stdin",
+                    "t",
+                    "tty",
+                    "R",
+                    "recursive",
+                    "server-print",
+                    "show-kind",
+                    "show-labels"
+                  ]
+                },
+                "plugin": "plugin-kubectl"
+              },
+              "execType": 0,
+              "execUUID": "cc2db8c7-deb7-4f9b-ae10-c184552efb33"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "kubectl get svc -n iter8",
+              "argvNoOptions": ["kubectl", "get", "svc"],
+              "parsedOptions": {
+                "_": ["kubectl", "get", "svc"],
+                "n": "iter8"
+              },
+              "execUUID": "cc2db8c7-deb7-4f9b-ae10-c184552efb33",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "plugin": "plugin-kubectl"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "cc2db8c7-deb7-4f9b-ae10-c184552efb33",
+                "history": 255,
+                "env": {}
+              },
+              "response": {
+                "header": {
+                  "key": "NAME",
+                  "name": "Name",
+                  "rowKey": "NAME",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": " kui--table-cell-is-name",
+                  "rowCSS": [],
+                  "outerCSS": "header-cell entity-name-group",
+                  "attributes": [
+                    {
+                      "key": "TYPE",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell hide-with-sidecar",
+                      "css": "  ",
+                      "value": "Type"
+                    },
+                    {
+                      "key": "CLUSTER-IP",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell ",
+                      "css": "  ",
+                      "value": "Cluster-ip"
+                    },
+                    {
+                      "key": "EXTERNAL-IP",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "External-ip"
+                    },
+                    {
+                      "key": "PORT(S)",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell entity-name-group entity-name-group-narrow hide-with-sidecar hide-with-sidecar",
+                      "css": "  ",
+                      "value": "Port(s)"
+                    },
+                    {
+                      "key": "AGE",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell hide-with-sidecar hide-with-sidecar",
+                      "css": "  ",
+                      "value": "Age"
+                    }
+                  ]
+                },
+                "body": [
+                  {
+                    "key": "NAME",
+                    "name": "iter8-analytics",
+                    "rowKey": "iter8-analytics",
+                    "fontawesome": false,
+                    "onclick": "kubectl get Service iter8-analytics -o yaml -n iter8 ",
+                    "onclickSilence": true,
+                    "css": " kui--table-cell-is-name",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group",
+                    "attributes": [
+                      {
+                        "key": "TYPE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar",
+                        "css": "  ",
+                        "value": "ClusterIP"
+                      },
+                      {
+                        "key": "CLUSTER-IP",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  ",
+                        "value": "172.21.243.237"
+                      },
+                      {
+                        "key": "EXTERNAL-IP",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  yellow-background",
+                        "value": "<none>"
+                      },
+                      {
+                        "key": "PORT(S)",
+                        "onclick": false,
+                        "outerCSS": " entity-name-group entity-name-group-narrow hide-with-sidecar hide-with-sidecar",
+                        "css": "  ",
+                        "value": "8080/TCP"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "19d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAME",
+                    "name": "iter8-controller",
+                    "rowKey": "iter8-controller",
+                    "fontawesome": false,
+                    "onclick": "kubectl get Service iter8-controller -o yaml -n iter8 ",
+                    "onclickSilence": true,
+                    "css": " kui--table-cell-is-name",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group",
+                    "attributes": [
+                      {
+                        "key": "TYPE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar",
+                        "css": "  ",
+                        "value": "ClusterIP"
+                      },
+                      {
+                        "key": "CLUSTER-IP",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  ",
+                        "value": "172.21.245.193"
+                      },
+                      {
+                        "key": "EXTERNAL-IP",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  yellow-background",
+                        "value": "<none>"
+                      },
+                      {
+                        "key": "PORT(S)",
+                        "onclick": false,
+                        "outerCSS": " entity-name-group entity-name-group-narrow hide-with-sidecar hide-with-sidecar",
+                        "css": "  ",
+                        "value": "443/TCP"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "19d"
+                      }
+                    ]
+                  }
+                ],
+                "noSort": true,
+                "title": "Service",
+                "breadcrumbs": [
+                  {
+                    "label": "iter8"
+                  }
+                ],
+                "statusColumnIdx": -1
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 255
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "state": "valid-response",
+            "execUUID": "cc2db8c7-deb7-4f9b-ae10-c184552efb33",
+            "startTime": "2020-09-30T21:19:28.237Z"
+          },
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "## Learn more about iter8 and how to use it"
+              }
+            },
+            "historyIdx": 256,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "d25f423b-284d-47fc-9703-28af580a6330"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "d25f423b-284d-47fc-9703-28af580a6330",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "d25f423b-284d-47fc-9703-28af580a6330",
+                "history": 256,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "## Learn more about iter8 and how to use it"
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 256
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "d25f423b-284d-47fc-9703-28af580a6330",
+            "startTime": "2020-09-30T21:19:32.805Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          },
+          {
+            "response": true,
+            "historyIdx": 257,
+            "cwd": "~/Workspace7/kui",
+            "command": "iter8 about",
+            "startEvent": {
+              "route": "/iter8/about",
+              "command": "iter8 about",
+              "evaluatorOptions": {
+                "isExperimental": true,
+                "plugin": "plugin-iter8"
+              },
+              "execType": 0,
+              "execUUID": "b968321e-7106-4854-93e7-8b38e7c6522e"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "iter8 about",
+              "argvNoOptions": ["iter8", "about"],
+              "parsedOptions": {
+                "_": ["iter8", "about"]
+              },
+              "execUUID": "b968321e-7106-4854-93e7-8b38e7c6522e",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "isExperimental": true,
+                "plugin": "plugin-iter8"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "b968321e-7106-4854-93e7-8b38e7c6522e",
+                "history": 257,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "NavResponse",
+                "breadcrumbs": [
+                  {
+                    "label": "iter8"
+                  },
+                  {
+                    "label": "about",
+                    "command": "iter8 about"
+                  }
+                ],
+                "menus": [
+                  {
+                    "label": "Iter8",
+                    "items": [
+                      {
+                        "mode": "About",
+                        "content": "#### Iter8\n\n[Iter8](https://github.com/iter8-tools/iter8) enables statistically robust continuous experimentation of microservices in your CI/CD pipelines\n\nIter8’s expressive model of cloud experimentation supports a variety of CI/CD scenarios. Using an iter8 experiment, you can:\n\n- Run a **_performance test_** with a single version of a microservice.\n\n- Perform a **_canary release_** with two versions, a baseline and a candidate. Iter8 will shift application traffic safely and gradually to the candidate, if it meets the criteria you specify in the experiment.\n\n- Perform an **_A/B test_** with two versions – a baseline and a candidate. Iter8 will identify and shift application traffic safely and gradually to the winner, where the winning version is defined by the criteria you specify in the experiment.\n\n- Perform an **_A/B/N_** test with multiple versions – a baseline and multiple candidates. Iter8 will identify and shift application traffic safely and gradually to the winner.\n\n[Learn more](https://iter8.tools/)\n",
+                        "contentType": "text/markdown"
+                      },
+                      {
+                        "mode": "Commands",
+                        "content": "\n#### Currently Available Commands:\n\nWe have implemented the following commands that can be used once the KUI terminal is up and running:\n#### 1. iter8 metrics\nThis command opens a KUI sidecar where the user can perform CRUD operations on the iter8 metric configmap. Specifically, users can add, edit, delete and restore metrics on the KUI sidecar that is opened.\n#### 2. iter8 create experiment\nThis command also opens a KUI sidecar and is used to create Human-In-The-Loop experiments with iter8. This command opens a sidecar with two tabs- one for creating the experiment and one for viewing the decision and metrics for the experiment from _iter8-analytics_. The sidecar options are interactive and can be experimented with by the user.\n#### 2. iter8 config verify\nThis command verifies if _iter8-analytics_ and _iter8-controller_ service is currently installed in the user's environment\n\nMore information on how to use these commands is available [here](http://iter8.tools/integrations/iter8-kui/)\n",
+                        "contentType": "text/markdown"
+                      }
+                    ]
+                  },
+                  {
+                    "label": "Components",
+                    "items": [
+                      {
+                        "mode": "Iter8 Controller",
+                        "content": "\n#### Iter8 Controller\n\nA Kubernetes controller that automates canary releases and A/B testing by adjusting the traffic across different versions of a microservice as recommended by _iter8-analytics_ until the canary replaces the baseline (previous) version.\n",
+                        "contentType": "text/markdown"
+                      },
+                      {
+                        "mode": "Iter8 Analytics",
+                        "content": "\n#### Iter8 Analytics\n\nA service that assesses the behavior of different microservice versions by analyzing metrics associated with each version using robust statistical techniques to determine which version is the winner with respect to the metrics of interest and which versions pass a set of success criteria.\n\nIt returns the result of the data analysis along with a recommendation for how the traffic should be split across all microservice versions. The iter8-analytics' REST API is used by _iter8-controller_.\n",
+                        "contentType": "text/markdown"
+                      }
+                    ]
+                  }
+                ],
+                "links": [
+                  {
+                    "label": "Github",
+                    "href": "https://github.com/iter8-tools/iter8"
+                  },
+                  {
+                    "label": "Join Slack",
+                    "href": "https://join.slack.com/t/iter8-tools/shared_invite/enQtODU0NTczMTQ5NDU4LTJmNGE1OTBhOWI4NzllZGE0ZjdhM2M3MzJlMjcxYjliMTJlM2YxMzQ4OWQ5NGViYTM2MTU4MWRkZTgxNzZiMzg"
+                  },
+                  {
+                    "label": "Learn More",
+                    "href": "https://iter8.tools/"
+                  }
+                ]
+              },
+              "responseType": "NavResponse",
+              "historyIdx": 257
+            },
+            "isExperimental": true,
+            "isReplay": false,
+            "execUUID": "b968321e-7106-4854-93e7-8b38e7c6522e",
+            "startTime": "2020-09-30T21:19:47.045Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": false,
+            "state": "valid-response"
           }
         ]
       }
-    ]
+    ],
+    "clicks": {
+      "startEvents": {},
+      "completeEvents": {}
+    }
   }
 }

--- a/plugins/plugin-kubectl/notebooks/create-jobs.json
+++ b/plugins/plugin-kubectl/notebooks/create-jobs.json
@@ -1,7562 +1,14543 @@
 {
   "apiVersion": "kui-shell/v1",
-  "kind": "Snapshot",
+  "kind": "Notebook",
+  "metadata": {
+    "name": "Kubernetes &mdash; `Working with Jobs`"
+  },
   "spec": {
-    "title": "Kubernetes &mdash; `Working with Jobs`",
-    "clicks": {
-      "startEvents": {},
-      "completeEvents": {}
-    },
-    "windows": [
+    "splits": [
       {
-        "uuid": "0",
-        "tabs": [
+        "uuid": "1_c57e811f-2da8-557e-a402-9f0950407675",
+        "blocks": [
           {
-            "uuid": "0",
-            "blocks": [
-              {
-                "startTime": 1599153272454,
-                "startEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/#",
-                  "command": "#    # Creating a Job \\n You can create a Job using `kubectl apply` with a manifest file",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "# Creating a Job \n You can create a Job using `kubectl apply` with a manifest file"
+              }
+            },
+            "historyIdx": 250,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
                     },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 1,
-                  "execUUID": "81be30d0-2402-45b7-b11b-fa763236f67a",
-                  "echo": true
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
                 },
-                "completeEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 1,
-                  "command": "#   # Creating a Job \\n You can create a Job using `kubectl apply` with a manifest file",
-                  "argvNoOptions": [
-                    "#",
-                    "    # Creating a Job \\n You can create a Job using `kubectl apply` with a manifest file"
-                  ],
-                  "parsedOptions": {
-                    "_": [
-                      "#",
-                      "    # Creating a Job \\n You can create a Job using `kubectl apply` with a manifest file"
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "b8c21897-2021-4166-94db-a0dd47374737"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "b8c21897-2021-4166-94db-a0dd47374737",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "b8c21897-2021-4166-94db-a0dd47374737",
+                "history": 250,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "# Creating a Job \n You can create a Job using `kubectl apply` with a manifest file"
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 250
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "b8c21897-2021-4166-94db-a0dd47374737",
+            "startTime": "2020-09-30T18:29:08.618Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "header": {
+                "key": "JOB",
+                "name": "Job",
+                "rowKey": "NAME",
+                "fontawesome": false,
+                "onclick": false,
+                "onclickSilence": true,
+                "css": "",
+                "rowCSS": [],
+                "outerCSS": "header-cell ",
+                "attributes": [
+                  {
+                    "key": "NAME",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell entity-name-group",
+                    "css": "  ",
+                    "value": "Name"
+                  },
+                  {
+                    "key": "STATUS",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell ",
+                    "css": "  ",
+                    "value": "Status"
+                  },
+                  {
+                    "key": "START",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell  hide-with-sidecar",
+                    "css": "  ",
+                    "value": "Start"
+                  },
+                  {
+                    "key": "START2",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "hide",
+                    "css": "  ",
+                    "value": "Start2"
+                  },
+                  {
+                    "key": "END",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell  hide-with-sidecar",
+                    "css": "  ",
+                    "value": "End"
+                  },
+                  {
+                    "key": "Duration",
+                    "value": "Duration"
+                  },
+                  {
+                    "key": "Cold Start",
+                    "value": "Cold Start",
+                    "outerCSS": "hide-with-sidecar"
+                  }
+                ]
+              },
+              "body": [
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-mpzth",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-mpzth -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-mpzth"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:26Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:29Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:39Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "13000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "3000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-vw4qb",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-vw4qb -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-vw4qb"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:26Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:28Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:37Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "11000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "2000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-vhmlh",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-vhmlh -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-vhmlh"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:26Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:28Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:38Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "12000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "2000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-f9cb9",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-f9cb9 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-f9cb9"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:27Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:29Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:35Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "8000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "2000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-z9845",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-z9845 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-z9845"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:35Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:37Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:44Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "9000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "2000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-5pfck",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-5pfck -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-5pfck"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:37Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:39Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:46Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "9000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "2000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-s9l95",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-s9l95 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-s9l95"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:38Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:40Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:47Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "9000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "2000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-mr6zd",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-mr6zd -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-mr6zd"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:39Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:42Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:48Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "9000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "3000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-sfplv",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-sfplv -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-sfplv"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:44Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:46Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:55Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "11000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "2000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-km5mq",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-km5mq -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-km5mq"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:47Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:49Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:00Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "13000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "2000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-rb647",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-rb647 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-rb647"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:47Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:48Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:02Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "15000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "1000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-qz6hn",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-qz6hn -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-qz6hn"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:48Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:50Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:00Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "12000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "2000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-r5t9j",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-r5t9j -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-r5t9j"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:56Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:03:57Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:05Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "9000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "1000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-8msfn",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-8msfn -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-8msfn"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:01Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:02Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:12Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "11000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "1000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-99swq",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-99swq -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-99swq"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:01Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:05Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:13Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "12000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "4000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-bjf8g",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-bjf8g -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-bjf8g"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:03Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:06Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:15Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "12000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "3000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-vpwq8",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-vpwq8 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-vpwq8"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:06Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:07Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:13Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "7000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "1000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-7bstz",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-7bstz -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-7bstz"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:13Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:15Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:21Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "8000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "2000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-chbzt",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-chbzt -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-chbzt"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:14Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:16Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:21Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "7000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "2000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                {
+                  "key": "JOB",
+                  "name": "pi",
+                  "rowKey": "pi-5cgk4",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-5cgk4 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-5cgk4"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  blue-background",
+                      "value": "Succeeded"
+                    },
+                    {
+                      "key": "START",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:14Z"
+                    },
+                    {
+                      "key": "START2",
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:15Z"
+                    },
+                    {
+                      "key": "END",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "2020-08-31T20:04:21Z"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "7000"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "1000",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                }
+              ],
+              "noSort": true,
+              "title": "Job",
+              "breadcrumbs": [
+                {
+                  "label": "default"
+                }
+              ],
+              "statusColumnIdx": 1,
+              "startColumnIdx": 2,
+              "completeColumnIdx": 4,
+              "durationColumnIdx": 5,
+              "coldStartColumnIdx": 6,
+              "kuiSourceRef": {
+                "templates": [
+                  {
+                    "filepath": "plugins/plugin-kubectl/tests/data/k8s/job.yaml",
+                    "data": "apiVersion: batch/v1\nkind: Job\nmetadata:\n  name: pi\nspec:\n  completions: 20\n  parallelism: 4\n  template:\n    spec:\n      containers:\n      - name: pi\n        image: perl\n        command: [\"perl\",  \"-Mbignum=bpi\", \"-wle\", \"print bpi(2000)\"]\n      restartPolicy: Never\n  backoffLimit: 4\n",
+                    "isFor": "f",
+                    "kind": "source",
+                    "contentType": "yaml"
+                  }
+                ]
+              }
+            },
+            "historyIdx": 251,
+            "cwd": "~/Workspace7/kui",
+            "command": "k apply -f plugins/plugin-kubectl/tests/data/k8s/job.yaml",
+            "startEvent": {
+              "route": "/kubeui/k/apply",
+              "command": "k apply -f plugins/plugin-kubectl/tests/data/k8s/job.yaml",
+              "evaluatorOptions": {
+                "flags": {
+                  "configuration": {
+                    "short-option-groups": false,
+                    "duplicate-arguments-array": false
+                  },
+                  "narg": {
+                    "w": 0,
+                    "watch": 0,
+                    "watch-only": 0
+                  },
+                  "boolean": [
+                    "w",
+                    "watch",
+                    "watch-only",
+                    "A",
+                    "all-namespaces",
+                    "ignore-not-found",
+                    "no-headers",
+                    "i",
+                    "it",
+                    "ti",
+                    "stdin",
+                    "t",
+                    "tty",
+                    "R",
+                    "recursive",
+                    "server-print",
+                    "show-kind",
+                    "show-labels"
+                  ]
+                },
+                "alwaysViewIn": "Terminal",
+                "plugin": "plugin-kubectl"
+              },
+              "execType": 0,
+              "execUUID": "8accdd0a-d479-4a39-ad8a-0edc150e836f"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "k apply -f plugins/plugin-kubectl/tests/data/k8s/job.yaml",
+              "argvNoOptions": ["k", "apply"],
+              "parsedOptions": {
+                "_": ["k", "apply"],
+                "f": "plugins/plugin-kubectl/tests/data/k8s/job.yaml"
+              },
+              "execUUID": "8accdd0a-d479-4a39-ad8a-0edc150e836f",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "alwaysViewIn": "Terminal",
+                "plugin": "plugin-kubectl"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "8accdd0a-d479-4a39-ad8a-0edc150e836f",
+                "history": 251,
+                "env": {}
+              },
+              "response": {
+                "header": {
+                  "key": "JOB",
+                  "name": "Job",
+                  "rowKey": "NAME",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": "header-cell ",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell entity-name-group",
+                      "css": "  ",
+                      "value": "Name"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell ",
+                      "css": "  ",
+                      "value": "Status"
+                    },
+                    {
+                      "key": "START",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "Start"
+                    },
+                    {
+                      "key": "START2",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "hide",
+                      "css": "  ",
+                      "value": "Start2"
+                    },
+                    {
+                      "key": "END",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "End"
+                    },
+                    {
+                      "key": "Duration",
+                      "value": "Duration"
+                    },
+                    {
+                      "key": "Cold Start",
+                      "value": "Cold Start",
+                      "outerCSS": "hide-with-sidecar"
+                    }
+                  ]
+                },
+                "body": [
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-mpzth",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-mpzth -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-mpzth"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:26Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:29Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:39Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "13000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "3000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
                     ]
                   },
-                  "execUUID": "81be30d0-2402-45b7-b11b-fa763236f67a",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-vw4qb",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-vw4qb -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-vw4qb"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:26Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:28Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:37Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "11000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "2000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
                   },
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "81be30d0-2402-45b7-b11b-fa763236f67a",
-                    "history": 251,
-                    "env": {}
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-vhmlh",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-vhmlh -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-vhmlh"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:26Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:28Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:38Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "12000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "2000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
                   },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "# Creating a Job \n You can create a Job using `kubectl apply` with a manifest file"
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-f9cb9",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-f9cb9 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-f9cb9"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:27Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:29Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:35Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "8000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "2000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-z9845",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-z9845 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-z9845"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:35Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:37Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:44Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "9000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "2000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-5pfck",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-5pfck -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-5pfck"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:37Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:39Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:46Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "9000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "2000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-s9l95",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-s9l95 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-s9l95"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:38Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:40Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:47Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "9000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "2000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-mr6zd",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-mr6zd -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-mr6zd"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:39Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:42Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:48Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "9000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "3000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-sfplv",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-sfplv -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-sfplv"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:44Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:46Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:55Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "11000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "2000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-km5mq",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-km5mq -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-km5mq"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:47Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:49Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:00Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "13000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "2000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-rb647",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-rb647 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-rb647"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:47Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:48Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:02Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "15000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "1000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-qz6hn",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-qz6hn -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-qz6hn"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:48Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:50Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:00Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "12000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "2000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-r5t9j",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-r5t9j -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-r5t9j"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:56Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:03:57Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:05Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "9000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "1000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-8msfn",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-8msfn -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-8msfn"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:01Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:02Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:12Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "11000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "1000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-99swq",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-99swq -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-99swq"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:01Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:05Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:13Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "12000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "4000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-bjf8g",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-bjf8g -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-bjf8g"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:03Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:06Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:15Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "12000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "3000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-vpwq8",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-vpwq8 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-vpwq8"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:06Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:07Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:13Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "7000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "1000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-7bstz",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-7bstz -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-7bstz"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:13Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:15Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:21Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "8000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "2000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-chbzt",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-chbzt -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-chbzt"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:14Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:16Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:21Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "7000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "2000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "JOB",
+                    "name": "pi",
+                    "rowKey": "pi-5cgk4",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " ",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-5cgk4 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-5cgk4"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  blue-background",
+                        "value": "Succeeded"
+                      },
+                      {
+                        "key": "START",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:14Z"
+                      },
+                      {
+                        "key": "START2",
+                        "onclick": false,
+                        "outerCSS": "hide",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:15Z"
+                      },
+                      {
+                        "key": "END",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  ",
+                        "value": "2020-08-31T20:04:21Z"
+                      },
+                      {
+                        "key": "Duration",
+                        "value": "7000"
+                      },
+                      {
+                        "key": "Cold Start",
+                        "value": "1000",
+                        "outerCSS": "hide-with-sidecar"
+                      }
+                    ]
+                  }
+                ],
+                "noSort": true,
+                "title": "Job",
+                "breadcrumbs": [
+                  {
+                    "label": "default"
+                  }
+                ],
+                "statusColumnIdx": 1,
+                "startColumnIdx": 2,
+                "completeColumnIdx": 4,
+                "durationColumnIdx": 5,
+                "coldStartColumnIdx": 6,
+                "kuiSourceRef": {
+                  "templates": [
+                    {
+                      "filepath": "plugins/plugin-kubectl/tests/data/k8s/job.yaml",
+                      "data": "apiVersion: batch/v1\nkind: Job\nmetadata:\n  name: pi\nspec:\n  completions: 20\n  parallelism: 4\n  template:\n    spec:\n      containers:\n      - name: pi\n        image: perl\n        command: [\"perl\",  \"-Mbignum=bpi\", \"-wle\", \"print bpi(2000)\"]\n      restartPolicy: Never\n  backoffLimit: 4\n",
+                      "isFor": "f",
+                      "kind": "source",
+                      "contentType": "yaml"
                     }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 251
+                  ]
                 }
               },
-              {
-                "startTime": 1599153272533,
-                "startEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/kubeui/k/apply",
-                  "command": "k apply -f plugins/plugin-kubectl/tests/data/k8s/job.yaml",
-                  "evaluatorOptions": {
-                    "flags": {
-                      "configuration": {
-                        "short-option-groups": false,
-                        "duplicate-arguments-array": false
-                      },
-                      "narg": {
-                        "w": 0,
-                        "watch": 0,
-                        "watch-only": 0
-                      },
-                      "boolean": [
-                        "w",
-                        "watch",
-                        "watch-only",
-                        "A",
-                        "all-namespaces",
-                        "ignore-not-found",
-                        "no-headers",
-                        "i",
-                        "it",
-                        "ti",
-                        "stdin",
-                        "t",
-                        "tty",
-                        "R",
-                        "recursive",
-                        "server-print",
-                        "show-kind",
-                        "show-labels"
-                      ]
+              "responseType": "ScalarResponse",
+              "historyIdx": 251
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "8accdd0a-d479-4a39-ad8a-0edc150e836f",
+            "startTime": "2020-09-30T18:29:22.418Z",
+            "prefersTerminalPresentation": true,
+            "outputOnly": false,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "# Inspecting a Job\nTo check a Job's status, run the following command:"
+              }
+            },
+            "historyIdx": 252,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
                     },
-                    "alwaysViewIn": "Terminal",
-                    "plugin": "plugin-kubectl"
-                  },
-                  "execType": 1,
-                  "execUUID": "29dc3aa2-f37b-4961-bf35-4f911b532e04",
-                  "echo": true
-                },
-                "completeEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 1,
-                  "command": "k apply -f plugins/plugin-kubectl/tests/data/k8s/job.yaml",
-                  "argvNoOptions": ["k", "apply"],
-                  "parsedOptions": {
-                    "_": ["k", "apply"],
-                    "f": "plugins/plugin-kubectl/tests/data/k8s/job.yaml"
-                  },
-                  "execUUID": "29dc3aa2-f37b-4961-bf35-4f911b532e04",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {
-                    "alwaysViewIn": "Terminal",
-                    "plugin": "plugin-kubectl"
-                  },
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "29dc3aa2-f37b-4961-bf35-4f911b532e04",
-                    "history": 252,
-                    "env": {}
-                  },
-                  "response": {
-                    "header": {
-                      "key": "JOB",
-                      "name": "Job",
-                      "rowKey": "NAME",
-                      "fontawesome": false,
-                      "onclick": false,
-                      "onclickSilence": true,
-                      "css": "",
-                      "rowCSS": [],
-                      "outerCSS": "header-cell ",
-                      "attributes": [
-                        {
-                          "key": "NAME",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell entity-name-group",
-                          "css": "  ",
-                          "value": "Name"
-                        },
-                        {
-                          "key": "STATUS",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell ",
-                          "css": "  ",
-                          "value": "Status"
-                        },
-                        {
-                          "key": "START",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell  hide-with-sidecar",
-                          "css": "  ",
-                          "value": "Start"
-                        },
-                        {
-                          "key": "START2",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "hide",
-                          "css": "  ",
-                          "value": "Start2"
-                        },
-                        {
-                          "key": "END",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell  hide-with-sidecar",
-                          "css": "  ",
-                          "value": "End"
-                        },
-                        {
-                          "key": "Duration",
-                          "value": "Duration"
-                        },
-                        {
-                          "key": "Cold Start",
-                          "value": "Cold Start",
-                          "outerCSS": "hide-with-sidecar"
-                        }
-                      ]
-                    },
-                    "body": [
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-mpzth",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-mpzth -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-mpzth"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:26Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:29Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:39Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "13000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "3000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-vw4qb",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-vw4qb -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-vw4qb"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:26Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:28Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:37Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "11000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "2000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-vhmlh",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-vhmlh -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-vhmlh"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:26Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:28Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:38Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "12000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "2000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-f9cb9",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-f9cb9 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-f9cb9"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:27Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:29Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:35Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "8000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "2000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-z9845",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-z9845 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-z9845"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:35Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:37Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:44Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "9000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "2000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-5pfck",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-5pfck -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-5pfck"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:37Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:39Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:46Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "9000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "2000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-s9l95",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-s9l95 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-s9l95"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:38Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:40Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:47Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "9000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "2000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-mr6zd",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-mr6zd -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-mr6zd"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:39Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:42Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:48Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "9000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "3000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-sfplv",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-sfplv -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-sfplv"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:44Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:46Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:55Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "11000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "2000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-km5mq",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-km5mq -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-km5mq"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:47Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:49Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:00Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "13000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "2000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-rb647",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-rb647 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-rb647"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:47Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:48Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:02Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "15000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "1000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-qz6hn",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-qz6hn -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-qz6hn"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:48Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:50Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:00Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "12000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "2000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-r5t9j",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-r5t9j -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-r5t9j"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:56Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:03:57Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:05Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "9000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "1000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-8msfn",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-8msfn -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-8msfn"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:01Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:02Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:12Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "11000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "1000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-99swq",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-99swq -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-99swq"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:01Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:05Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:13Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "12000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "4000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-bjf8g",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-bjf8g -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-bjf8g"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:03Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:06Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:15Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "12000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "3000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-vpwq8",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-vpwq8 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-vpwq8"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:06Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:07Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:13Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "7000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "1000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-7bstz",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-7bstz -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-7bstz"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:13Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:15Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:21Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "8000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "2000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-chbzt",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-chbzt -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-chbzt"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:14Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:16Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:21Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "7000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "2000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "JOB",
-                        "name": "pi",
-                        "rowKey": "pi-5cgk4",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " ",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-5cgk4 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-5cgk4"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  blue-background",
-                            "value": "Succeeded"
-                          },
-                          {
-                            "key": "START",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:14Z"
-                          },
-                          {
-                            "key": "START2",
-                            "onclick": false,
-                            "outerCSS": "hide",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:15Z"
-                          },
-                          {
-                            "key": "END",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  ",
-                            "value": "2020-08-31T20:04:21Z"
-                          },
-                          {
-                            "key": "Duration",
-                            "value": "7000"
-                          },
-                          {
-                            "key": "Cold Start",
-                            "value": "1000",
-                            "outerCSS": "hide-with-sidecar"
-                          }
-                        ]
-                      }
-                    ],
-                    "noSort": true,
-                    "title": "Job",
-                    "breadcrumbs": [
-                      {
-                        "label": "default"
-                      }
-                    ],
-                    "statusColumnIdx": 1,
-                    "startColumnIdx": 2,
-                    "completeColumnIdx": 4,
-                    "durationColumnIdx": 5,
-                    "coldStartColumnIdx": 6,
-                    "kuiSourceRef": {
-                      "templates": [
-                        {
-                          "filepath": "plugins/plugin-kubectl/tests/data/k8s/job.yaml",
-                          "data": "apiVersion: batch/v1\nkind: Job\nmetadata:\n  name: pi\nspec:\n  completions: 20\n  parallelism: 4\n  template:\n    spec:\n      containers:\n      - name: pi\n        image: perl\n        command: [\"perl\",  \"-Mbignum=bpi\", \"-wle\", \"print bpi(2000)\"]\n      restartPolicy: Never\n  backoffLimit: 4\n",
-                          "isFor": "f",
-                          "kind": "source",
-                          "contentType": "yaml"
-                        }
-                      ]
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
                     }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 252
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "cbb4ce37-e7b9-4e0a-a63a-3aa0e3c29591"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "cbb4ce37-e7b9-4e0a-a63a-3aa0e3c29591",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "cbb4ce37-e7b9-4e0a-a63a-3aa0e3c29591",
+                "history": 252,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "# Inspecting a Job\nTo check a Job's status, run the following command:"
                 }
               },
-              {
-                "startTime": 1599153274206,
-                "startEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/#",
-                  "command": "#   # Inspecting a Job\\nTo check a Job's status, run the following command:",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
+              "responseType": "ScalarResponse",
+              "historyIdx": 252
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "cbb4ce37-e7b9-4e0a-a63a-3aa0e3c29591",
+            "startTime": "2020-09-30T18:29:44.386Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          },
+          {
+            "response": true,
+            "historyIdx": 253,
+            "cwd": "~/Workspace7/kui",
+            "command": "kubectl describe job pi",
+            "startEvent": {
+              "route": "/kubeui/kubectl/describe",
+              "command": "kubectl describe job pi",
+              "evaluatorOptions": {
+                "flags": {
+                  "configuration": {
+                    "short-option-groups": false,
+                    "duplicate-arguments-array": false
                   },
-                  "execType": 1,
-                  "execUUID": "aef1c800-a0b7-4d4b-b1ba-7980aac86860",
-                  "echo": true
+                  "narg": {
+                    "w": 0,
+                    "watch": 0,
+                    "watch-only": 0
+                  },
+                  "boolean": [
+                    "w",
+                    "watch",
+                    "watch-only",
+                    "A",
+                    "all-namespaces",
+                    "ignore-not-found",
+                    "no-headers",
+                    "i",
+                    "it",
+                    "ti",
+                    "stdin",
+                    "t",
+                    "tty",
+                    "R",
+                    "recursive",
+                    "server-print",
+                    "show-kind",
+                    "show-labels"
+                  ]
                 },
-                "completeEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 1,
-                  "command": "#  # Inspecting a Job\\nTo check a Job's status, run the following command:",
-                  "argvNoOptions": ["#", "   # Inspecting a Job\\nTo check a Job's status, run the following command:"],
-                  "parsedOptions": {
-                    "_": ["#", "   # Inspecting a Job\\nTo check a Job's status, run the following command:"]
+                "plugin": "plugin-kubectl"
+              },
+              "execType": 0,
+              "execUUID": "c50665ea-a834-4d37-823b-4595953c8554"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "kubectl describe job pi",
+              "argvNoOptions": ["kubectl", "describe", "job", "pi"],
+              "parsedOptions": {
+                "_": ["kubectl", "describe", "job", "pi"]
+              },
+              "execUUID": "c50665ea-a834-4d37-823b-4595953c8554",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "plugin": "plugin-kubectl"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "c50665ea-a834-4d37-823b-4595953c8554",
+                "history": 253,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "batch/v1",
+                "kind": "Job",
+                "metadata": {
+                  "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"annotations\":{},\"name\":\"pi\",\"namespace\":\"demo\"},\"spec\":{\"backoffLimit\":4,\"completions\":20,\"parallelism\":4,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
                   },
-                  "execUUID": "aef1c800-a0b7-4d4b-b1ba-7980aac86860",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
+                  "creationTimestamp": "2020-08-26T16:41:55Z",
+                  "labels": {
+                    "controller-uid": "2403b972-ad67-4e73-8f6b-d3bdab795f70",
+                    "job-name": "pi"
                   },
+                  "name": "pi",
+                  "namespace": "demo",
+                  "resourceVersion": "25654",
+                  "selfLink": "/apis/batch/v1/namespaces/demo/jobs/pi",
+                  "uid": "2403b972-ad67-4e73-8f6b-d3bdab795f70"
+                },
+                "spec": {
+                  "backoffLimit": 4,
+                  "completions": 20,
+                  "parallelism": 4,
+                  "selector": {
+                    "matchLabels": {
+                      "controller-uid": "2403b972-ad67-4e73-8f6b-d3bdab795f70"
+                    }
+                  },
+                  "template": {
+                    "metadata": {
+                      "creationTimestamp": null,
+                      "labels": {
+                        "controller-uid": "2403b972-ad67-4e73-8f6b-d3bdab795f70",
+                        "job-name": "pi"
+                      }
+                    },
+                    "spec": {
+                      "containers": [
+                        {
+                          "command": ["perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"],
+                          "image": "perl",
+                          "imagePullPolicy": "Always",
+                          "name": "pi",
+                          "resources": {},
+                          "terminationMessagePath": "/dev/termination-log",
+                          "terminationMessagePolicy": "File"
+                        }
+                      ],
+                      "dnsPolicy": "ClusterFirst",
+                      "restartPolicy": "Never",
+                      "schedulerName": "default-scheduler",
+                      "securityContext": {},
+                      "terminationGracePeriodSeconds": 30
+                    }
+                  }
+                },
+                "status": {
+                  "completionTime": "2020-08-26T16:44:04Z",
+                  "conditions": [
+                    {
+                      "lastProbeTime": "2020-08-26T16:44:04Z",
+                      "lastTransitionTime": "2020-08-26T16:44:04Z",
+                      "status": "True",
+                      "type": "Complete"
+                    }
+                  ],
+                  "startTime": "2020-08-26T16:41:56Z",
+                  "succeeded": 20
+                },
+                "isKubeResource": true,
+                "originatingCommand": {
+                  "REPL": {},
+                  "argv": ["kubectl", "describe", "job", "pi"],
+                  "command": "kubectl describe job pi",
                   "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "aef1c800-a0b7-4d4b-b1ba-7980aac86860",
+                    "type": 0,
+                    "language": "en-US",
+                    "execUUID": "c50665ea-a834-4d37-823b-4595953c8554",
                     "history": 253,
                     "env": {}
                   },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "# Inspecting a Job\nTo check a Job's status, run the following command:"
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 253
-                }
-              },
-              {
-                "startTime": 1599153274279,
-                "startEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/kubeui/kubectl/describe",
-                  "command": "kubectl describe job pi",
-                  "evaluatorOptions": {
-                    "flags": {
-                      "configuration": {
-                        "short-option-groups": false,
-                        "duplicate-arguments-array": false
-                      },
-                      "narg": {
-                        "w": 0,
-                        "watch": 0,
-                        "watch-only": 0
-                      },
-                      "boolean": [
-                        "w",
-                        "watch",
-                        "watch-only",
-                        "A",
-                        "all-namespaces",
-                        "ignore-not-found",
-                        "no-headers",
-                        "i",
-                        "it",
-                        "ti",
-                        "stdin",
-                        "t",
-                        "tty",
-                        "R",
-                        "recursive",
-                        "server-print",
-                        "show-kind",
-                        "show-labels"
-                      ]
-                    },
-                    "plugin": "plugin-kubectl"
-                  },
-                  "execType": 1,
-                  "execUUID": "a54cc208-73cf-4b6e-a35c-895be6d6b0a6",
-                  "echo": true
-                },
-                "completeEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 1,
-                  "command": "kubectl describe job pi",
                   "argvNoOptions": ["kubectl", "describe", "job", "pi"],
                   "parsedOptions": {
                     "_": ["kubectl", "describe", "job", "pi"]
-                  },
-                  "execUUID": "a54cc208-73cf-4b6e-a35c-895be6d6b0a6",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {
-                    "plugin": "plugin-kubectl"
-                  },
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "a54cc208-73cf-4b6e-a35c-895be6d6b0a6",
-                    "history": 254,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "batch/v1",
-                    "kind": "Job",
-                    "metadata": {
-                      "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"annotations\":{},\"name\":\"pi\",\"namespace\":\"default\"},\"spec\":{\"backoffLimit\":4,\"completions\":20,\"parallelism\":4,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n"
-                      },
-                      "creationTimestamp": "2020-08-31T20:03:26Z",
-                      "labels": {
-                        "controller-uid": "78839850-f90e-4325-a9e2-7eb2bfaaf107",
-                        "job-name": "pi"
-                      },
-                      "name": "pi",
-                      "namespace": "default",
-                      "resourceVersion": "76469112",
-                      "selfLink": "/apis/batch/v1/namespaces/default/jobs/pi",
-                      "uid": "78839850-f90e-4325-a9e2-7eb2bfaaf107"
-                    },
-                    "spec": {
-                      "backoffLimit": 4,
-                      "completions": 20,
-                      "parallelism": 4,
-                      "selector": {
-                        "matchLabels": {
-                          "controller-uid": "78839850-f90e-4325-a9e2-7eb2bfaaf107"
-                        }
-                      },
-                      "template": {
-                        "metadata": {
-                          "creationTimestamp": null,
-                          "labels": {
-                            "controller-uid": "78839850-f90e-4325-a9e2-7eb2bfaaf107",
-                            "job-name": "pi"
-                          }
-                        },
-                        "spec": {
-                          "containers": [
-                            {
-                              "command": ["perl", "-Mbignum=bpi", "-wle", "print bpi(2000)"],
-                              "image": "perl",
-                              "imagePullPolicy": "Always",
-                              "name": "pi",
-                              "resources": {},
-                              "terminationMessagePath": "/dev/termination-log",
-                              "terminationMessagePolicy": "File"
-                            }
-                          ],
-                          "dnsPolicy": "ClusterFirst",
-                          "restartPolicy": "Never",
-                          "schedulerName": "default-scheduler",
-                          "securityContext": {},
-                          "terminationGracePeriodSeconds": 30
-                        }
-                      }
-                    },
-                    "status": {
-                      "completionTime": "2020-08-31T20:04:22Z",
-                      "conditions": [
-                        {
-                          "lastProbeTime": "2020-08-31T20:04:22Z",
-                          "lastTransitionTime": "2020-08-31T20:04:22Z",
-                          "status": "True",
-                          "type": "Complete"
-                        }
-                      ],
-                      "startTime": "2020-08-31T20:03:26Z",
-                      "succeeded": 20
-                    },
-                    "isKubeResource": true,
-                    "originatingCommand": {
-                      "REPL": {},
-                      "argv": ["kubectl", "describe", "job", "pi"],
-                      "command": "kubectl describe job pi",
-                      "execOptions": {
-                        "echo": true,
-                        "type": 1,
-                        "execUUID": "a54cc208-73cf-4b6e-a35c-895be6d6b0a6",
-                        "history": 254,
-                        "env": {}
-                      },
-                      "argvNoOptions": ["kubectl", "describe", "job", "pi"],
-                      "parsedOptions": {
-                        "_": ["kubectl", "describe", "job", "pi"]
-                      }
-                    },
-                    "kuiRawData": "apiVersion: batch/v1\nkind: Job\nmetadata:\n  annotations:\n    kubectl.kubernetes.io/last-applied-configuration: |\n      {\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"annotations\":{},\"name\":\"pi\",\"namespace\":\"default\"},\"spec\":{\"backoffLimit\":4,\"completions\":20,\"parallelism\":4,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n  creationTimestamp: \"2020-08-31T20:03:26Z\"\n  labels:\n    controller-uid: 78839850-f90e-4325-a9e2-7eb2bfaaf107\n    job-name: pi\n  name: pi\n  namespace: default\n  resourceVersion: \"76469112\"\n  selfLink: /apis/batch/v1/namespaces/default/jobs/pi\n  uid: 78839850-f90e-4325-a9e2-7eb2bfaaf107\nspec:\n  backoffLimit: 4\n  completions: 20\n  parallelism: 4\n  selector:\n    matchLabels:\n      controller-uid: 78839850-f90e-4325-a9e2-7eb2bfaaf107\n  template:\n    metadata:\n      creationTimestamp: null\n      labels:\n        controller-uid: 78839850-f90e-4325-a9e2-7eb2bfaaf107\n        job-name: pi\n    spec:\n      containers:\n      - command:\n        - perl\n        - -Mbignum=bpi\n        - -wle\n        - print bpi(2000)\n        image: perl\n        imagePullPolicy: Always\n        name: pi\n        resources: {}\n        terminationMessagePath: /dev/termination-log\n        terminationMessagePolicy: File\n      dnsPolicy: ClusterFirst\n      restartPolicy: Never\n      schedulerName: default-scheduler\n      securityContext: {}\n      terminationGracePeriodSeconds: 30\nstatus:\n  completionTime: \"2020-08-31T20:04:22Z\"\n  conditions:\n  - lastProbeTime: \"2020-08-31T20:04:22Z\"\n    lastTransitionTime: \"2020-08-31T20:04:22Z\"\n    status: \"True\"\n    type: Complete\n  startTime: \"2020-08-31T20:03:26Z\"\n  succeeded: 20\n",
-                    "toolbarText": {
-                      "type": "info",
-                      "text": "Created on **8/31/2020, 4:03:26 PM**. Showing resource version **76469112**."
-                    },
-                    "onclick": {
-                      "kind": "kubectl get Job.v1.batch -n default",
-                      "name": "kubectl get Job.v1.batch -n default pi",
-                      "namespace": "kubectl get ns default -o yaml"
-                    },
-                    "modes": []
-                  },
-                  "responseType": "MultiModalResponse",
-                  "historyIdx": 254
-                }
-              },
-              {
-                "startTime": 1599153274731,
-                "startEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/#",
-                  "command": "#   To view all Pod resources in your cluster, including Pods created by the Job which have completed, run:",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 1,
-                  "execUUID": "efc15dcc-3667-4f36-9ca7-52fffb378a3c",
-                  "echo": true
+                  }
                 },
-                "completeEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 1,
-                  "command": "#  To view all Pod resources in your cluster, including Pods created by the Job which have completed, run:",
-                  "argvNoOptions": [
-                    "#",
-                    "   To view all Pod resources in your cluster, including Pods created by the Job which have completed, run:"
-                  ],
-                  "parsedOptions": {
-                    "_": [
-                      "#",
-                      "   To view all Pod resources in your cluster, including Pods created by the Job which have completed, run:"
-                    ]
-                  },
-                  "execUUID": "efc15dcc-3667-4f36-9ca7-52fffb378a3c",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "efc15dcc-3667-4f36-9ca7-52fffb378a3c",
-                    "history": 255,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "To view all Pod resources in your cluster, including Pods created by the Job which have completed, run:"
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 255
-                }
-              },
-              {
-                "startTime": 1599153274794,
-                "startEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/kubeui/kubectl/get",
-                  "command": "kubectl get pods -A",
-                  "evaluatorOptions": {
-                    "flags": {
-                      "configuration": {
-                        "short-option-groups": false,
-                        "duplicate-arguments-array": false
-                      },
-                      "narg": {
-                        "w": 0,
-                        "watch": 0,
-                        "watch-only": 0
-                      },
-                      "boolean": [
-                        "w",
-                        "watch",
-                        "watch-only",
-                        "A",
-                        "all-namespaces",
-                        "ignore-not-found",
-                        "no-headers",
-                        "i",
-                        "it",
-                        "ti",
-                        "stdin",
-                        "t",
-                        "tty",
-                        "R",
-                        "recursive",
-                        "server-print",
-                        "show-kind",
-                        "show-labels"
-                      ]
-                    },
-                    "plugin": "plugin-kubectl"
-                  },
-                  "execType": 1,
-                  "execUUID": "9723f84c-9d32-436d-8c14-d7c6ec1bf508",
-                  "echo": true
+                "kuiRawData": "apiVersion: batch/v1\nkind: Job\nmetadata:\n  annotations:\n    kubectl.kubernetes.io/last-applied-configuration: |\n      {\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"annotations\":{},\"name\":\"pi\",\"namespace\":\"demo\"},\"spec\":{\"backoffLimit\":4,\"completions\":20,\"parallelism\":4,\"template\":{\"spec\":{\"containers\":[{\"command\":[\"perl\",\"-Mbignum=bpi\",\"-wle\",\"print bpi(2000)\"],\"image\":\"perl\",\"name\":\"pi\"}],\"restartPolicy\":\"Never\"}}}}\n  creationTimestamp: \"2020-08-26T16:41:55Z\"\n  labels:\n    controller-uid: 2403b972-ad67-4e73-8f6b-d3bdab795f70\n    job-name: pi\n  name: pi\n  namespace: demo\n  resourceVersion: \"25654\"\n  selfLink: /apis/batch/v1/namespaces/demo/jobs/pi\n  uid: 2403b972-ad67-4e73-8f6b-d3bdab795f70\nspec:\n  backoffLimit: 4\n  completions: 20\n  parallelism: 4\n  selector:\n    matchLabels:\n      controller-uid: 2403b972-ad67-4e73-8f6b-d3bdab795f70\n  template:\n    metadata:\n      creationTimestamp: null\n      labels:\n        controller-uid: 2403b972-ad67-4e73-8f6b-d3bdab795f70\n        job-name: pi\n    spec:\n      containers:\n      - command:\n        - perl\n        - -Mbignum=bpi\n        - -wle\n        - print bpi(2000)\n        image: perl\n        imagePullPolicy: Always\n        name: pi\n        resources: {}\n        terminationMessagePath: /dev/termination-log\n        terminationMessagePolicy: File\n      dnsPolicy: ClusterFirst\n      restartPolicy: Never\n      schedulerName: default-scheduler\n      securityContext: {}\n      terminationGracePeriodSeconds: 30\nstatus:\n  completionTime: \"2020-08-26T16:44:04Z\"\n  conditions:\n  - lastProbeTime: \"2020-08-26T16:44:04Z\"\n    lastTransitionTime: \"2020-08-26T16:44:04Z\"\n    status: \"True\"\n    type: Complete\n  startTime: \"2020-08-26T16:41:56Z\"\n  succeeded: 20\n",
+                "toolbarText": {
+                  "type": "info",
+                  "text": "Created on **8/26/2020, 12:41:55 PM**. Showing resource version **25654**."
                 },
-                "completeEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 1,
-                  "command": "kubectl get pods -A",
-                  "argvNoOptions": ["kubectl", "get", "pods"],
-                  "parsedOptions": {
-                    "_": ["kubectl", "get", "pods"],
-                    "A": true
-                  },
-                  "execUUID": "9723f84c-9d32-436d-8c14-d7c6ec1bf508",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {
-                    "plugin": "plugin-kubectl"
-                  },
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "9723f84c-9d32-436d-8c14-d7c6ec1bf508",
-                    "history": 256,
-                    "env": {}
-                  },
-                  "response": {
-                    "header": {
-                      "key": "NAMESPACE",
-                      "name": "Namespace",
-                      "rowKey": "NAMESPACE-NAME",
-                      "fontawesome": false,
-                      "onclick": false,
-                      "onclickSilence": true,
-                      "css": "",
-                      "rowCSS": [],
-                      "outerCSS": "header-cell entity-name-group hide-with-sidecar not-a-name",
-                      "attributes": [
-                        {
-                          "key": "NAME",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell entity-name-group",
-                          "css": "  ",
-                          "value": "Name"
-                        },
-                        {
-                          "key": "READY",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell a-few-numbers-wide kui--hide-in-narrower-windows",
-                          "css": "  yellow-background",
-                          "value": "Ready"
-                        },
-                        {
-                          "key": "STATUS",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell ",
-                          "css": "  ",
-                          "value": "Status"
-                        },
-                        {
-                          "key": "RESTARTS",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell  hide-with-sidecar",
-                          "css": "  ",
-                          "value": "Restarts"
-                        },
-                        {
-                          "key": "AGE",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell hide-with-sidecar hide-with-sidecar",
-                          "css": "  ",
-                          "value": "Age"
-                        }
-                      ]
-                    },
-                    "body": [
-                      {
-                        "key": "NAMESPACE",
-                        "name": "3dd6fe0f-3f05-4919-afce-6156e72dedb3-kui",
-                        "rowKey": "3dd6fe0f-3f05-4919-afce-6156e72dedb3-kui-nginx",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod nginx -o yaml -n 3dd6fe0f-3f05-4919-afce-6156e72dedb3-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "nginx"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "16d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "436f7d95-2ec4-4e6b-a816-a5f3adfd06d3-kui",
-                        "rowKey": "436f7d95-2ec4-4e6b-a816-a5f3adfd06d3-kui-nginx",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod nginx -o yaml -n 436f7d95-2ec4-4e6b-a816-a5f3adfd06d3-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "nginx"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "16d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "5bccd177-e0be-4511-81f8-2fcfd3d896af-kui",
-                        "rowKey": "5bccd177-e0be-4511-81f8-2fcfd3d896af-kui-nginx",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod nginx -o yaml -n 5bccd177-e0be-4511-81f8-2fcfd3d896af-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "nginx"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "15d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-2cf7b",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-2cf7b -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-2cf7b"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-6fwsd",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-6fwsd -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-6fwsd"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-77r9g",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-77r9g -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-77r9g"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-8lg2t",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-8lg2t -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-8lg2t"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-9j542",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-9j542 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-9j542"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-bfslr",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-bfslr -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-bfslr"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-bh658",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-bh658 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-bh658"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-bl425",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-bl425 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-bl425"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-fcbsm",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-fcbsm -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-fcbsm"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-fxjxr",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-fxjxr -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-fxjxr"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-gvf5v",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-gvf5v -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-gvf5v"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-hm6d8",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-hm6d8 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-hm6d8"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-jchbl",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-jchbl -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-jchbl"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-kcxw2",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-kcxw2 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-kcxw2"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-rqxbl",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-rqxbl -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-rqxbl"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-tdb7p",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-tdb7p -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-tdb7p"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-vxptg",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-vxptg -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-vxptg"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-wp7pj",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-wp7pj -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-wp7pj"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-x9szj",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-x9szj -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-x9szj"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
-                        "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-xf4wp",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-xf4wp -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-xf4wp"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "7b72fdf7-28a9-4484-83ef-0d92cc948c33-kui",
-                        "rowKey": "7b72fdf7-28a9-4484-83ef-0d92cc948c33-kui-myapp-6446557848-6m9c7",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod myapp-6446557848-6m9c7 -o yaml -n 7b72fdf7-28a9-4484-83ef-0d92cc948c33-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "myapp-6446557848-6m9c7"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "16h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "8b29341c-1c5a-47a1-a75d-e0507292238a-kui",
-                        "rowKey": "8b29341c-1c5a-47a1-a75d-e0507292238a-kui-nginx",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod nginx -o yaml -n 8b29341c-1c5a-47a1-a75d-e0507292238a-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "nginx"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "16d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "96880667-44ae-4e9f-86f2-68bf2fa0cba3-kui",
-                        "rowKey": "96880667-44ae-4e9f-86f2-68bf2fa0cba3-kui-myapp-6446557848-dltm4",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod myapp-6446557848-dltm4 -o yaml -n 96880667-44ae-4e9f-86f2-68bf2fa0cba3-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "myapp-6446557848-dltm4"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "15d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "acff6bec-0dc6-408b-9872-025a752aaa2b-kui",
-                        "rowKey": "acff6bec-0dc6-408b-9872-025a752aaa2b-kui-nginx",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod nginx -o yaml -n acff6bec-0dc6-408b-9872-025a752aaa2b-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "nginx"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "15d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "b2906106-80f8-45fc-ae2f-e47bcc1d0799-kui",
-                        "rowKey": "b2906106-80f8-45fc-ae2f-e47bcc1d0799-kui-nginx",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod nginx -o yaml -n b2906106-80f8-45fc-ae2f-e47bcc1d0799-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "nginx"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "16d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "c33beae1-25d5-4eac-80af-66352dfb0e97-kui",
-                        "rowKey": "c33beae1-25d5-4eac-80af-66352dfb0e97-kui-myapp-6446557848-pj89x",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod myapp-6446557848-pj89x -o yaml -n c33beae1-25d5-4eac-80af-66352dfb0e97-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "myapp-6446557848-pj89x"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "16h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "dce34466-1db6-48cc-b0ff-57c502d92fa4-kui",
-                        "rowKey": "dce34466-1db6-48cc-b0ff-57c502d92fa4-kui-myapp-6446557848-ml9m8",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod myapp-6446557848-ml9m8 -o yaml -n dce34466-1db6-48cc-b0ff-57c502d92fa4-kui ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "myapp-6446557848-ml9m8"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "16h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-details-v1-68c7c8666d-8c78v",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod details-v1-68c7c8666d-8c78v -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "details-v1-68c7c8666d-8c78v"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-kui-deployment-577db4b45b-4fltz",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod kui-deployment-577db4b45b-4fltz -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "kui-deployment-577db4b45b-4fltz"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-kui-ui-7b946968df-n7kj8",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod kui-ui-7b946968df-n7kj8 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "kui-ui-7b946968df-n7kj8"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "2/2"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-myapp-7d449c8db4-96xwm",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod myapp-7d449c8db4-96xwm -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "myapp-7d449c8db4-96xwm"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-nginx",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod nginx -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "nginx"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "16d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-nginx-deployment-7fd6966748-jsp4j",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod nginx-deployment-7fd6966748-jsp4j -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "nginx-deployment-7fd6966748-jsp4j"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-nginx-deployment-7fd6966748-k4bxc",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod nginx-deployment-7fd6966748-k4bxc -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "nginx-deployment-7fd6966748-k4bxc"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-nginx-deployment-7fd6966748-q56lw",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod nginx-deployment-7fd6966748-q56lw -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "nginx-deployment-7fd6966748-q56lw"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-opining-ibex-mychart-646f6b5f77-mhzlk",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod opining-ibex-mychart-646f6b5f77-mhzlk -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "opining-ibex-mychart-646f6b5f77-mhzlk"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-5cgk4",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-5cgk4 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-5cgk4"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-5pfck",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-5pfck -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-5pfck"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-7bstz",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-7bstz -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-7bstz"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-8msfn",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-8msfn -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-8msfn"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-99swq",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-99swq -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-99swq"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-bjf8g",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-bjf8g -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-bjf8g"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-chbzt",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-chbzt -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-chbzt"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-f9cb9",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-f9cb9 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-f9cb9"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-km5mq",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-km5mq -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-km5mq"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-mpzth",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-mpzth -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-mpzth"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-mr6zd",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-mr6zd -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-mr6zd"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-qz6hn",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-qz6hn -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-qz6hn"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-r5t9j",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-r5t9j -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-r5t9j"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-rb647",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-rb647 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-rb647"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-s9l95",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-s9l95 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-s9l95"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-sfplv",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-sfplv -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-sfplv"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-vhmlh",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-vhmlh -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-vhmlh"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-vpwq8",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-vpwq8 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-vpwq8"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-vw4qb",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-vw4qb -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-vw4qb"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi-z9845",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi-z9845 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi-z9845"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d21h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-29mbp",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-29mbp -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-29mbp"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-2glnx",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-2glnx -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-2glnx"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-2qvdb",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-2qvdb -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-2qvdb"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-2wj7k",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-2wj7k -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-2wj7k"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-48zw8",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-48zw8 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-48zw8"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-58kdg",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-58kdg -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-58kdg"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-6kpd5",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-6kpd5 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-6kpd5"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-6q7jn",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-6q7jn -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-6q7jn"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-d2v2k",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-d2v2k -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-d2v2k"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-hwmvg",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-hwmvg -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-hwmvg"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-mkfkl",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-mkfkl -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-mkfkl"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-mq427",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-mq427 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-mq427"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-rs9dq",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-rs9dq -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-rs9dq"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-t5bnw",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-t5bnw -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-t5bnw"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-tqp6d",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-tqp6d -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-tqp6d"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-vjbcs",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-vjbcs -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-vjbcs"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-vx5z5",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-vx5z5 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-vx5z5"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-vz59r",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-vz59r -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-vz59r"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-wblj9",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-wblj9 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-wblj9"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pi2-zzl6c",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pi2-zzl6c -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pi2-zzl6c"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  gray-background",
-                            "value": "Completed"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "14d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-productpage-v1-54d799c966-fjz5b",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod productpage-v1-54d799c966-fjz5b -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "productpage-v1-54d799c966-fjz5b"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-pugnacious-abalone-nginx-7f4889cdcb-b9gnq",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod pugnacious-abalone-nginx-7f4889cdcb-b9gnq -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "pugnacious-abalone-nginx-7f4889cdcb-b9gnq"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-ratings-v1-8558d4458d-qqhp6",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod ratings-v1-8558d4458d-qqhp6 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "ratings-v1-8558d4458d-qqhp6"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-reviews-v1-cb8655c75-2n5sj",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod reviews-v1-cb8655c75-2n5sj -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "reviews-v1-cb8655c75-2n5sj"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-reviews-v2-7fc9bb6dcf-r9gnk",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod reviews-v2-7fc9bb6dcf-r9gnk -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "reviews-v2-7fc9bb6dcf-r9gnk"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-reviews-v3-c995979bc-mnbq9",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod reviews-v3-c995979bc-mnbq9 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "reviews-v3-c995979bc-mnbq9"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "default",
-                        "rowKey": "default-test-release-mysql-746846c8fd-krnm6",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod test-release-mysql-746846c8fd-krnm6 -o yaml -n default ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "test-release-mysql-746846c8fd-krnm6"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "ibm-system",
-                        "rowKey": "ibm-system-addon-catalog-source-ld52x",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod addon-catalog-source-ld52x -o yaml -n ibm-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "addon-catalog-source-ld52x"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d2h"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "ibm-system",
-                        "rowKey": "ibm-system-catalog-operator-67cbc5d959-wcjzk",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod catalog-operator-67cbc5d959-wcjzk -o yaml -n ibm-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "catalog-operator-67cbc5d959-wcjzk"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "ibm-system",
-                        "rowKey": "ibm-system-ibm-cloud-provider-ip-169-60-169-42-6d89f45598-fvchc",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod ibm-cloud-provider-ip-169-60-169-42-6d89f45598-fvchc -o yaml -n ibm-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "ibm-cloud-provider-ip-169-60-169-42-6d89f45598-fvchc"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "ibm-system",
-                        "rowKey": "ibm-system-ibm-cloud-provider-ip-169-60-169-42-6d89f45598-kz8l4",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod ibm-cloud-provider-ip-169-60-169-42-6d89f45598-kz8l4 -o yaml -n ibm-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "ibm-cloud-provider-ip-169-60-169-42-6d89f45598-kz8l4"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "ibm-system",
-                        "rowKey": "ibm-system-ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-5ss7h",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-5ss7h -o yaml -n ibm-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-5ss7h"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "ibm-system",
-                        "rowKey": "ibm-system-ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-jph8s",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-jph8s -o yaml -n ibm-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-jph8s"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "ibm-system",
-                        "rowKey": "ibm-system-olm-operator-6f74dfc868-5m47h",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod olm-operator-6f74dfc868-5m47h -o yaml -n ibm-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "olm-operator-6f74dfc868-5m47h"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "istio-system",
-                        "rowKey": "istio-system-kiali-568997dcdb-dtmvn",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod kiali-568997dcdb-dtmvn -o yaml -n istio-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "kiali-568997dcdb-dtmvn"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  yellow-background",
-                            "value": "0/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  yellow-background",
-                            "value": "ContainerCreating"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-calico-kube-controllers-54c66c7555-q2ksx",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod calico-kube-controllers-54c66c7555-q2ksx -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "calico-kube-controllers-54c66c7555-q2ksx"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-calico-node-h2ddn",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod calico-node-h2ddn -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "calico-node-h2ddn"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-calico-node-vmhgf",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod calico-node-vmhgf -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "calico-node-vmhgf"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-coredns-6d96d4784-48qf2",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod coredns-6d96d4784-48qf2 -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "coredns-6d96d4784-48qf2"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-coredns-6d96d4784-gxgx6",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod coredns-6d96d4784-gxgx6 -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "coredns-6d96d4784-gxgx6"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-coredns-autoscaler-777bf994bf-jp8m9",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod coredns-autoscaler-777bf994bf-jp8m9 -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "coredns-autoscaler-777bf994bf-jp8m9"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-dashboard-metrics-scraper-76756886dc-msh7z",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod dashboard-metrics-scraper-76756886dc-msh7z -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "dashboard-metrics-scraper-76756886dc-msh7z"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-ibm-file-plugin-86b7cd9c54-pzrck",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod ibm-file-plugin-86b7cd9c54-pzrck -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "ibm-file-plugin-86b7cd9c54-pzrck"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "9d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-ibm-keepalived-watcher-n7866",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod ibm-keepalived-watcher-n7866 -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "ibm-keepalived-watcher-n7866"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-ibm-keepalived-watcher-psxdc",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod ibm-keepalived-watcher-psxdc -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "ibm-keepalived-watcher-psxdc"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-ibm-master-proxy-static-10.73.230.194",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod ibm-master-proxy-static-10.73.230.194 -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "ibm-master-proxy-static-10.73.230.194"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "2/2"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-ibm-master-proxy-static-10.73.230.207",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod ibm-master-proxy-static-10.73.230.207 -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "ibm-master-proxy-static-10.73.230.207"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "2/2"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-ibm-storage-watcher-7f4c95cf97-nbf67",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod ibm-storage-watcher-7f4c95cf97-nbf67 -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "ibm-storage-watcher-7f4c95cf97-nbf67"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "9d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-kubernetes-dashboard-85b945ff4b-pv27f",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod kubernetes-dashboard-85b945ff4b-pv27f -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "kubernetes-dashboard-85b945ff4b-pv27f"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  green-background",
-                            "value": "1"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-metrics-server-84f999b67b-9nfdr",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod metrics-server-84f999b67b-9nfdr -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "metrics-server-84f999b67b-9nfdr"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "2/2"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "9d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-5gqks",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-5gqks -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-5gqks"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "4/4"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-srfjx",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-srfjx -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-srfjx"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "4/4"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-tiller-deploy-8557598fbc-d4xf4",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod tiller-deploy-8557598fbc-d4xf4 -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "tiller-deploy-8557598fbc-d4xf4"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "kube-system",
-                        "rowKey": "kube-system-vpn-86875c5bdb-kj8b7",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod vpn-86875c5bdb-kj8b7 -o yaml -n kube-system ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "vpn-86875c5bdb-kj8b7"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "tekton-pipelines",
-                        "rowKey": "tekton-pipelines-tekton-pipelines-controller-7bf66fcb4f-k42fj",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod tekton-pipelines-controller-7bf66fcb4f-k42fj -o yaml -n tekton-pipelines ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "tekton-pipelines-controller-7bf66fcb4f-k42fj"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "18d"
-                          }
-                        ]
-                      },
-                      {
-                        "key": "NAMESPACE",
-                        "name": "tekton-pipelines",
-                        "rowKey": "tekton-pipelines-tekton-pipelines-webhook-cd747db44-5fcfn",
-                        "fontawesome": false,
-                        "onclick": false,
-                        "onclickSilence": true,
-                        "css": "",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
-                        "attributes": [
-                          {
-                            "key": "NAME",
-                            "onclick": "kubectl get Pod tekton-pipelines-webhook-cd747db44-5fcfn -o yaml -n tekton-pipelines ",
-                            "outerCSS": " entity-name-group",
-                            "css": " entity-name ",
-                            "value": "tekton-pipelines-webhook-cd747db44-5fcfn"
-                          },
-                          {
-                            "key": "READY",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " ",
-                            "css": "  green-background",
-                            "value": "Running"
-                          },
-                          {
-                            "key": "RESTARTS",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "2d5h"
-                          }
-                        ]
-                      }
-                    ],
-                    "noSort": true,
-                    "title": "Pod",
-                    "breadcrumbs": [
-                      {
-                        "label": "all"
-                      }
-                    ],
-                    "statusColumnIdx": 2
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 256
-                }
-              },
-              {
-                "startTime": 1599153275880,
-                "startEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/#",
-                  "command": "#   The -A flag specifies that all resources of the type specified (in this case, Pods) should be shown.",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        {
-                          "name": "--title",
-                          "alias": "-t",
-                          "docs": "Title for the commentary"
-                        },
-                        {
-                          "name": "--file",
-                          "alias": "-f",
-                          "docs": "File that contains the texts"
-                        }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 1,
-                  "execUUID": "9fe0678c-68eb-4553-ae51-144c136e8fc0",
-                  "echo": true
+                "onclick": {
+                  "kind": "kubectl get Job.v1.batch -n demo",
+                  "name": "kubectl get Job.v1.batch -n demo pi",
+                  "namespace": "kubectl get ns demo -o yaml"
                 },
-                "completeEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 1,
-                  "command": "#  The -A flag specifies that all resources of the type specified (in this case, Pods) should be shown.",
-                  "argvNoOptions": [
-                    "#",
-                    "   The -A flag specifies that all resources of the type specified (in this case, Pods) should be shown."
-                  ],
-                  "parsedOptions": {
-                    "_": [
-                      "#",
-                      "   The -A flag specifies that all resources of the type specified (in this case, Pods) should be shown."
-                    ]
-                  },
-                  "execUUID": "9fe0678c-68eb-4553-ae51-144c136e8fc0",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                    "execUUID": "9fe0678c-68eb-4553-ae51-144c136e8fc0",
-                    "history": 257,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "The -A flag specifies that all resources of the type specified (in this case, Pods) should be shown."
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 257
-                }
+                "modes": []
+              },
+              "responseType": "MultiModalResponse",
+              "historyIdx": 253
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "c50665ea-a834-4d37-823b-4595953c8554",
+            "startTime": "2020-09-30T18:29:53.433Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": false,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "To view all Pod resources in your cluster, including Pods created by the Job which have completed, run:"
               }
-            ]
+            },
+            "historyIdx": 254,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "6c10bc19-d994-49df-833e-4c2ed7400799"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "6c10bc19-d994-49df-833e-4c2ed7400799",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "6c10bc19-d994-49df-833e-4c2ed7400799",
+                "history": 254,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "To view all Pod resources in your cluster, including Pods created by the Job which have completed, run:"
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 254
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "6c10bc19-d994-49df-833e-4c2ed7400799",
+            "startTime": "2020-09-30T18:30:02.617Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "header": {
+                "key": "NAMESPACE",
+                "name": "Namespace",
+                "rowKey": "NAMESPACE-NAME",
+                "fontawesome": false,
+                "onclick": false,
+                "onclickSilence": true,
+                "css": "",
+                "rowCSS": [],
+                "outerCSS": "header-cell entity-name-group hide-with-sidecar not-a-name",
+                "attributes": [
+                  {
+                    "key": "NAME",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell entity-name-group",
+                    "css": "  ",
+                    "value": "Name"
+                  },
+                  {
+                    "key": "READY",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell a-few-numbers-wide kui--hide-in-narrower-windows",
+                    "css": "  yellow-background",
+                    "value": "Ready"
+                  },
+                  {
+                    "key": "STATUS",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell ",
+                    "css": "  ",
+                    "value": "Status"
+                  },
+                  {
+                    "key": "RESTARTS",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell  hide-with-sidecar",
+                    "css": "  ",
+                    "value": "Restarts"
+                  },
+                  {
+                    "key": "AGE",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell hide-with-sidecar hide-with-sidecar",
+                    "css": "  ",
+                    "value": "Age"
+                  }
+                ]
+              },
+              "body": [
+                {
+                  "key": "NAMESPACE",
+                  "name": "3dd6fe0f-3f05-4919-afce-6156e72dedb3-kui",
+                  "rowKey": "3dd6fe0f-3f05-4919-afce-6156e72dedb3-kui-nginx",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod nginx -o yaml -n 3dd6fe0f-3f05-4919-afce-6156e72dedb3-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "nginx"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "16d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "436f7d95-2ec4-4e6b-a816-a5f3adfd06d3-kui",
+                  "rowKey": "436f7d95-2ec4-4e6b-a816-a5f3adfd06d3-kui-nginx",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod nginx -o yaml -n 436f7d95-2ec4-4e6b-a816-a5f3adfd06d3-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "nginx"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "16d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "5bccd177-e0be-4511-81f8-2fcfd3d896af-kui",
+                  "rowKey": "5bccd177-e0be-4511-81f8-2fcfd3d896af-kui-nginx",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod nginx -o yaml -n 5bccd177-e0be-4511-81f8-2fcfd3d896af-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "nginx"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "15d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-2cf7b",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-2cf7b -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-2cf7b"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-6fwsd",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-6fwsd -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-6fwsd"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-77r9g",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-77r9g -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-77r9g"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-8lg2t",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-8lg2t -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-8lg2t"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-9j542",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-9j542 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-9j542"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-bfslr",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-bfslr -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-bfslr"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-bh658",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-bh658 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-bh658"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-bl425",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-bl425 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-bl425"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-fcbsm",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-fcbsm -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-fcbsm"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-fxjxr",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-fxjxr -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-fxjxr"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-gvf5v",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-gvf5v -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-gvf5v"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-hm6d8",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-hm6d8 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-hm6d8"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-jchbl",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-jchbl -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-jchbl"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-kcxw2",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-kcxw2 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-kcxw2"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-rqxbl",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-rqxbl -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-rqxbl"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-tdb7p",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-tdb7p -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-tdb7p"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-vxptg",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-vxptg -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-vxptg"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-wp7pj",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-wp7pj -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-wp7pj"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-x9szj",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-x9szj -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-x9szj"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                  "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-xf4wp",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-xf4wp -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-xf4wp"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "7b72fdf7-28a9-4484-83ef-0d92cc948c33-kui",
+                  "rowKey": "7b72fdf7-28a9-4484-83ef-0d92cc948c33-kui-myapp-6446557848-6m9c7",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod myapp-6446557848-6m9c7 -o yaml -n 7b72fdf7-28a9-4484-83ef-0d92cc948c33-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "myapp-6446557848-6m9c7"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "16h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "8b29341c-1c5a-47a1-a75d-e0507292238a-kui",
+                  "rowKey": "8b29341c-1c5a-47a1-a75d-e0507292238a-kui-nginx",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod nginx -o yaml -n 8b29341c-1c5a-47a1-a75d-e0507292238a-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "nginx"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "16d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "96880667-44ae-4e9f-86f2-68bf2fa0cba3-kui",
+                  "rowKey": "96880667-44ae-4e9f-86f2-68bf2fa0cba3-kui-myapp-6446557848-dltm4",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod myapp-6446557848-dltm4 -o yaml -n 96880667-44ae-4e9f-86f2-68bf2fa0cba3-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "myapp-6446557848-dltm4"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "15d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "acff6bec-0dc6-408b-9872-025a752aaa2b-kui",
+                  "rowKey": "acff6bec-0dc6-408b-9872-025a752aaa2b-kui-nginx",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod nginx -o yaml -n acff6bec-0dc6-408b-9872-025a752aaa2b-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "nginx"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "15d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "b2906106-80f8-45fc-ae2f-e47bcc1d0799-kui",
+                  "rowKey": "b2906106-80f8-45fc-ae2f-e47bcc1d0799-kui-nginx",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod nginx -o yaml -n b2906106-80f8-45fc-ae2f-e47bcc1d0799-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "nginx"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "16d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "c33beae1-25d5-4eac-80af-66352dfb0e97-kui",
+                  "rowKey": "c33beae1-25d5-4eac-80af-66352dfb0e97-kui-myapp-6446557848-pj89x",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod myapp-6446557848-pj89x -o yaml -n c33beae1-25d5-4eac-80af-66352dfb0e97-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "myapp-6446557848-pj89x"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "16h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "dce34466-1db6-48cc-b0ff-57c502d92fa4-kui",
+                  "rowKey": "dce34466-1db6-48cc-b0ff-57c502d92fa4-kui-myapp-6446557848-ml9m8",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod myapp-6446557848-ml9m8 -o yaml -n dce34466-1db6-48cc-b0ff-57c502d92fa4-kui ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "myapp-6446557848-ml9m8"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "16h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-details-v1-68c7c8666d-8c78v",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod details-v1-68c7c8666d-8c78v -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "details-v1-68c7c8666d-8c78v"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-kui-deployment-577db4b45b-4fltz",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod kui-deployment-577db4b45b-4fltz -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "kui-deployment-577db4b45b-4fltz"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-kui-ui-7b946968df-n7kj8",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod kui-ui-7b946968df-n7kj8 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "kui-ui-7b946968df-n7kj8"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "2/2"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-myapp-7d449c8db4-96xwm",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod myapp-7d449c8db4-96xwm -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "myapp-7d449c8db4-96xwm"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-nginx",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod nginx -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "nginx"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "16d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-nginx-deployment-7fd6966748-jsp4j",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod nginx-deployment-7fd6966748-jsp4j -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "nginx-deployment-7fd6966748-jsp4j"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-nginx-deployment-7fd6966748-k4bxc",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod nginx-deployment-7fd6966748-k4bxc -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "nginx-deployment-7fd6966748-k4bxc"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-nginx-deployment-7fd6966748-q56lw",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod nginx-deployment-7fd6966748-q56lw -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "nginx-deployment-7fd6966748-q56lw"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-opining-ibex-mychart-646f6b5f77-mhzlk",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod opining-ibex-mychart-646f6b5f77-mhzlk -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "opining-ibex-mychart-646f6b5f77-mhzlk"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-5cgk4",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-5cgk4 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-5cgk4"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-5pfck",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-5pfck -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-5pfck"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-7bstz",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-7bstz -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-7bstz"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-8msfn",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-8msfn -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-8msfn"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-99swq",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-99swq -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-99swq"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-bjf8g",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-bjf8g -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-bjf8g"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-chbzt",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-chbzt -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-chbzt"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-f9cb9",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-f9cb9 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-f9cb9"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-km5mq",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-km5mq -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-km5mq"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-mpzth",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-mpzth -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-mpzth"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-mr6zd",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-mr6zd -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-mr6zd"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-qz6hn",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-qz6hn -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-qz6hn"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-r5t9j",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-r5t9j -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-r5t9j"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-rb647",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-rb647 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-rb647"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-s9l95",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-s9l95 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-s9l95"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-sfplv",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-sfplv -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-sfplv"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-vhmlh",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-vhmlh -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-vhmlh"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-vpwq8",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-vpwq8 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-vpwq8"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-vw4qb",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-vw4qb -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-vw4qb"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi-z9845",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi-z9845 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi-z9845"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d21h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-29mbp",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-29mbp -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-29mbp"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-2glnx",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-2glnx -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-2glnx"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-2qvdb",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-2qvdb -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-2qvdb"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-2wj7k",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-2wj7k -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-2wj7k"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-48zw8",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-48zw8 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-48zw8"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-58kdg",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-58kdg -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-58kdg"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-6kpd5",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-6kpd5 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-6kpd5"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-6q7jn",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-6q7jn -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-6q7jn"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-d2v2k",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-d2v2k -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-d2v2k"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-hwmvg",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-hwmvg -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-hwmvg"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-mkfkl",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-mkfkl -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-mkfkl"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-mq427",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-mq427 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-mq427"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-rs9dq",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-rs9dq -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-rs9dq"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-t5bnw",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-t5bnw -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-t5bnw"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-tqp6d",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-tqp6d -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-tqp6d"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-vjbcs",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-vjbcs -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-vjbcs"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-vx5z5",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-vx5z5 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-vx5z5"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-vz59r",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-vz59r -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-vz59r"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-wblj9",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-wblj9 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-wblj9"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pi2-zzl6c",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pi2-zzl6c -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pi2-zzl6c"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  gray-background",
+                      "value": "Completed"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "14d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-productpage-v1-54d799c966-fjz5b",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod productpage-v1-54d799c966-fjz5b -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "productpage-v1-54d799c966-fjz5b"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-pugnacious-abalone-nginx-7f4889cdcb-b9gnq",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod pugnacious-abalone-nginx-7f4889cdcb-b9gnq -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "pugnacious-abalone-nginx-7f4889cdcb-b9gnq"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-ratings-v1-8558d4458d-qqhp6",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod ratings-v1-8558d4458d-qqhp6 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "ratings-v1-8558d4458d-qqhp6"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-reviews-v1-cb8655c75-2n5sj",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod reviews-v1-cb8655c75-2n5sj -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "reviews-v1-cb8655c75-2n5sj"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-reviews-v2-7fc9bb6dcf-r9gnk",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod reviews-v2-7fc9bb6dcf-r9gnk -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "reviews-v2-7fc9bb6dcf-r9gnk"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-reviews-v3-c995979bc-mnbq9",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod reviews-v3-c995979bc-mnbq9 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "reviews-v3-c995979bc-mnbq9"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "default",
+                  "rowKey": "default-test-release-mysql-746846c8fd-krnm6",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod test-release-mysql-746846c8fd-krnm6 -o yaml -n default ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "test-release-mysql-746846c8fd-krnm6"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "ibm-system",
+                  "rowKey": "ibm-system-addon-catalog-source-ld52x",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod addon-catalog-source-ld52x -o yaml -n ibm-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "addon-catalog-source-ld52x"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d2h"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "ibm-system",
+                  "rowKey": "ibm-system-catalog-operator-67cbc5d959-wcjzk",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod catalog-operator-67cbc5d959-wcjzk -o yaml -n ibm-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "catalog-operator-67cbc5d959-wcjzk"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "ibm-system",
+                  "rowKey": "ibm-system-ibm-cloud-provider-ip-169-60-169-42-6d89f45598-fvchc",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod ibm-cloud-provider-ip-169-60-169-42-6d89f45598-fvchc -o yaml -n ibm-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "ibm-cloud-provider-ip-169-60-169-42-6d89f45598-fvchc"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "ibm-system",
+                  "rowKey": "ibm-system-ibm-cloud-provider-ip-169-60-169-42-6d89f45598-kz8l4",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod ibm-cloud-provider-ip-169-60-169-42-6d89f45598-kz8l4 -o yaml -n ibm-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "ibm-cloud-provider-ip-169-60-169-42-6d89f45598-kz8l4"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "ibm-system",
+                  "rowKey": "ibm-system-ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-5ss7h",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-5ss7h -o yaml -n ibm-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-5ss7h"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "ibm-system",
+                  "rowKey": "ibm-system-ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-jph8s",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-jph8s -o yaml -n ibm-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-jph8s"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "ibm-system",
+                  "rowKey": "ibm-system-olm-operator-6f74dfc868-5m47h",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod olm-operator-6f74dfc868-5m47h -o yaml -n ibm-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "olm-operator-6f74dfc868-5m47h"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "istio-system",
+                  "rowKey": "istio-system-kiali-568997dcdb-dtmvn",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod kiali-568997dcdb-dtmvn -o yaml -n istio-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "kiali-568997dcdb-dtmvn"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "0/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  yellow-background",
+                      "value": "ContainerCreating"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-calico-kube-controllers-54c66c7555-q2ksx",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod calico-kube-controllers-54c66c7555-q2ksx -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "calico-kube-controllers-54c66c7555-q2ksx"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-calico-node-h2ddn",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod calico-node-h2ddn -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "calico-node-h2ddn"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-calico-node-vmhgf",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod calico-node-vmhgf -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "calico-node-vmhgf"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-coredns-6d96d4784-48qf2",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod coredns-6d96d4784-48qf2 -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "coredns-6d96d4784-48qf2"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-coredns-6d96d4784-gxgx6",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod coredns-6d96d4784-gxgx6 -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "coredns-6d96d4784-gxgx6"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-coredns-autoscaler-777bf994bf-jp8m9",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod coredns-autoscaler-777bf994bf-jp8m9 -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "coredns-autoscaler-777bf994bf-jp8m9"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-dashboard-metrics-scraper-76756886dc-msh7z",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod dashboard-metrics-scraper-76756886dc-msh7z -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "dashboard-metrics-scraper-76756886dc-msh7z"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-ibm-file-plugin-86b7cd9c54-pzrck",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod ibm-file-plugin-86b7cd9c54-pzrck -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "ibm-file-plugin-86b7cd9c54-pzrck"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "9d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-ibm-keepalived-watcher-n7866",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod ibm-keepalived-watcher-n7866 -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "ibm-keepalived-watcher-n7866"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-ibm-keepalived-watcher-psxdc",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod ibm-keepalived-watcher-psxdc -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "ibm-keepalived-watcher-psxdc"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-ibm-master-proxy-static-10.73.230.194",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod ibm-master-proxy-static-10.73.230.194 -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "ibm-master-proxy-static-10.73.230.194"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "2/2"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-ibm-master-proxy-static-10.73.230.207",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod ibm-master-proxy-static-10.73.230.207 -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "ibm-master-proxy-static-10.73.230.207"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "2/2"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-ibm-storage-watcher-7f4c95cf97-nbf67",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod ibm-storage-watcher-7f4c95cf97-nbf67 -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "ibm-storage-watcher-7f4c95cf97-nbf67"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "9d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-kubernetes-dashboard-85b945ff4b-pv27f",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod kubernetes-dashboard-85b945ff4b-pv27f -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "kubernetes-dashboard-85b945ff4b-pv27f"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  green-background",
+                      "value": "1"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-metrics-server-84f999b67b-9nfdr",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod metrics-server-84f999b67b-9nfdr -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "metrics-server-84f999b67b-9nfdr"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "2/2"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "9d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-5gqks",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-5gqks -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-5gqks"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "4/4"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-srfjx",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-srfjx -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-srfjx"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "4/4"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-tiller-deploy-8557598fbc-d4xf4",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod tiller-deploy-8557598fbc-d4xf4 -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "tiller-deploy-8557598fbc-d4xf4"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "kube-system",
+                  "rowKey": "kube-system-vpn-86875c5bdb-kj8b7",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod vpn-86875c5bdb-kj8b7 -o yaml -n kube-system ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "vpn-86875c5bdb-kj8b7"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "tekton-pipelines",
+                  "rowKey": "tekton-pipelines-tekton-pipelines-controller-7bf66fcb4f-k42fj",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod tekton-pipelines-controller-7bf66fcb4f-k42fj -o yaml -n tekton-pipelines ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "tekton-pipelines-controller-7bf66fcb4f-k42fj"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "18d"
+                    }
+                  ]
+                },
+                {
+                  "key": "NAMESPACE",
+                  "name": "tekton-pipelines",
+                  "rowKey": "tekton-pipelines-tekton-pipelines-webhook-cd747db44-5fcfn",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "onclick": "kubectl get Pod tekton-pipelines-webhook-cd747db44-5fcfn -o yaml -n tekton-pipelines ",
+                      "outerCSS": " entity-name-group",
+                      "css": " entity-name ",
+                      "value": "tekton-pipelines-webhook-cd747db44-5fcfn"
+                    },
+                    {
+                      "key": "READY",
+                      "onclick": false,
+                      "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1/1"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "onclick": false,
+                      "outerCSS": " ",
+                      "css": "  green-background",
+                      "value": "Running"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  red-background",
+                      "value": "0"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "2d5h"
+                    }
+                  ]
+                }
+              ],
+              "noSort": true,
+              "title": "Pod",
+              "breadcrumbs": [
+                {
+                  "label": "all"
+                }
+              ],
+              "statusColumnIdx": 2
+            },
+            "historyIdx": 255,
+            "cwd": "~/Workspace7/kui",
+            "command": "kubectl get pods -A",
+            "startEvent": {
+              "route": "/kubeui/kubectl/get",
+              "command": "kubectl get pods -A",
+              "evaluatorOptions": {
+                "flags": {
+                  "configuration": {
+                    "short-option-groups": false,
+                    "duplicate-arguments-array": false
+                  },
+                  "narg": {
+                    "w": 0,
+                    "watch": 0,
+                    "watch-only": 0
+                  },
+                  "boolean": [
+                    "w",
+                    "watch",
+                    "watch-only",
+                    "A",
+                    "all-namespaces",
+                    "ignore-not-found",
+                    "no-headers",
+                    "i",
+                    "it",
+                    "ti",
+                    "stdin",
+                    "t",
+                    "tty",
+                    "R",
+                    "recursive",
+                    "server-print",
+                    "show-kind",
+                    "show-labels"
+                  ]
+                },
+                "plugin": "plugin-kubectl"
+              },
+              "execType": 0,
+              "execUUID": "e297620c-7e43-45d1-af26-3b0ea2af20bf"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "kubectl get pods -A",
+              "argvNoOptions": ["kubectl", "get", "pods"],
+              "parsedOptions": {
+                "_": ["kubectl", "get", "pods"],
+                "A": true
+              },
+              "execUUID": "e297620c-7e43-45d1-af26-3b0ea2af20bf",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "plugin": "plugin-kubectl"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "e297620c-7e43-45d1-af26-3b0ea2af20bf",
+                "history": 255,
+                "env": {}
+              },
+              "response": {
+                "header": {
+                  "key": "NAMESPACE",
+                  "name": "Namespace",
+                  "rowKey": "NAMESPACE-NAME",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickSilence": true,
+                  "css": "",
+                  "rowCSS": [],
+                  "outerCSS": "header-cell entity-name-group hide-with-sidecar not-a-name",
+                  "attributes": [
+                    {
+                      "key": "NAME",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell entity-name-group",
+                      "css": "  ",
+                      "value": "Name"
+                    },
+                    {
+                      "key": "READY",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell a-few-numbers-wide kui--hide-in-narrower-windows",
+                      "css": "  yellow-background",
+                      "value": "Ready"
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell ",
+                      "css": "  ",
+                      "value": "Status"
+                    },
+                    {
+                      "key": "RESTARTS",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "Restarts"
+                    },
+                    {
+                      "key": "AGE",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell hide-with-sidecar hide-with-sidecar",
+                      "css": "  ",
+                      "value": "Age"
+                    }
+                  ]
+                },
+                "body": [
+                  {
+                    "key": "NAMESPACE",
+                    "name": "3dd6fe0f-3f05-4919-afce-6156e72dedb3-kui",
+                    "rowKey": "3dd6fe0f-3f05-4919-afce-6156e72dedb3-kui-nginx",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod nginx -o yaml -n 3dd6fe0f-3f05-4919-afce-6156e72dedb3-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "nginx"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "16d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "436f7d95-2ec4-4e6b-a816-a5f3adfd06d3-kui",
+                    "rowKey": "436f7d95-2ec4-4e6b-a816-a5f3adfd06d3-kui-nginx",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod nginx -o yaml -n 436f7d95-2ec4-4e6b-a816-a5f3adfd06d3-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "nginx"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "16d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "5bccd177-e0be-4511-81f8-2fcfd3d896af-kui",
+                    "rowKey": "5bccd177-e0be-4511-81f8-2fcfd3d896af-kui-nginx",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod nginx -o yaml -n 5bccd177-e0be-4511-81f8-2fcfd3d896af-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "nginx"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "15d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-2cf7b",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-2cf7b -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-2cf7b"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-6fwsd",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-6fwsd -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-6fwsd"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-77r9g",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-77r9g -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-77r9g"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-8lg2t",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-8lg2t -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-8lg2t"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-9j542",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-9j542 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-9j542"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-bfslr",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-bfslr -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-bfslr"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-bh658",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-bh658 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-bh658"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-bl425",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-bl425 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-bl425"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-fcbsm",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-fcbsm -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-fcbsm"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-fxjxr",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-fxjxr -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-fxjxr"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-gvf5v",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-gvf5v -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-gvf5v"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-hm6d8",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-hm6d8 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-hm6d8"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-jchbl",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-jchbl -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-jchbl"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-kcxw2",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-kcxw2 -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-kcxw2"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-rqxbl",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-rqxbl -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-rqxbl"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-tdb7p",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-tdb7p -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-tdb7p"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-vxptg",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-vxptg -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-vxptg"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-wp7pj",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-wp7pj -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-wp7pj"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-x9szj",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-x9szj -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-x9szj"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "69f07aad-2570-454e-af19-63563dfafa8b-kui",
+                    "rowKey": "69f07aad-2570-454e-af19-63563dfafa8b-kui-pi-xf4wp",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-xf4wp -o yaml -n 69f07aad-2570-454e-af19-63563dfafa8b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-xf4wp"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "7b72fdf7-28a9-4484-83ef-0d92cc948c33-kui",
+                    "rowKey": "7b72fdf7-28a9-4484-83ef-0d92cc948c33-kui-myapp-6446557848-6m9c7",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod myapp-6446557848-6m9c7 -o yaml -n 7b72fdf7-28a9-4484-83ef-0d92cc948c33-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "myapp-6446557848-6m9c7"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "16h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "8b29341c-1c5a-47a1-a75d-e0507292238a-kui",
+                    "rowKey": "8b29341c-1c5a-47a1-a75d-e0507292238a-kui-nginx",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod nginx -o yaml -n 8b29341c-1c5a-47a1-a75d-e0507292238a-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "nginx"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "16d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "96880667-44ae-4e9f-86f2-68bf2fa0cba3-kui",
+                    "rowKey": "96880667-44ae-4e9f-86f2-68bf2fa0cba3-kui-myapp-6446557848-dltm4",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod myapp-6446557848-dltm4 -o yaml -n 96880667-44ae-4e9f-86f2-68bf2fa0cba3-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "myapp-6446557848-dltm4"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "15d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "acff6bec-0dc6-408b-9872-025a752aaa2b-kui",
+                    "rowKey": "acff6bec-0dc6-408b-9872-025a752aaa2b-kui-nginx",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod nginx -o yaml -n acff6bec-0dc6-408b-9872-025a752aaa2b-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "nginx"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "15d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "b2906106-80f8-45fc-ae2f-e47bcc1d0799-kui",
+                    "rowKey": "b2906106-80f8-45fc-ae2f-e47bcc1d0799-kui-nginx",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod nginx -o yaml -n b2906106-80f8-45fc-ae2f-e47bcc1d0799-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "nginx"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "16d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "c33beae1-25d5-4eac-80af-66352dfb0e97-kui",
+                    "rowKey": "c33beae1-25d5-4eac-80af-66352dfb0e97-kui-myapp-6446557848-pj89x",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod myapp-6446557848-pj89x -o yaml -n c33beae1-25d5-4eac-80af-66352dfb0e97-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "myapp-6446557848-pj89x"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "16h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "dce34466-1db6-48cc-b0ff-57c502d92fa4-kui",
+                    "rowKey": "dce34466-1db6-48cc-b0ff-57c502d92fa4-kui-myapp-6446557848-ml9m8",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod myapp-6446557848-ml9m8 -o yaml -n dce34466-1db6-48cc-b0ff-57c502d92fa4-kui ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "myapp-6446557848-ml9m8"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "16h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-details-v1-68c7c8666d-8c78v",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod details-v1-68c7c8666d-8c78v -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "details-v1-68c7c8666d-8c78v"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-kui-deployment-577db4b45b-4fltz",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod kui-deployment-577db4b45b-4fltz -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "kui-deployment-577db4b45b-4fltz"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-kui-ui-7b946968df-n7kj8",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod kui-ui-7b946968df-n7kj8 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "kui-ui-7b946968df-n7kj8"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "2/2"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-myapp-7d449c8db4-96xwm",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod myapp-7d449c8db4-96xwm -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "myapp-7d449c8db4-96xwm"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-nginx",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod nginx -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "nginx"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "16d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-nginx-deployment-7fd6966748-jsp4j",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod nginx-deployment-7fd6966748-jsp4j -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "nginx-deployment-7fd6966748-jsp4j"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-nginx-deployment-7fd6966748-k4bxc",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod nginx-deployment-7fd6966748-k4bxc -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "nginx-deployment-7fd6966748-k4bxc"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-nginx-deployment-7fd6966748-q56lw",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod nginx-deployment-7fd6966748-q56lw -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "nginx-deployment-7fd6966748-q56lw"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-opining-ibex-mychart-646f6b5f77-mhzlk",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod opining-ibex-mychart-646f6b5f77-mhzlk -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "opining-ibex-mychart-646f6b5f77-mhzlk"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-5cgk4",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-5cgk4 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-5cgk4"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-5pfck",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-5pfck -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-5pfck"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-7bstz",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-7bstz -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-7bstz"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-8msfn",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-8msfn -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-8msfn"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-99swq",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-99swq -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-99swq"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-bjf8g",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-bjf8g -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-bjf8g"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-chbzt",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-chbzt -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-chbzt"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-f9cb9",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-f9cb9 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-f9cb9"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-km5mq",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-km5mq -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-km5mq"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-mpzth",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-mpzth -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-mpzth"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-mr6zd",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-mr6zd -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-mr6zd"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-qz6hn",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-qz6hn -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-qz6hn"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-r5t9j",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-r5t9j -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-r5t9j"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-rb647",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-rb647 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-rb647"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-s9l95",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-s9l95 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-s9l95"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-sfplv",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-sfplv -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-sfplv"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-vhmlh",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-vhmlh -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-vhmlh"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-vpwq8",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-vpwq8 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-vpwq8"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-vw4qb",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-vw4qb -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-vw4qb"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi-z9845",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi-z9845 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi-z9845"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d21h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-29mbp",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-29mbp -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-29mbp"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-2glnx",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-2glnx -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-2glnx"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-2qvdb",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-2qvdb -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-2qvdb"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-2wj7k",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-2wj7k -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-2wj7k"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-48zw8",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-48zw8 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-48zw8"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-58kdg",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-58kdg -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-58kdg"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-6kpd5",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-6kpd5 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-6kpd5"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-6q7jn",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-6q7jn -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-6q7jn"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-d2v2k",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-d2v2k -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-d2v2k"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-hwmvg",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-hwmvg -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-hwmvg"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-mkfkl",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-mkfkl -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-mkfkl"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-mq427",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-mq427 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-mq427"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-rs9dq",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-rs9dq -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-rs9dq"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-t5bnw",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-t5bnw -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-t5bnw"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-tqp6d",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-tqp6d -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-tqp6d"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-vjbcs",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-vjbcs -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-vjbcs"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-vx5z5",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-vx5z5 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-vx5z5"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-vz59r",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-vz59r -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-vz59r"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-wblj9",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-wblj9 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-wblj9"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pi2-zzl6c",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pi2-zzl6c -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pi2-zzl6c"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  gray-background",
+                        "value": "Completed"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "14d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-productpage-v1-54d799c966-fjz5b",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod productpage-v1-54d799c966-fjz5b -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "productpage-v1-54d799c966-fjz5b"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-pugnacious-abalone-nginx-7f4889cdcb-b9gnq",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod pugnacious-abalone-nginx-7f4889cdcb-b9gnq -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "pugnacious-abalone-nginx-7f4889cdcb-b9gnq"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-ratings-v1-8558d4458d-qqhp6",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod ratings-v1-8558d4458d-qqhp6 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "ratings-v1-8558d4458d-qqhp6"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-reviews-v1-cb8655c75-2n5sj",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod reviews-v1-cb8655c75-2n5sj -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "reviews-v1-cb8655c75-2n5sj"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-reviews-v2-7fc9bb6dcf-r9gnk",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod reviews-v2-7fc9bb6dcf-r9gnk -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "reviews-v2-7fc9bb6dcf-r9gnk"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-reviews-v3-c995979bc-mnbq9",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod reviews-v3-c995979bc-mnbq9 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "reviews-v3-c995979bc-mnbq9"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "default",
+                    "rowKey": "default-test-release-mysql-746846c8fd-krnm6",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod test-release-mysql-746846c8fd-krnm6 -o yaml -n default ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "test-release-mysql-746846c8fd-krnm6"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "ibm-system",
+                    "rowKey": "ibm-system-addon-catalog-source-ld52x",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod addon-catalog-source-ld52x -o yaml -n ibm-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "addon-catalog-source-ld52x"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d2h"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "ibm-system",
+                    "rowKey": "ibm-system-catalog-operator-67cbc5d959-wcjzk",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod catalog-operator-67cbc5d959-wcjzk -o yaml -n ibm-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "catalog-operator-67cbc5d959-wcjzk"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "ibm-system",
+                    "rowKey": "ibm-system-ibm-cloud-provider-ip-169-60-169-42-6d89f45598-fvchc",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod ibm-cloud-provider-ip-169-60-169-42-6d89f45598-fvchc -o yaml -n ibm-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "ibm-cloud-provider-ip-169-60-169-42-6d89f45598-fvchc"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "ibm-system",
+                    "rowKey": "ibm-system-ibm-cloud-provider-ip-169-60-169-42-6d89f45598-kz8l4",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod ibm-cloud-provider-ip-169-60-169-42-6d89f45598-kz8l4 -o yaml -n ibm-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "ibm-cloud-provider-ip-169-60-169-42-6d89f45598-kz8l4"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "ibm-system",
+                    "rowKey": "ibm-system-ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-5ss7h",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-5ss7h -o yaml -n ibm-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-5ss7h"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "ibm-system",
+                    "rowKey": "ibm-system-ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-jph8s",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-jph8s -o yaml -n ibm-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "ibm-cloud-provider-ip-169-60-169-46-68f47bb6f8-jph8s"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "ibm-system",
+                    "rowKey": "ibm-system-olm-operator-6f74dfc868-5m47h",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod olm-operator-6f74dfc868-5m47h -o yaml -n ibm-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "olm-operator-6f74dfc868-5m47h"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "istio-system",
+                    "rowKey": "istio-system-kiali-568997dcdb-dtmvn",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod kiali-568997dcdb-dtmvn -o yaml -n istio-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "kiali-568997dcdb-dtmvn"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  yellow-background",
+                        "value": "0/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  yellow-background",
+                        "value": "ContainerCreating"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-calico-kube-controllers-54c66c7555-q2ksx",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod calico-kube-controllers-54c66c7555-q2ksx -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "calico-kube-controllers-54c66c7555-q2ksx"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-calico-node-h2ddn",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod calico-node-h2ddn -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "calico-node-h2ddn"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-calico-node-vmhgf",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod calico-node-vmhgf -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "calico-node-vmhgf"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-coredns-6d96d4784-48qf2",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod coredns-6d96d4784-48qf2 -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "coredns-6d96d4784-48qf2"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-coredns-6d96d4784-gxgx6",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod coredns-6d96d4784-gxgx6 -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "coredns-6d96d4784-gxgx6"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-coredns-autoscaler-777bf994bf-jp8m9",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod coredns-autoscaler-777bf994bf-jp8m9 -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "coredns-autoscaler-777bf994bf-jp8m9"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-dashboard-metrics-scraper-76756886dc-msh7z",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod dashboard-metrics-scraper-76756886dc-msh7z -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "dashboard-metrics-scraper-76756886dc-msh7z"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-ibm-file-plugin-86b7cd9c54-pzrck",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod ibm-file-plugin-86b7cd9c54-pzrck -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "ibm-file-plugin-86b7cd9c54-pzrck"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "9d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-ibm-keepalived-watcher-n7866",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod ibm-keepalived-watcher-n7866 -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "ibm-keepalived-watcher-n7866"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-ibm-keepalived-watcher-psxdc",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod ibm-keepalived-watcher-psxdc -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "ibm-keepalived-watcher-psxdc"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-ibm-master-proxy-static-10.73.230.194",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod ibm-master-proxy-static-10.73.230.194 -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "ibm-master-proxy-static-10.73.230.194"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "2/2"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-ibm-master-proxy-static-10.73.230.207",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod ibm-master-proxy-static-10.73.230.207 -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "ibm-master-proxy-static-10.73.230.207"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "2/2"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-ibm-storage-watcher-7f4c95cf97-nbf67",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod ibm-storage-watcher-7f4c95cf97-nbf67 -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "ibm-storage-watcher-7f4c95cf97-nbf67"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "9d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-kubernetes-dashboard-85b945ff4b-pv27f",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod kubernetes-dashboard-85b945ff4b-pv27f -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "kubernetes-dashboard-85b945ff4b-pv27f"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  green-background",
+                        "value": "1"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-metrics-server-84f999b67b-9nfdr",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod metrics-server-84f999b67b-9nfdr -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "metrics-server-84f999b67b-9nfdr"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "2/2"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "9d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-5gqks",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-5gqks -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-5gqks"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "4/4"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-srfjx",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-srfjx -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "public-crf3ec154925a041f39389f895a203c513-alb1-64946c7674-srfjx"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "4/4"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-tiller-deploy-8557598fbc-d4xf4",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod tiller-deploy-8557598fbc-d4xf4 -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "tiller-deploy-8557598fbc-d4xf4"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "kube-system",
+                    "rowKey": "kube-system-vpn-86875c5bdb-kj8b7",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod vpn-86875c5bdb-kj8b7 -o yaml -n kube-system ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "vpn-86875c5bdb-kj8b7"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "tekton-pipelines",
+                    "rowKey": "tekton-pipelines-tekton-pipelines-controller-7bf66fcb4f-k42fj",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod tekton-pipelines-controller-7bf66fcb4f-k42fj -o yaml -n tekton-pipelines ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "tekton-pipelines-controller-7bf66fcb4f-k42fj"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "18d"
+                      }
+                    ]
+                  },
+                  {
+                    "key": "NAMESPACE",
+                    "name": "tekton-pipelines",
+                    "rowKey": "tekton-pipelines-tekton-pipelines-webhook-cd747db44-5fcfn",
+                    "fontawesome": false,
+                    "onclick": false,
+                    "onclickSilence": true,
+                    "css": "",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group hide-with-sidecar not-a-name",
+                    "attributes": [
+                      {
+                        "key": "NAME",
+                        "onclick": "kubectl get Pod tekton-pipelines-webhook-cd747db44-5fcfn -o yaml -n tekton-pipelines ",
+                        "outerCSS": " entity-name-group",
+                        "css": " entity-name ",
+                        "value": "tekton-pipelines-webhook-cd747db44-5fcfn"
+                      },
+                      {
+                        "key": "READY",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " ",
+                        "css": "  green-background",
+                        "value": "Running"
+                      },
+                      {
+                        "key": "RESTARTS",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  red-background",
+                        "value": "0"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "2d5h"
+                      }
+                    ]
+                  }
+                ],
+                "noSort": true,
+                "title": "Pod",
+                "breadcrumbs": [
+                  {
+                    "label": "all"
+                  }
+                ],
+                "statusColumnIdx": 2
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 255
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "e297620c-7e43-45d1-af26-3b0ea2af20bf",
+            "startTime": "2020-09-30T18:30:09.794Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": false,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "The -A flag specifies that all resources of the type specified (in this case, Pods) should be shown."
+              }
+            },
+            "historyIdx": 256,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "cd4611d7-a654-4faf-9348-0a139c0693ae"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "cd4611d7-a654-4faf-9348-0a139c0693ae",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "cd4611d7-a654-4faf-9348-0a139c0693ae",
+                "history": 256,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "The -A flag specifies that all resources of the type specified (in this case, Pods) should be shown."
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 256
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "cd4611d7-a654-4faf-9348-0a139c0693ae",
+            "startTime": "2020-09-30T18:30:19.201Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
           }
         ]
       }

--- a/plugins/plugin-kubectl/notebooks/list-resources.json
+++ b/plugins/plugin-kubectl/notebooks/list-resources.json
@@ -1,1474 +1,1340 @@
 {
   "apiVersion": "kui-shell/v1",
-  "kind": "Snapshot",
+  "kind": "Notebook",
+  "metadata": {
+    "name": "Kubernetes &mdash; `Listing Resources`"
+  },
   "spec": {
-    "title": "Kubernetes &mdash; `Listing Resources`",
-    "clicks": {
-      "startEvents": {
-        "2cac6097-cf5b-4135-9118-c2e6f41199b3": [
+    "splits": [
+      {
+        "uuid": "1_c57e811f-2da8-557e-a402-9f0950407675",
+        "blocks": [
           {
-            "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-            "route": "/kubeui/kubectl/get/Deployment",
-            "command": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1",
-            "evaluatorOptions": {
-              "flags": {
-                "configuration": { "short-option-groups": false, "duplicate-arguments-array": false },
-                "narg": { "w": 0, "watch": 0, "watch-only": 0 },
-                "boolean": [
-                  "w",
-                  "watch",
-                  "watch-only",
-                  "A",
-                  "all-namespaces",
-                  "ignore-not-found",
-                  "no-headers",
-                  "i",
-                  "it",
-                  "ti",
-                  "stdin",
-                  "t",
-                  "tty",
-                  "R",
-                  "recursive",
-                  "server-print",
-                  "show-kind",
-                  "show-labels"
-                ]
-              },
-              "plugin": "plugin-kubectl"
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "# Declarative Management of Kubernetes Objects\n\nKubernetes objects can be created, updated, and deleted by storing multiple object configuration files in a directory and using kubectl apply to recursively create and update those objects as needed. This method retains writes made to live objects without merging the changes back into the object configuration files."
+              }
             },
-            "execType": 1,
-            "execUUID": "570a28d6-f9fb-432f-aa40-4cebd54637b2",
-            "echo": false
-          }
-        ],
-        "a20d8456-a58e-418d-adbc-0d5e98dcaef7": [
-          {
-            "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-            "route": "/kubeui/kubectl/get/Deployment",
-            "command": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1",
-            "evaluatorOptions": {
-              "flags": {
-                "configuration": { "short-option-groups": false, "duplicate-arguments-array": false },
-                "narg": { "w": 0, "watch": 0, "watch-only": 0 },
-                "boolean": [
-                  "w",
-                  "watch",
-                  "watch-only",
-                  "A",
-                  "all-namespaces",
-                  "ignore-not-found",
-                  "no-headers",
-                  "i",
-                  "it",
-                  "ti",
-                  "stdin",
-                  "t",
-                  "tty",
-                  "R",
-                  "recursive",
-                  "server-print",
-                  "show-kind",
-                  "show-labels"
-                ]
+            "historyIdx": 251,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
               },
-              "plugin": "plugin-kubectl"
+              "execType": 0,
+              "execUUID": "f02d2fa5-61ae-4663-9463-f7769989824f"
             },
-            "execType": 1,
-            "execUUID": "570a28d6-f9fb-432f-aa40-4cebd54637b2",
-            "echo": false
-          }
-        ],
-        "f5204b3d-3d4c-4c65-bc41-006cd97d03ec": [
-          {
-            "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-            "route": "/kubeui/kubectl/get/Deployment",
-            "command": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1",
-            "evaluatorOptions": {
-              "flags": {
-                "configuration": { "short-option-groups": false, "duplicate-arguments-array": false },
-                "narg": { "w": 0, "watch": 0, "watch-only": 0 },
-                "boolean": [
-                  "w",
-                  "watch",
-                  "watch-only",
-                  "A",
-                  "all-namespaces",
-                  "ignore-not-found",
-                  "no-headers",
-                  "i",
-                  "it",
-                  "ti",
-                  "stdin",
-                  "t",
-                  "tty",
-                  "R",
-                  "recursive",
-                  "server-print",
-                  "show-kind",
-                  "show-labels"
-                ]
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
               },
-              "plugin": "plugin-kubectl"
+              "execUUID": "f02d2fa5-61ae-4663-9463-f7769989824f",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "f02d2fa5-61ae-4663-9463-f7769989824f",
+                "history": 251,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "# Declarative Management of Kubernetes Objects\n\nKubernetes objects can be created, updated, and deleted by storing multiple object configuration files in a directory and using kubectl apply to recursively create and update those objects as needed. This method retains writes made to live objects without merging the changes back into the object configuration files."
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 251
             },
-            "execType": 1,
-            "execUUID": "570a28d6-f9fb-432f-aa40-4cebd54637b2",
-            "echo": false
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "f02d2fa5-61ae-4663-9463-f7769989824f",
+            "startTime": "2020-09-30T18:22:52.147Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
           }
         ]
       },
-      "completeEvents": {
-        "2cac6097-cf5b-4135-9118-c2e6f41199b3": [
+      {
+        "uuid": "1_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
+        "blocks": [
           {
-            "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-            "execType": 1,
-            "command": "kubectl get ns -n default kui-notebook-1 -o yaml",
-            "argvNoOptions": ["kubectl", "get", "ns", "kui-notebook-1"],
-            "parsedOptions": { "_": ["kubectl", "get", "ns", "kui-notebook-1"], "n": "default", "o": "yaml" },
-            "execUUID": "403f6008-abf8-4544-a327-61df05fd316c",
-            "cancelled": false,
-            "echo": false,
-            "evaluatorOptions": {
-              "flags": {
-                "configuration": { "short-option-groups": false, "duplicate-arguments-array": false },
-                "narg": { "w": 0, "watch": 0, "watch-only": 0 },
-                "boolean": [
-                  "w",
-                  "watch",
-                  "watch-only",
-                  "A",
-                  "all-namespaces",
-                  "ignore-not-found",
-                  "no-headers",
-                  "i",
-                  "it",
-                  "ti",
-                  "stdin",
-                  "t",
-                  "tty",
-                  "R",
-                  "recursive",
-                  "server-print",
-                  "show-kind",
-                  "show-labels"
-                ]
-              },
-              "plugin": "plugin-kubectl"
-            },
-            "execOptions": {
-              "echo": false,
-              "type": 1,
-              "execUUID": "403f6008-abf8-4544-a327-61df05fd316c",
-              "history": 250,
-              "env": {}
-            },
             "response": {
-              "apiVersion": "v1",
-              "kind": "Namespace",
-              "metadata": {
-                "creationTimestamp": "2020-09-25T17:29:24Z",
-                "name": "kui-notebook-1",
-                "resourceVersion": "81846538",
-                "selfLink": "/api/v1/namespaces/kui-notebook-1",
-                "uid": "93990185-0ba0-46cb-983b-a5cdf6de36cf"
-              },
-              "spec": { "finalizers": ["kubernetes"] },
-              "status": { "phase": "Active" },
-              "isKubeResource": true,
-              "originatingCommand": {
-                "REPL": {},
-                "argv": ["kubectl", "get", "ns", "-n", "default", "kui-notebook-1", "-o", "yaml"],
-                "command": "kubectl get ns -n default kui-notebook-1 -o yaml",
-                "execOptions": {
-                  "echo": false,
-                  "type": 1,
-                  "execUUID": "403f6008-abf8-4544-a327-61df05fd316c",
-                  "history": 250,
-                  "env": {}
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "## Exploring Further\n\n- `kubectl diff` gives you a preview of what changes apply will make."
+              }
+            },
+            "historyIdx": 95,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
                 },
-                "argvNoOptions": ["kubectl", "get", "ns", "kui-notebook-1"],
-                "parsedOptions": { "_": ["kubectl", "get", "ns", "kui-notebook-1"], "n": "default", "o": "yaml" }
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
               },
-              "kuiRawData": "apiVersion: v1\nkind: Namespace\nmetadata:\n  creationTimestamp: \"2020-09-25T17:29:24Z\"\n  name: kui-notebook-1\n  resourceVersion: \"81846538\"\n  selfLink: /api/v1/namespaces/kui-notebook-1\n  uid: 93990185-0ba0-46cb-983b-a5cdf6de36cf\nspec:\n  finalizers:\n  - kubernetes\nstatus:\n  phase: Active\n",
-              "toolbarText": {
-                "type": "info",
-                "text": "Created on **9/25/2020, 1:29:24 PM**. Showing resource version **81846538**."
-              },
-              "onclick": {
-                "kind": "kubectl get Namespace -n undefined",
-                "name": "kubectl get Namespace -n undefined kui-notebook-1"
-              },
-              "modes": []
+              "execType": 0,
+              "execUUID": "4817a885-686f-4713-8a67-0994a74d57f8"
             },
-            "responseType": "MultiModalResponse",
-            "historyIdx": 250
-          }
-        ],
-        "a20d8456-a58e-418d-adbc-0d5e98dcaef7": [
-          {
-            "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-            "execType": 1,
-            "command": "kubectl get Deployment.v1.apps -n kui-notebook-1 nginx-deployment -o yaml",
-            "argvNoOptions": ["kubectl", "get", "Deployment.v1.apps", "nginx-deployment"],
-            "parsedOptions": {
-              "_": ["kubectl", "get", "Deployment.v1.apps", "nginx-deployment"],
-              "n": "kui-notebook-1",
-              "o": "yaml"
-            },
-            "execUUID": "c7b73272-6de6-4ef9-a73e-26f915aa9347",
-            "cancelled": false,
-            "echo": false,
-            "evaluatorOptions": {
-              "flags": {
-                "configuration": { "short-option-groups": false, "duplicate-arguments-array": false },
-                "narg": { "w": 0, "watch": 0, "watch-only": 0 },
-                "boolean": [
-                  "w",
-                  "watch",
-                  "watch-only",
-                  "A",
-                  "all-namespaces",
-                  "ignore-not-found",
-                  "no-headers",
-                  "i",
-                  "it",
-                  "ti",
-                  "stdin",
-                  "t",
-                  "tty",
-                  "R",
-                  "recursive",
-                  "server-print",
-                  "show-kind",
-                  "show-labels"
-                ]
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
               },
-              "plugin": "plugin-kubectl"
-            },
-            "execOptions": {
-              "echo": false,
-              "type": 1,
-              "execUUID": "c7b73272-6de6-4ef9-a73e-26f915aa9347",
-              "history": 251,
-              "env": {}
-            },
-            "response": {
-              "apiVersion": "apps/v1",
-              "kind": "Deployment",
-              "metadata": {
-                "annotations": {
-                  "deployment.kubernetes.io/revision": "1",
-                  "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"name\":\"nginx-deployment\",\"namespace\":\"kui-notebook-1\"},\"spec\":{\"minReadySeconds\":5,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"nginx\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:1.14.2\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}}}\n"
-                },
-                "creationTimestamp": "2020-09-25T17:29:28Z",
-                "generation": 1,
-                "name": "nginx-deployment",
-                "namespace": "kui-notebook-1",
-                "resourceVersion": "81846594",
-                "selfLink": "/apis/apps/v1/namespaces/kui-notebook-1/deployments/nginx-deployment",
-                "uid": "c323f4b4-1297-42ca-8e58-8e5347bf98fa"
+              "execUUID": "4817a885-686f-4713-8a67-0994a74d57f8",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
               },
-              "spec": {
-                "minReadySeconds": 5,
-                "progressDeadlineSeconds": 600,
-                "replicas": 1,
-                "revisionHistoryLimit": 10,
-                "selector": { "matchLabels": { "app": "nginx" } },
-                "strategy": {
-                  "rollingUpdate": { "maxSurge": "25%", "maxUnavailable": "25%" },
-                  "type": "RollingUpdate"
-                },
-                "template": {
-                  "metadata": { "creationTimestamp": null, "labels": { "app": "nginx" } },
-                  "spec": {
-                    "containers": [
-                      {
-                        "image": "nginx:1.14.2",
-                        "imagePullPolicy": "IfNotPresent",
-                        "name": "nginx",
-                        "ports": [{ "containerPort": 80, "protocol": "TCP" }],
-                        "resources": {},
-                        "terminationMessagePath": "/dev/termination-log",
-                        "terminationMessagePolicy": "File"
-                      }
-                    ],
-                    "dnsPolicy": "ClusterFirst",
-                    "restartPolicy": "Always",
-                    "schedulerName": "default-scheduler",
-                    "securityContext": {},
-                    "terminationGracePeriodSeconds": 30
-                  }
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "4817a885-686f-4713-8a67-0994a74d57f8",
+                "history": 95,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "## Exploring Further\n\n- `kubectl diff` gives you a preview of what changes apply will make."
                 }
               },
-              "status": {
-                "availableReplicas": 1,
-                "conditions": [
-                  {
-                    "lastTransitionTime": "2020-09-25T17:29:35Z",
-                    "lastUpdateTime": "2020-09-25T17:29:35Z",
-                    "message": "Deployment has minimum availability.",
-                    "reason": "MinimumReplicasAvailable",
-                    "status": "True",
-                    "type": "Available"
-                  },
-                  {
-                    "lastTransitionTime": "2020-09-25T17:29:28Z",
-                    "lastUpdateTime": "2020-09-25T17:29:35Z",
-                    "message": "ReplicaSet \"nginx-deployment-574b87c764\" has successfully progressed.",
-                    "reason": "NewReplicaSetAvailable",
-                    "status": "True",
-                    "type": "Progressing"
-                  }
-                ],
-                "observedGeneration": 1,
-                "readyReplicas": 1,
-                "replicas": 1,
-                "updatedReplicas": 1
-              },
-              "isKubeResource": true,
-              "originatingCommand": {
-                "REPL": {},
-                "argv": [
-                  "kubectl",
-                  "get",
-                  "Deployment.v1.apps",
-                  "-n",
-                  "kui-notebook-1",
-                  "nginx-deployment",
-                  "-o",
-                  "yaml"
-                ],
-                "command": "kubectl get Deployment.v1.apps -n kui-notebook-1 nginx-deployment -o yaml",
-                "execOptions": {
-                  "echo": false,
-                  "type": 1,
-                  "execUUID": "c7b73272-6de6-4ef9-a73e-26f915aa9347",
-                  "history": 251,
-                  "env": {}
-                },
-                "argvNoOptions": ["kubectl", "get", "Deployment.v1.apps", "nginx-deployment"],
-                "parsedOptions": {
-                  "_": ["kubectl", "get", "Deployment.v1.apps", "nginx-deployment"],
-                  "n": "kui-notebook-1",
-                  "o": "yaml"
-                }
-              },
-              "kuiRawData": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  annotations:\n    deployment.kubernetes.io/revision: \"1\"\n    kubectl.kubernetes.io/last-applied-configuration: |\n      {\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"name\":\"nginx-deployment\",\"namespace\":\"kui-notebook-1\"},\"spec\":{\"minReadySeconds\":5,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"nginx\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:1.14.2\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}}}\n  creationTimestamp: \"2020-09-25T17:29:28Z\"\n  generation: 1\n  name: nginx-deployment\n  namespace: kui-notebook-1\n  resourceVersion: \"81846594\"\n  selfLink: /apis/apps/v1/namespaces/kui-notebook-1/deployments/nginx-deployment\n  uid: c323f4b4-1297-42ca-8e58-8e5347bf98fa\nspec:\n  minReadySeconds: 5\n  progressDeadlineSeconds: 600\n  replicas: 1\n  revisionHistoryLimit: 10\n  selector:\n    matchLabels:\n      app: nginx\n  strategy:\n    rollingUpdate:\n      maxSurge: 25%\n      maxUnavailable: 25%\n    type: RollingUpdate\n  template:\n    metadata:\n      creationTimestamp: null\n      labels:\n        app: nginx\n    spec:\n      containers:\n      - image: nginx:1.14.2\n        imagePullPolicy: IfNotPresent\n        name: nginx\n        ports:\n        - containerPort: 80\n          protocol: TCP\n        resources: {}\n        terminationMessagePath: /dev/termination-log\n        terminationMessagePolicy: File\n      dnsPolicy: ClusterFirst\n      restartPolicy: Always\n      schedulerName: default-scheduler\n      securityContext: {}\n      terminationGracePeriodSeconds: 30\nstatus:\n  availableReplicas: 1\n  conditions:\n  - lastTransitionTime: \"2020-09-25T17:29:35Z\"\n    lastUpdateTime: \"2020-09-25T17:29:35Z\"\n    message: Deployment has minimum availability.\n    reason: MinimumReplicasAvailable\n    status: \"True\"\n    type: Available\n  - lastTransitionTime: \"2020-09-25T17:29:28Z\"\n    lastUpdateTime: \"2020-09-25T17:29:35Z\"\n    message: ReplicaSet \"nginx-deployment-574b87c764\" has successfully progressed.\n    reason: NewReplicaSetAvailable\n    status: \"True\"\n    type: Progressing\n  observedGeneration: 1\n  readyReplicas: 1\n  replicas: 1\n  updatedReplicas: 1\n",
-              "toolbarText": {
-                "type": "info",
-                "text": "Created on **9/25/2020, 1:29:28 PM**. Showing resource version **81846594**."
-              },
-              "onclick": {
-                "kind": "kubectl get Deployment.v1.apps -n kui-notebook-1",
-                "name": "kubectl get Deployment.v1.apps -n kui-notebook-1 nginx-deployment",
-                "namespace": "kubectl get ns kui-notebook-1 -o yaml"
-              },
-              "modes": []
+              "responseType": "ScalarResponse",
+              "historyIdx": 95
             },
-            "responseType": "MultiModalResponse",
-            "historyIdx": 251
-          }
-        ],
-        "f5204b3d-3d4c-4c65-bc41-006cd97d03ec": [
-          {
-            "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-            "execType": 1,
-            "command": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1 ",
-            "argvNoOptions": ["kubectl", "get", "Deployment", "nginx-deployment"],
-            "parsedOptions": {
-              "_": ["kubectl", "get", "Deployment", "nginx-deployment"],
-              "o": "yaml",
-              "n": "kui-notebook-1"
-            },
-            "execUUID": "570a28d6-f9fb-432f-aa40-4cebd54637b2",
-            "cancelled": false,
-            "echo": false,
-            "evaluatorOptions": {
-              "flags": {
-                "configuration": { "short-option-groups": false, "duplicate-arguments-array": false },
-                "narg": { "w": 0, "watch": 0, "watch-only": 0 },
-                "boolean": [
-                  "w",
-                  "watch",
-                  "watch-only",
-                  "A",
-                  "all-namespaces",
-                  "ignore-not-found",
-                  "no-headers",
-                  "i",
-                  "it",
-                  "ti",
-                  "stdin",
-                  "t",
-                  "tty",
-                  "R",
-                  "recursive",
-                  "server-print",
-                  "show-kind",
-                  "show-labels"
-                ]
-              },
-              "plugin": "plugin-kubectl"
-            },
-            "execOptions": {
-              "echo": false,
-              "type": 1,
-              "execUUID": "570a28d6-f9fb-432f-aa40-4cebd54637b2",
-              "history": 252,
-              "env": {}
-            },
-            "response": {
-              "apiVersion": "apps/v1",
-              "kind": "Deployment",
-              "metadata": {
-                "annotations": {
-                  "deployment.kubernetes.io/revision": "1",
-                  "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"name\":\"nginx-deployment\",\"namespace\":\"kui-notebook-1\"},\"spec\":{\"minReadySeconds\":5,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"nginx\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:1.14.2\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}}}\n"
-                },
-                "creationTimestamp": "2020-09-25T17:29:28Z",
-                "generation": 1,
-                "name": "nginx-deployment",
-                "namespace": "kui-notebook-1",
-                "resourceVersion": "81846594",
-                "selfLink": "/apis/apps/v1/namespaces/kui-notebook-1/deployments/nginx-deployment",
-                "uid": "c323f4b4-1297-42ca-8e58-8e5347bf98fa"
-              },
-              "spec": {
-                "minReadySeconds": 5,
-                "progressDeadlineSeconds": 600,
-                "replicas": 1,
-                "revisionHistoryLimit": 10,
-                "selector": { "matchLabels": { "app": "nginx" } },
-                "strategy": {
-                  "rollingUpdate": { "maxSurge": "25%", "maxUnavailable": "25%" },
-                  "type": "RollingUpdate"
-                },
-                "template": {
-                  "metadata": { "creationTimestamp": null, "labels": { "app": "nginx" } },
-                  "spec": {
-                    "containers": [
-                      {
-                        "image": "nginx:1.14.2",
-                        "imagePullPolicy": "IfNotPresent",
-                        "name": "nginx",
-                        "ports": [{ "containerPort": 80, "protocol": "TCP" }],
-                        "resources": {},
-                        "terminationMessagePath": "/dev/termination-log",
-                        "terminationMessagePolicy": "File"
-                      }
-                    ],
-                    "dnsPolicy": "ClusterFirst",
-                    "restartPolicy": "Always",
-                    "schedulerName": "default-scheduler",
-                    "securityContext": {},
-                    "terminationGracePeriodSeconds": 30
-                  }
-                }
-              },
-              "status": {
-                "availableReplicas": 1,
-                "conditions": [
-                  {
-                    "lastTransitionTime": "2020-09-25T17:29:35Z",
-                    "lastUpdateTime": "2020-09-25T17:29:35Z",
-                    "message": "Deployment has minimum availability.",
-                    "reason": "MinimumReplicasAvailable",
-                    "status": "True",
-                    "type": "Available"
-                  },
-                  {
-                    "lastTransitionTime": "2020-09-25T17:29:28Z",
-                    "lastUpdateTime": "2020-09-25T17:29:35Z",
-                    "message": "ReplicaSet \"nginx-deployment-574b87c764\" has successfully progressed.",
-                    "reason": "NewReplicaSetAvailable",
-                    "status": "True",
-                    "type": "Progressing"
-                  }
-                ],
-                "observedGeneration": 1,
-                "readyReplicas": 1,
-                "replicas": 1,
-                "updatedReplicas": 1
-              },
-              "isKubeResource": true,
-              "originatingCommand": {
-                "REPL": {},
-                "argv": ["kubectl", "get", "Deployment", "nginx-deployment", "-o", "yaml", "-n", "kui-notebook-1"],
-                "command": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1",
-                "execOptions": {
-                  "echo": false,
-                  "type": 1,
-                  "execUUID": "570a28d6-f9fb-432f-aa40-4cebd54637b2",
-                  "history": 252,
-                  "env": {}
-                },
-                "argvNoOptions": ["kubectl", "get", "Deployment", "nginx-deployment"],
-                "parsedOptions": {
-                  "_": ["kubectl", "get", "Deployment", "nginx-deployment"],
-                  "o": "yaml",
-                  "n": "kui-notebook-1"
-                }
-              },
-              "kuiRawData": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  annotations:\n    deployment.kubernetes.io/revision: \"1\"\n    kubectl.kubernetes.io/last-applied-configuration: |\n      {\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"name\":\"nginx-deployment\",\"namespace\":\"kui-notebook-1\"},\"spec\":{\"minReadySeconds\":5,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"nginx\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:1.14.2\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}}}\n  creationTimestamp: \"2020-09-25T17:29:28Z\"\n  generation: 1\n  name: nginx-deployment\n  namespace: kui-notebook-1\n  resourceVersion: \"81846594\"\n  selfLink: /apis/apps/v1/namespaces/kui-notebook-1/deployments/nginx-deployment\n  uid: c323f4b4-1297-42ca-8e58-8e5347bf98fa\nspec:\n  minReadySeconds: 5\n  progressDeadlineSeconds: 600\n  replicas: 1\n  revisionHistoryLimit: 10\n  selector:\n    matchLabels:\n      app: nginx\n  strategy:\n    rollingUpdate:\n      maxSurge: 25%\n      maxUnavailable: 25%\n    type: RollingUpdate\n  template:\n    metadata:\n      creationTimestamp: null\n      labels:\n        app: nginx\n    spec:\n      containers:\n      - image: nginx:1.14.2\n        imagePullPolicy: IfNotPresent\n        name: nginx\n        ports:\n        - containerPort: 80\n          protocol: TCP\n        resources: {}\n        terminationMessagePath: /dev/termination-log\n        terminationMessagePolicy: File\n      dnsPolicy: ClusterFirst\n      restartPolicy: Always\n      schedulerName: default-scheduler\n      securityContext: {}\n      terminationGracePeriodSeconds: 30\nstatus:\n  availableReplicas: 1\n  conditions:\n  - lastTransitionTime: \"2020-09-25T17:29:35Z\"\n    lastUpdateTime: \"2020-09-25T17:29:35Z\"\n    message: Deployment has minimum availability.\n    reason: MinimumReplicasAvailable\n    status: \"True\"\n    type: Available\n  - lastTransitionTime: \"2020-09-25T17:29:28Z\"\n    lastUpdateTime: \"2020-09-25T17:29:35Z\"\n    message: ReplicaSet \"nginx-deployment-574b87c764\" has successfully progressed.\n    reason: NewReplicaSetAvailable\n    status: \"True\"\n    type: Progressing\n  observedGeneration: 1\n  readyReplicas: 1\n  replicas: 1\n  updatedReplicas: 1\n",
-              "toolbarText": {
-                "type": "info",
-                "text": "Created on **9/25/2020, 1:29:28 PM**. Showing resource version **81846594**."
-              },
-              "onclick": {
-                "kind": "kubectl get Deployment.v1.apps -n kui-notebook-1",
-                "name": "kubectl get Deployment.v1.apps -n kui-notebook-1 nginx-deployment",
-                "namespace": "kubectl get ns kui-notebook-1 -o yaml"
-              },
-              "modes": []
-            },
-            "responseType": "MultiModalResponse",
-            "historyIdx": 252
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "4817a885-686f-4713-8a67-0994a74d57f8",
+            "startTime": "2020-09-30T18:23:00.506Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
           }
         ]
-      }
-    },
-    "windows": [
+      },
       {
-        "uuid": "0",
-        "tabs": [
+        "uuid": "1_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
+        "blocks": [
           {
-            "uuid": "0",
-            "blocks": [
-              {
-                "startTime": 1601054957190,
-                "startEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/#",
-                  "command": "#    # Creating a Resource\\nCreate a Kubernetes Resource from configuration file.",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        { "name": "--title", "alias": "-t", "docs": "Title for the commentary" },
-                        { "name": "--file", "alias": "-f", "docs": "File that contains the texts" }
-                      ]
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "## How to create objects\n\nUse `kubectl apply` to create all objects, except those that already exist, defined by configuration files in a specified directory. It is good practice to experiment in a separate namespace. First, we create a scratch namespace, and then we use `kubectl apply` to create a resource in that namespace."
+              }
+            },
+            "historyIdx": 250,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
                     },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 1,
-                  "execUUID": "d5737109-1a54-4f0b-ae12-2906fd7ac4d1",
-                  "echo": true
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
                 },
-                "completeEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 1,
-                  "command": "#   # Creating a Resource\\nCreate a Kubernetes Resource from configuration file.",
-                  "argvNoOptions": [
-                    "#",
-                    "    # Creating a Resource\\nCreate a Kubernetes Resource from configuration file."
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "032a3a30-cde5-42cc-9f5a-25a62ff99053"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "032a3a30-cde5-42cc-9f5a-25a62ff99053",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "032a3a30-cde5-42cc-9f5a-25a62ff99053",
+                "history": 250,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "## How to create objects\n\nUse `kubectl apply` to create all objects, except those that already exist, defined by configuration files in a specified directory. It is good practice to experiment in a separate namespace. First, we create a scratch namespace, and then we use `kubectl apply` to create a resource in that namespace."
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 250
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "032a3a30-cde5-42cc-9f5a-25a62ff99053",
+            "startTime": "2020-09-30T18:23:17.794Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "header": {
+                "key": "NAME",
+                "name": "Name",
+                "attributes": [
+                  {
+                    "key": "NAMESPACE",
+                    "value": "Namespace"
+                  },
+                  {
+                    "key": "KIND",
+                    "value": "Kind",
+                    "outerCSS": ""
+                  },
+                  {
+                    "key": "STATUS",
+                    "value": "Status",
+                    "outerCSS": ""
+                  }
+                ]
+              },
+              "body": [
+                {
+                  "name": "kui-notebook-1",
+                  "onclick": "kubectl get ns -n demo kui-notebook-1 -o yaml",
+                  "onclickSilence": true,
+                  "onclickIdempotent": true,
+                  "attributes": [
+                    {
+                      "key": "NAMESPACE",
+                      "value": "demo"
+                    },
+                    {
+                      "key": "KIND",
+                      "value": "ns",
+                      "outerCSS": "",
+                      "css": ""
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "value": "Active",
+                      "outerCSS": "",
+                      "css": "green-background"
+                    }
                   ],
-                  "parsedOptions": {
-                    "_": ["#", "    # Creating a Resource\\nCreate a Kubernetes Resource from configuration file."]
-                  },
-                  "execUUID": "d5737109-1a54-4f0b-ae12-2906fd7ac4d1",
-                  "cancelled": false,
-                  "echo": true,
-                  "evaluatorOptions": { "outputOnly": true, "plugin": "plugin-client-common" },
-                  "execOptions": {
-                    "echo": true,
-                    "type": 1,
-                    "execUUID": "d5737109-1a54-4f0b-ae12-2906fd7ac4d1",
-                    "history": 251,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "# Declarative Management of Kubernetes Objects\n\nKubernetes objects can be created, updated, and deleted by storing multiple object configuration files in a directory and using kubectl apply to recursively create and update those objects as needed. This method retains writes made to live objects without merging the changes back into the object configuration files."
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 251
+                  "key": "NAME"
                 }
-              },
-              {
-                "startTime": 1601054957220,
-                "startEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/split",
-                  "command": "split",
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "flags": { "boolean": ["inverse"] },
-                    "plugin": "plugin-client-common"
+              ]
+            },
+            "historyIdx": 251,
+            "cwd": "~/Workspace7/kui",
+            "command": "kubectl create ns kui-notebook-1",
+            "startEvent": {
+              "route": "/kubeui/kubectl/create",
+              "command": "kubectl create ns kui-notebook-1",
+              "evaluatorOptions": {
+                "flags": {
+                  "configuration": {
+                    "short-option-groups": false,
+                    "duplicate-arguments-array": false
                   },
-                  "execType": 0,
-                  "execUUID": "0b7e3d54-10ca-46a2-993e-26750a72f0dd"
+                  "narg": {
+                    "w": 0,
+                    "watch": 0,
+                    "watch-only": 0
+                  },
+                  "boolean": [
+                    "w",
+                    "watch",
+                    "watch-only",
+                    "A",
+                    "all-namespaces",
+                    "ignore-not-found",
+                    "no-headers",
+                    "i",
+                    "it",
+                    "ti",
+                    "stdin",
+                    "t",
+                    "tty",
+                    "R",
+                    "recursive",
+                    "server-print",
+                    "show-kind",
+                    "show-labels"
+                  ]
                 },
-                "completeEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 0,
-                  "command": "split",
-                  "argvNoOptions": ["split"],
-                  "parsedOptions": { "_": ["split"] },
-                  "execUUID": "0b7e3d54-10ca-46a2-993e-26750a72f0dd",
-                  "cancelled": false,
-                  "evaluatorOptions": { "outputOnly": true, "plugin": "plugin-client-common" },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "execUUID": "0b7e3d54-10ca-46a2-993e-26750a72f0dd",
-                    "history": 250,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "TabLayoutModificationResponse",
-                    "spec": {
-                      "modification": "NewSplit",
-                      "ok": {
-                        "apiVersion": "kui-shell/v1",
-                        "kind": "CommentaryResponse",
-                        "props": {
-                          "elsewhere": true,
-                          "tabUUID": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                          "children": "Created a split"
-                        }
-                      }
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 250
-                }
+                "alwaysViewIn": "Terminal",
+                "plugin": "plugin-kubectl"
               },
-              {
-                "startTime": 1601054957264,
-                "startEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "route": "/split",
-                  "command": "split --index 1",
-                  "evaluatorOptions": {
-                    "outputOnly": true,
-                    "flags": { "boolean": ["inverse"] },
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "39e42599-4565-423a-aa28-129c795d87b8"
-                },
-                "completeEvent": {
-                  "tab": "2_c57e811f-2da8-557e-a402-9f0950407675",
-                  "execType": 0,
-                  "command": "split --index 1",
-                  "argvNoOptions": ["split"],
-                  "parsedOptions": { "_": ["split"], "index": 1 },
-                  "execUUID": "39e42599-4565-423a-aa28-129c795d87b8",
-                  "cancelled": false,
-                  "evaluatorOptions": { "outputOnly": true, "plugin": "plugin-client-common" },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "execUUID": "39e42599-4565-423a-aa28-129c795d87b8",
-                    "history": 249,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "TabLayoutModificationResponse",
-                    "spec": {
-                      "modification": "NewSplit",
-                      "options": { "index": 1 },
-                      "ok": {
-                        "apiVersion": "kui-shell/v1",
-                        "kind": "CommentaryResponse",
-                        "props": {
-                          "elsewhere": true,
-                          "tabUUID": "2_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                          "children": "Created a split"
-                        }
-                      }
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 249
-                }
+              "execType": 0,
+              "execUUID": "953ac930-8845-47c9-bbf1-2927a7234459"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "kubectl create ns kui-notebook-1",
+              "argvNoOptions": ["kubectl", "create", "ns", "kui-notebook-1"],
+              "parsedOptions": {
+                "_": ["kubectl", "create", "ns", "kui-notebook-1"]
               },
-              {
-                "startTime": 1601054957345,
-                "startEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "route": "/#",
-                  "command": "# ",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        { "name": "--title", "alias": "-t", "docs": "Title for the commentary" },
-                        { "name": "--file", "alias": "-f", "docs": "File that contains the texts" }
-                      ]
+              "execUUID": "953ac930-8845-47c9-bbf1-2927a7234459",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "alwaysViewIn": "Terminal",
+                "plugin": "plugin-kubectl"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "953ac930-8845-47c9-bbf1-2927a7234459",
+                "history": 251,
+                "env": {}
+              },
+              "response": {
+                "header": {
+                  "key": "NAME",
+                  "name": "Name",
+                  "attributes": [
+                    {
+                      "key": "NAMESPACE",
+                      "value": "Namespace"
                     },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "d77f4305-33be-4772-8049-e13e4472f892"
-                },
-                "completeEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "execType": 0,
-                  "command": "#",
-                  "argvNoOptions": ["#"],
-                  "parsedOptions": { "_": ["#"] },
-                  "execUUID": "d77f4305-33be-4772-8049-e13e4472f892",
-                  "cancelled": false,
-                  "evaluatorOptions": { "outputOnly": true, "plugin": "plugin-client-common" },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "execUUID": "d77f4305-33be-4772-8049-e13e4472f892",
-                    "history": 135,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "## How to create objects\n\nUse `kubectl apply` to create all objects, except those that already exist, defined by configuration files in a specified directory. It is good practice to experiment in a separate namespace. First, we create a scratch namespace, and then we use `kubectl apply` to create a resource in that namespace."
+                    {
+                      "key": "KIND",
+                      "value": "Kind",
+                      "outerCSS": ""
+                    },
+                    {
+                      "key": "STATUS",
+                      "value": "Status",
+                      "outerCSS": ""
                     }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 135
-                }
-              },
-              {
-                "startTime": 1601054964546,
-                "startEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "route": "/kubeui/kubectl/create",
-                  "command": "kubectl create ns kui-notebook-1",
-                  "evaluatorOptions": {
-                    "flags": {
-                      "configuration": { "short-option-groups": false, "duplicate-arguments-array": false },
-                      "narg": { "w": 0, "watch": 0, "watch-only": 0 },
-                      "boolean": [
-                        "w",
-                        "watch",
-                        "watch-only",
-                        "A",
-                        "all-namespaces",
-                        "ignore-not-found",
-                        "no-headers",
-                        "i",
-                        "it",
-                        "ti",
-                        "stdin",
-                        "t",
-                        "tty",
-                        "R",
-                        "recursive",
-                        "server-print",
-                        "show-kind",
-                        "show-labels"
-                      ]
-                    },
-                    "alwaysViewIn": "Terminal",
-                    "plugin": "plugin-kubectl"
-                  },
-                  "execType": 0,
-                  "execUUID": "2cac6097-cf5b-4135-9118-c2e6f41199b3"
+                  ]
                 },
-                "completeEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "execType": 0,
-                  "command": "kubectl create ns kui-notebook-1",
-                  "argvNoOptions": ["kubectl", "create", "ns", "kui-notebook-1"],
-                  "parsedOptions": { "_": ["kubectl", "create", "ns", "kui-notebook-1"] },
-                  "execUUID": "2cac6097-cf5b-4135-9118-c2e6f41199b3",
-                  "cancelled": false,
-                  "evaluatorOptions": { "alwaysViewIn": "Terminal", "plugin": "plugin-kubectl" },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                    "execUUID": "2cac6097-cf5b-4135-9118-c2e6f41199b3",
-                    "history": 250,
-                    "env": {}
-                  },
-                  "response": {
-                    "header": {
-                      "key": "NAME",
-                      "name": "Name",
-                      "attributes": [
-                        { "key": "KIND", "value": "Kind", "outerCSS": "" },
-                        { "key": "STATUS", "value": "Status", "outerCSS": "" }
-                      ]
-                    },
-                    "body": [
+                "body": [
+                  {
+                    "name": "kui-notebook-1",
+                    "onclick": "kubectl get ns -n demo kui-notebook-1 -o yaml",
+                    "onclickSilence": true,
+                    "onclickIdempotent": true,
+                    "attributes": [
                       {
-                        "name": "kui-notebook-1",
-                        "onclick": "replay-click-2cac6097-cf5b-4135-9118-c2e6f41199b3-0",
-                        "onclickSilence": true,
-                        "onclickIdempotent": true,
-                        "attributes": [
-                          { "key": "KIND", "value": "ns", "outerCSS": "", "css": "" },
-                          {
-                            "key": "STATUS",
-                            "tag": "badge",
-                            "value": "Active",
-                            "outerCSS": "",
-                            "css": "green-background"
-                          }
-                        ],
-                        "key": "NAME",
-                        "onclickExec": "qexec"
-                      }
-                    ]
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 250
-                }
-              },
-              {
-                "startTime": 1601054957411,
-                "startEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "route": "/#",
-                  "command": "#  Now we can use `apply`:",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        { "name": "--title", "alias": "-t", "docs": "Title for the commentary" },
-                        { "name": "--file", "alias": "-f", "docs": "File that contains the texts" }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "a8634777-9f4f-4db4-b86a-b5e960eb584a"
-                },
-                "completeEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "execType": 0,
-                  "command": "# Now we can use `apply`:",
-                  "argvNoOptions": ["#", "  Now we can use `apply`:"],
-                  "parsedOptions": { "_": ["#", "  Now we can use `apply`:"] },
-                  "execUUID": "a8634777-9f4f-4db4-b86a-b5e960eb584a",
-                  "cancelled": false,
-                  "evaluatorOptions": { "outputOnly": true, "plugin": "plugin-client-common" },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "execUUID": "a8634777-9f4f-4db4-b86a-b5e960eb584a",
-                    "history": 139,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": { "children": "Now we can use `apply`:" }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 139
-                }
-              },
-              {
-                "startTime": 1601054967333,
-                "startEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "route": "/kubeui/kubectl/apply",
-                  "command": "kubectl apply -f https://k8s.io/examples/application/simple_deployment.yaml -n kui-notebook-1",
-                  "evaluatorOptions": {
-                    "flags": {
-                      "configuration": { "short-option-groups": false, "duplicate-arguments-array": false },
-                      "narg": { "w": 0, "watch": 0, "watch-only": 0 },
-                      "boolean": [
-                        "w",
-                        "watch",
-                        "watch-only",
-                        "A",
-                        "all-namespaces",
-                        "ignore-not-found",
-                        "no-headers",
-                        "i",
-                        "it",
-                        "ti",
-                        "stdin",
-                        "t",
-                        "tty",
-                        "R",
-                        "recursive",
-                        "server-print",
-                        "show-kind",
-                        "show-labels"
-                      ]
-                    },
-                    "alwaysViewIn": "Terminal",
-                    "plugin": "plugin-kubectl"
-                  },
-                  "execType": 0,
-                  "execUUID": "a20d8456-a58e-418d-adbc-0d5e98dcaef7"
-                },
-                "completeEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "execType": 0,
-                  "command": "kubectl apply -f https://k8s.io/examples/application/simple_deployment.yaml -n kui-notebook-1",
-                  "argvNoOptions": ["kubectl", "apply"],
-                  "parsedOptions": {
-                    "_": ["kubectl", "apply"],
-                    "f": "https://k8s.io/examples/application/simple_deployment.yaml",
-                    "n": "kui-notebook-1"
-                  },
-                  "execUUID": "a20d8456-a58e-418d-adbc-0d5e98dcaef7",
-                  "cancelled": false,
-                  "evaluatorOptions": { "alwaysViewIn": "Terminal", "plugin": "plugin-kubectl" },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                    "execUUID": "a20d8456-a58e-418d-adbc-0d5e98dcaef7",
-                    "history": 251,
-                    "env": {}
-                  },
-                  "response": {
-                    "header": {
-                      "key": "NAME",
-                      "name": "Name",
-                      "attributes": [
-                        { "key": "NAMESPACE", "value": "Namespace" },
-                        { "key": "KIND", "value": "Kind", "outerCSS": "" },
-                        { "key": "STATUS", "value": "Status", "outerCSS": "" }
-                      ]
-                    },
-                    "body": [
+                        "key": "NAMESPACE",
+                        "value": "demo"
+                      },
                       {
-                        "name": "nginx-deployment",
-                        "onclick": "replay-click-a20d8456-a58e-418d-adbc-0d5e98dcaef7-0",
-                        "onclickSilence": true,
-                        "onclickIdempotent": true,
-                        "attributes": [
-                          { "key": "NAMESPACE", "value": "kui-notebook-1" },
-                          { "key": "KIND", "value": "Deployment.v1.apps", "outerCSS": "", "css": "" },
-                          { "key": "STATUS", "tag": "badge", "value": "1/1", "outerCSS": "", "css": "green-background" }
-                        ],
-                        "key": "NAME",
-                        "onclickExec": "qexec"
+                        "key": "KIND",
+                        "value": "ns",
+                        "outerCSS": "",
+                        "css": ""
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "value": "Active",
+                        "outerCSS": "",
+                        "css": "green-background"
                       }
                     ],
-                    "kuiSourceRef": {
-                      "templates": [
-                        {
-                          "filepath": "https://k8s.io/examples/application/simple_deployment.yaml",
-                          "data": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: nginx-deployment\nspec:\n  selector:\n    matchLabels:\n      app: nginx\n  minReadySeconds: 5\n  template:\n    metadata:\n      labels:\n        app: nginx\n    spec:\n      containers:\n      - name: nginx\n        image: nginx:1.14.2\n        ports:\n        - containerPort: 80\n",
-                          "isFor": "f",
-                          "kind": "source",
-                          "contentType": "yaml"
-                        }
-                      ]
+                    "key": "NAME"
+                  }
+                ]
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 251
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "953ac930-8845-47c9-bbf1-2927a7234459",
+            "startTime": "2020-09-30T18:23:30.075Z",
+            "prefersTerminalPresentation": true,
+            "outputOnly": false,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "Now we can use apply:"
+              }
+            },
+            "historyIdx": 252,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
                     }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 251
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "56012fcd-afbd-4afb-b289-423038ce4e2a"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "56012fcd-afbd-4afb-b289-423038ce4e2a",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "56012fcd-afbd-4afb-b289-423038ce4e2a",
+                "history": 252,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "Now we can use apply:"
                 }
               },
-              {
-                "startTime": 1601054957475,
-                "startEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "route": "/#",
-                  "command": "# ",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        { "name": "--title", "alias": "-t", "docs": "Title for the commentary" },
-                        { "name": "--file", "alias": "-f", "docs": "File that contains the texts" }
-                      ]
+              "responseType": "ScalarResponse",
+              "historyIdx": 252
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "56012fcd-afbd-4afb-b289-423038ce4e2a",
+            "startTime": "2020-09-30T18:23:40.337Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "header": {
+                "key": "NAME",
+                "name": "Name",
+                "attributes": [
+                  {
+                    "key": "NAMESPACE",
+                    "value": "Namespace"
+                  },
+                  {
+                    "key": "KIND",
+                    "value": "Kind",
+                    "outerCSS": ""
+                  },
+                  {
+                    "key": "STATUS",
+                    "value": "Status",
+                    "outerCSS": ""
+                  }
+                ]
+              },
+              "body": [
+                {
+                  "name": "nginx-deployment",
+                  "onclick": "kubectl get Deployment.v1.apps -n kui-notebook-1 nginx-deployment -o yaml",
+                  "onclickSilence": true,
+                  "onclickIdempotent": true,
+                  "attributes": [
+                    {
+                      "key": "NAMESPACE",
+                      "value": "kui-notebook-1"
                     },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "f44a546e-ccc5-4506-b127-6078e481b47d"
-                },
-                "completeEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "execType": 0,
-                  "command": "#",
-                  "argvNoOptions": ["#"],
-                  "parsedOptions": { "_": ["#"] },
-                  "execUUID": "f44a546e-ccc5-4506-b127-6078e481b47d",
-                  "cancelled": false,
-                  "evaluatorOptions": { "outputOnly": true, "plugin": "plugin-client-common" },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "execUUID": "f44a546e-ccc5-4506-b127-6078e481b47d",
-                    "history": 141,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "## Listing Resources\n\nUse the following command to list your Kubernetes Deployment Resources.\n\n**Note**: Deployments are Resources which manage Pod replicas (Pods run Containers)"
+                    {
+                      "key": "KIND",
+                      "value": "Deployment.v1.apps",
+                      "outerCSS": "",
+                      "css": ""
+                    },
+                    {
+                      "key": "STATUS",
+                      "tag": "badge",
+                      "value": "1/1",
+                      "outerCSS": "",
+                      "css": "green-background"
                     }
+                  ],
+                  "key": "NAME"
+                }
+              ],
+              "kuiSourceRef": {
+                "templates": [
+                  {
+                    "filepath": "https://k8s.io/examples/application/simple_deployment.yaml",
+                    "data": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: nginx-deployment\nspec:\n  selector:\n    matchLabels:\n      app: nginx\n  minReadySeconds: 5\n  template:\n    metadata:\n      labels:\n        app: nginx\n    spec:\n      containers:\n      - name: nginx\n        image: nginx:1.14.2\n        ports:\n        - containerPort: 80\n",
+                    "isFor": "f",
+                    "kind": "source",
+                    "contentType": "yaml"
+                  }
+                ]
+              }
+            },
+            "historyIdx": 253,
+            "cwd": "~/Workspace7/kui",
+            "command": "kubectl apply -f https://k8s.io/examples/application/simple_deployment.yaml -n kui-notebook-1",
+            "startEvent": {
+              "route": "/kubeui/kubectl/apply",
+              "command": "kubectl apply -f https://k8s.io/examples/application/simple_deployment.yaml -n kui-notebook-1",
+              "evaluatorOptions": {
+                "flags": {
+                  "configuration": {
+                    "short-option-groups": false,
+                    "duplicate-arguments-array": false
                   },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 141
+                  "narg": {
+                    "w": 0,
+                    "watch": 0,
+                    "watch-only": 0
+                  },
+                  "boolean": [
+                    "w",
+                    "watch",
+                    "watch-only",
+                    "A",
+                    "all-namespaces",
+                    "ignore-not-found",
+                    "no-headers",
+                    "i",
+                    "it",
+                    "ti",
+                    "stdin",
+                    "t",
+                    "tty",
+                    "R",
+                    "recursive",
+                    "server-print",
+                    "show-kind",
+                    "show-labels"
+                  ]
+                },
+                "alwaysViewIn": "Terminal",
+                "plugin": "plugin-kubectl"
+              },
+              "execType": 0,
+              "execUUID": "8486037b-de86-4ad2-ac12-53d340192b20"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "kubectl apply -f https://k8s.io/examples/application/simple_deployment.yaml -n kui-notebook-1",
+              "argvNoOptions": ["kubectl", "apply"],
+              "parsedOptions": {
+                "_": ["kubectl", "apply"],
+                "f": "https://k8s.io/examples/application/simple_deployment.yaml",
+                "n": "kui-notebook-1"
+              },
+              "execUUID": "8486037b-de86-4ad2-ac12-53d340192b20",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "alwaysViewIn": "Terminal",
+                "plugin": "plugin-kubectl"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "8486037b-de86-4ad2-ac12-53d340192b20",
+                "history": 253,
+                "env": {}
+              },
+              "response": {
+                "header": {
+                  "key": "NAME",
+                  "name": "Name",
+                  "attributes": [
+                    {
+                      "key": "NAMESPACE",
+                      "value": "Namespace"
+                    },
+                    {
+                      "key": "KIND",
+                      "value": "Kind",
+                      "outerCSS": ""
+                    },
+                    {
+                      "key": "STATUS",
+                      "value": "Status",
+                      "outerCSS": ""
+                    }
+                  ]
+                },
+                "body": [
+                  {
+                    "name": "nginx-deployment",
+                    "onclick": "kubectl get Deployment.v1.apps -n kui-notebook-1 nginx-deployment -o yaml",
+                    "onclickSilence": true,
+                    "onclickIdempotent": true,
+                    "attributes": [
+                      {
+                        "key": "NAMESPACE",
+                        "value": "kui-notebook-1"
+                      },
+                      {
+                        "key": "KIND",
+                        "value": "Deployment.v1.apps",
+                        "outerCSS": "",
+                        "css": ""
+                      },
+                      {
+                        "key": "STATUS",
+                        "tag": "badge",
+                        "value": "1/1",
+                        "outerCSS": "",
+                        "css": "green-background"
+                      }
+                    ],
+                    "key": "NAME"
+                  }
+                ],
+                "kuiSourceRef": {
+                  "templates": [
+                    {
+                      "filepath": "https://k8s.io/examples/application/simple_deployment.yaml",
+                      "data": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: nginx-deployment\nspec:\n  selector:\n    matchLabels:\n      app: nginx\n  minReadySeconds: 5\n  template:\n    metadata:\n      labels:\n        app: nginx\n    spec:\n      containers:\n      - name: nginx\n        image: nginx:1.14.2\n        ports:\n        - containerPort: 80\n",
+                      "isFor": "f",
+                      "kind": "source",
+                      "contentType": "yaml"
+                    }
+                  ]
                 }
               },
-              {
-                "startTime": 1601054973177,
-                "startEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "route": "/kubeui/kubectl/get/deployments",
-                  "command": "kubectl get deployments -n kui-notebook-1",
-                  "evaluatorOptions": {
-                    "flags": {
-                      "configuration": { "short-option-groups": false, "duplicate-arguments-array": false },
-                      "narg": { "w": 0, "watch": 0, "watch-only": 0 },
-                      "boolean": [
-                        "w",
-                        "watch",
-                        "watch-only",
-                        "A",
-                        "all-namespaces",
-                        "ignore-not-found",
-                        "no-headers",
-                        "i",
-                        "it",
-                        "ti",
-                        "stdin",
-                        "t",
-                        "tty",
-                        "R",
-                        "recursive",
-                        "server-print",
-                        "show-kind",
-                        "show-labels"
-                      ]
+              "responseType": "ScalarResponse",
+              "historyIdx": 253
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "8486037b-de86-4ad2-ac12-53d340192b20",
+            "startTime": "2020-09-30T18:23:48.498Z",
+            "prefersTerminalPresentation": true,
+            "outputOnly": false,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "## Listing Resources\n\nUse the following command to list your Kubernetes Deployment Resources.\n\n**Note**: Deployments are Resources which manage Pod replicas (Pods run Containers)"
+              }
+            },
+            "historyIdx": 254,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
                     },
-                    "plugin": "plugin-kubectl"
-                  },
-                  "execType": 0,
-                  "execUUID": "f5204b3d-3d4c-4c65-bc41-006cd97d03ec"
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
                 },
-                "completeEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "execType": 0,
-                  "command": "kubectl get deployments -n kui-notebook-1",
-                  "argvNoOptions": ["kubectl", "get", "deployments"],
-                  "parsedOptions": { "_": ["kubectl", "get", "deployments"], "n": "kui-notebook-1" },
-                  "execUUID": "f5204b3d-3d4c-4c65-bc41-006cd97d03ec",
-                  "cancelled": false,
-                  "evaluatorOptions": { "plugin": "plugin-kubectl" },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                    "execUUID": "f5204b3d-3d4c-4c65-bc41-006cd97d03ec",
-                    "history": 252,
-                    "env": {}
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "2513d2a4-cfae-468a-ad7e-78bc09bb46b9"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "2513d2a4-cfae-468a-ad7e-78bc09bb46b9",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "2513d2a4-cfae-468a-ad7e-78bc09bb46b9",
+                "history": 254,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "## Listing Resources\n\nUse the following command to list your Kubernetes Deployment Resources.\n\n**Note**: Deployments are Resources which manage Pod replicas (Pods run Containers)"
+                }
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 254
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "2513d2a4-cfae-468a-ad7e-78bc09bb46b9",
+            "startTime": "2020-09-30T18:23:57.650Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "header": {
+                "key": "NAME",
+                "name": "Name",
+                "rowKey": "NAME",
+                "fontawesome": false,
+                "onclick": false,
+                "onclickIdempotent": true,
+                "onclickSilence": true,
+                "css": " kui--table-cell-is-name",
+                "rowCSS": [],
+                "outerCSS": "header-cell entity-name-group",
+                "attributes": [
+                  {
+                    "key": "READY",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell a-few-numbers-wide ",
+                    "css": "  yellow-background",
+                    "value": "Ready"
                   },
-                  "response": {
-                    "header": {
-                      "key": "NAME",
-                      "name": "Name",
-                      "rowKey": "NAME",
-                      "fontawesome": false,
+                  {
+                    "key": "UP-TO-DATE",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell kui--hide-in-narrower-windows",
+                    "css": "  ",
+                    "value": "Up-to-date"
+                  },
+                  {
+                    "key": "AVAILABLE",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell  hide-with-sidecar",
+                    "css": "  ",
+                    "value": "Available"
+                  },
+                  {
+                    "key": "AGE",
+                    "tag": false,
+                    "onclick": false,
+                    "outerCSS": "header-cell hide-with-sidecar hide-with-sidecar",
+                    "css": "  ",
+                    "value": "Age"
+                  }
+                ]
+              },
+              "body": [
+                {
+                  "key": "NAME",
+                  "name": "nginx-deployment",
+                  "rowKey": "nginx-deployment",
+                  "fontawesome": false,
+                  "onclick": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1 ",
+                  "onclickIdempotent": true,
+                  "onclickSilence": true,
+                  "css": " kui--table-cell-is-name",
+                  "rowCSS": [],
+                  "outerCSS": " entity-name-group",
+                  "attributes": [
+                    {
+                      "key": "READY",
+                      "tag": "badge",
                       "onclick": false,
-                      "onclickIdempotent": true,
-                      "onclickSilence": true,
-                      "css": " kui--table-cell-is-name",
-                      "rowCSS": [],
-                      "outerCSS": "header-cell entity-name-group",
-                      "attributes": [
-                        {
-                          "key": "READY",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell a-few-numbers-wide ",
-                          "css": "  yellow-background",
-                          "value": "Ready"
-                        },
-                        {
-                          "key": "UP-TO-DATE",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell kui--hide-in-narrower-windows",
-                          "css": "  ",
-                          "value": "Up-to-date"
-                        },
-                        {
-                          "key": "AVAILABLE",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell  hide-with-sidecar",
-                          "css": "  ",
-                          "value": "Available"
-                        },
-                        {
-                          "key": "AGE",
-                          "tag": false,
-                          "onclick": false,
-                          "outerCSS": "header-cell hide-with-sidecar hide-with-sidecar",
-                          "css": "  ",
-                          "value": "Age"
-                        }
-                      ]
+                      "outerCSS": " a-few-numbers-wide ",
+                      "css": "green-background",
+                      "value": "1/1"
                     },
-                    "body": [
-                      {
-                        "key": "NAME",
-                        "name": "nginx-deployment",
-                        "rowKey": "nginx-deployment",
-                        "fontawesome": false,
-                        "onclick": "replay-click-f5204b3d-3d4c-4c65-bc41-006cd97d03ec-0",
-                        "onclickIdempotent": true,
-                        "onclickSilence": true,
-                        "css": " kui--table-cell-is-name",
-                        "rowCSS": [],
-                        "outerCSS": " entity-name-group",
-                        "attributes": [
-                          {
-                            "key": "READY",
-                            "tag": "badge",
-                            "onclick": false,
-                            "outerCSS": " a-few-numbers-wide ",
-                            "css": "green-background",
-                            "value": "1/1"
-                          },
-                          {
-                            "key": "UP-TO-DATE",
-                            "onclick": false,
-                            "outerCSS": " kui--hide-in-narrower-windows",
-                            "css": "  green-background",
-                            "value": "1"
-                          },
-                          {
-                            "key": "AVAILABLE",
-                            "onclick": false,
-                            "outerCSS": "  hide-with-sidecar",
-                            "css": "  red-background",
-                            "value": "0"
-                          },
-                          {
-                            "key": "AGE",
-                            "onclick": false,
-                            "outerCSS": " hide-with-sidecar hide-with-sidecar",
-                            "css": " slightly-deemphasize ",
-                            "value": "5s"
-                          }
-                        ],
-                        "onclickExec": "qexec"
-                      }
-                    ],
-                    "noSort": true,
-                    "title": "Deployment",
-                    "breadcrumbs": [{ "label": "kui-notebook-1" }],
-                    "statusColumnIdx": 0
+                    {
+                      "key": "UP-TO-DATE",
+                      "onclick": false,
+                      "outerCSS": " kui--hide-in-narrower-windows",
+                      "css": "  green-background",
+                      "value": "1"
+                    },
+                    {
+                      "key": "AVAILABLE",
+                      "onclick": false,
+                      "outerCSS": "  hide-with-sidecar",
+                      "css": "  green-background",
+                      "value": "1"
+                    },
+                    {
+                      "key": "AGE",
+                      "onclick": false,
+                      "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                      "css": " slightly-deemphasize ",
+                      "value": "17s"
+                    }
+                  ]
+                }
+              ],
+              "noSort": true,
+              "title": "Deployment",
+              "breadcrumbs": [
+                {
+                  "label": "kui-notebook-1"
+                }
+              ],
+              "statusColumnIdx": 0
+            },
+            "historyIdx": 255,
+            "cwd": "~/Workspace7/kui",
+            "command": "kubectl get deployments -n kui-notebook-1",
+            "startEvent": {
+              "route": "/kubeui/kubectl/get/deployments",
+              "command": "kubectl get deployments -n kui-notebook-1",
+              "evaluatorOptions": {
+                "flags": {
+                  "configuration": {
+                    "short-option-groups": false,
+                    "duplicate-arguments-array": false
                   },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 252
+                  "narg": {
+                    "w": 0,
+                    "watch": 0,
+                    "watch-only": 0
+                  },
+                  "boolean": [
+                    "w",
+                    "watch",
+                    "watch-only",
+                    "A",
+                    "all-namespaces",
+                    "ignore-not-found",
+                    "no-headers",
+                    "i",
+                    "it",
+                    "ti",
+                    "stdin",
+                    "t",
+                    "tty",
+                    "R",
+                    "recursive",
+                    "server-print",
+                    "show-kind",
+                    "show-labels"
+                  ]
+                },
+                "plugin": "plugin-kubectl"
+              },
+              "execType": 1,
+              "execUUID": "b81296f9-e1d8-4e87-8011-ff88e8c35169",
+              "echo": true
+            },
+            "completeEvent": {
+              "execType": 1,
+              "command": "kubectl get deployments -n kui-notebook-1",
+              "argvNoOptions": ["kubectl", "get", "deployments"],
+              "parsedOptions": {
+                "_": ["kubectl", "get", "deployments"],
+                "n": "kui-notebook-1"
+              },
+              "execUUID": "b81296f9-e1d8-4e87-8011-ff88e8c35169",
+              "cancelled": false,
+              "echo": true,
+              "evaluatorOptions": {
+                "plugin": "plugin-kubectl"
+              },
+              "execOptions": {
+                "echo": true,
+                "type": 1,
+                "execUUID": "b81296f9-e1d8-4e87-8011-ff88e8c35169",
+                "history": 255,
+                "env": {}
+              },
+              "response": {
+                "header": {
+                  "key": "NAME",
+                  "name": "Name",
+                  "rowKey": "NAME",
+                  "fontawesome": false,
+                  "onclick": false,
+                  "onclickIdempotent": true,
+                  "onclickSilence": true,
+                  "css": " kui--table-cell-is-name",
+                  "rowCSS": [],
+                  "outerCSS": "header-cell entity-name-group",
+                  "attributes": [
+                    {
+                      "key": "READY",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell a-few-numbers-wide ",
+                      "css": "  yellow-background",
+                      "value": "Ready"
+                    },
+                    {
+                      "key": "UP-TO-DATE",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell kui--hide-in-narrower-windows",
+                      "css": "  ",
+                      "value": "Up-to-date"
+                    },
+                    {
+                      "key": "AVAILABLE",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell  hide-with-sidecar",
+                      "css": "  ",
+                      "value": "Available"
+                    },
+                    {
+                      "key": "AGE",
+                      "tag": false,
+                      "onclick": false,
+                      "outerCSS": "header-cell hide-with-sidecar hide-with-sidecar",
+                      "css": "  ",
+                      "value": "Age"
+                    }
+                  ]
+                },
+                "body": [
+                  {
+                    "key": "NAME",
+                    "name": "nginx-deployment",
+                    "rowKey": "nginx-deployment",
+                    "fontawesome": false,
+                    "onclick": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1 ",
+                    "onclickIdempotent": true,
+                    "onclickSilence": true,
+                    "css": " kui--table-cell-is-name",
+                    "rowCSS": [],
+                    "outerCSS": " entity-name-group",
+                    "attributes": [
+                      {
+                        "key": "READY",
+                        "tag": "badge",
+                        "onclick": false,
+                        "outerCSS": " a-few-numbers-wide ",
+                        "css": "green-background",
+                        "value": "1/1"
+                      },
+                      {
+                        "key": "UP-TO-DATE",
+                        "onclick": false,
+                        "outerCSS": " kui--hide-in-narrower-windows",
+                        "css": "  green-background",
+                        "value": "1"
+                      },
+                      {
+                        "key": "AVAILABLE",
+                        "onclick": false,
+                        "outerCSS": "  hide-with-sidecar",
+                        "css": "  green-background",
+                        "value": "1"
+                      },
+                      {
+                        "key": "AGE",
+                        "onclick": false,
+                        "outerCSS": " hide-with-sidecar hide-with-sidecar",
+                        "css": " slightly-deemphasize ",
+                        "value": "17s"
+                      }
+                    ]
+                  }
+                ],
+                "noSort": true,
+                "title": "Deployment",
+                "breadcrumbs": [
+                  {
+                    "label": "kui-notebook-1"
+                  }
+                ],
+                "statusColumnIdx": 0
+              },
+              "responseType": "ScalarResponse",
+              "historyIdx": 255
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "b81296f9-e1d8-4e87-8011-ff88e8c35169",
+            "startTime": "2020-09-30T18:24:05.830Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": false,
+            "state": "valid-response"
+          },
+          {
+            "response": {
+              "apiVersion": "kui-shell/v1",
+              "kind": "CommentaryResponse",
+              "props": {
+                "children": "To drill down to the details of a resource, in Kui you may click on the Name cell of any table."
+              }
+            },
+            "historyIdx": 256,
+            "cwd": "~/Workspace7/kui",
+            "command": "# ",
+            "startEvent": {
+              "route": "/#",
+              "command": "# ",
+              "evaluatorOptions": {
+                "usage": {
+                  "command": "commentary",
+                  "strict": "commentary",
+                  "example": "commentary -f [<markdown file path>]",
+                  "docs": "Commentary",
+                  "optional": [
+                    {
+                      "name": "--title",
+                      "alias": "-t",
+                      "docs": "Title for the commentary"
+                    },
+                    {
+                      "name": "--file",
+                      "alias": "-f",
+                      "docs": "File that contains the texts"
+                    }
+                  ]
+                },
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execType": 0,
+              "execUUID": "56ce9c27-5a32-4d5a-83e8-0dec6c2fb41c"
+            },
+            "completeEvent": {
+              "execType": 0,
+              "command": "#",
+              "argvNoOptions": ["#"],
+              "parsedOptions": {
+                "_": ["#"]
+              },
+              "execUUID": "56ce9c27-5a32-4d5a-83e8-0dec6c2fb41c",
+              "cancelled": false,
+              "evaluatorOptions": {
+                "outputOnly": true,
+                "plugin": "plugin-client-common"
+              },
+              "execOptions": {
+                "type": 0,
+                "language": "en-US",
+                "execUUID": "56ce9c27-5a32-4d5a-83e8-0dec6c2fb41c",
+                "history": 256,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "kui-shell/v1",
+                "kind": "CommentaryResponse",
+                "props": {
+                  "children": "To drill down to the details of a resource, in Kui you may click on the Name cell of any table."
                 }
               },
-              {
-                "startTime": 1601054957547,
-                "startEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "route": "/#",
-                  "command": "#   To drill down to the details of a resource, in Kui you may click on the Name cell of any table.",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        { "name": "--title", "alias": "-t", "docs": "Title for the commentary" },
-                        { "name": "--file", "alias": "-f", "docs": "File that contains the texts" }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
+              "responseType": "ScalarResponse",
+              "historyIdx": 256
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "56ce9c27-5a32-4d5a-83e8-0dec6c2fb41c",
+            "startTime": "2020-09-30T18:24:13.898Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": true,
+            "state": "valid-response"
+          },
+          {
+            "response": true,
+            "historyIdx": 257,
+            "cwd": "~/Workspace7/kui",
+            "command": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1",
+            "startEvent": {
+              "route": "/kubeui/kubectl/get/Deployment",
+              "command": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1",
+              "evaluatorOptions": {
+                "flags": {
+                  "configuration": {
+                    "short-option-groups": false,
+                    "duplicate-arguments-array": false
                   },
-                  "execType": 0,
-                  "execUUID": "515bea74-0aaa-44c2-aa5e-21c7c725fd78"
+                  "narg": {
+                    "w": 0,
+                    "watch": 0,
+                    "watch-only": 0
+                  },
+                  "boolean": [
+                    "w",
+                    "watch",
+                    "watch-only",
+                    "A",
+                    "all-namespaces",
+                    "ignore-not-found",
+                    "no-headers",
+                    "i",
+                    "it",
+                    "ti",
+                    "stdin",
+                    "t",
+                    "tty",
+                    "R",
+                    "recursive",
+                    "server-print",
+                    "show-kind",
+                    "show-labels"
+                  ]
                 },
-                "completeEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "execType": 0,
-                  "command": "#  To drill down to the details of a resource, in Kui you may click on the Name cell of any table.",
-                  "argvNoOptions": [
-                    "#",
-                    "   To drill down to the details of a resource, in Kui you may click on the Name cell of any table."
-                  ],
-                  "parsedOptions": {
-                    "_": [
-                      "#",
-                      "   To drill down to the details of a resource, in Kui you may click on the Name cell of any table."
-                    ]
+                "plugin": "plugin-kubectl"
+              },
+              "execType": 1,
+              "execUUID": "b9313254-28e5-4bb2-99bf-3ca03e6a31aa",
+              "echo": false
+            },
+            "completeEvent": {
+              "execType": 1,
+              "command": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1 ",
+              "argvNoOptions": ["kubectl", "get", "Deployment", "nginx-deployment"],
+              "parsedOptions": {
+                "_": ["kubectl", "get", "Deployment", "nginx-deployment"],
+                "o": "yaml",
+                "n": "kui-notebook-1"
+              },
+              "execUUID": "b9313254-28e5-4bb2-99bf-3ca03e6a31aa",
+              "cancelled": false,
+              "echo": false,
+              "evaluatorOptions": {
+                "plugin": "plugin-kubectl"
+              },
+              "execOptions": {
+                "echo": false,
+                "type": 1,
+                "execUUID": "b9313254-28e5-4bb2-99bf-3ca03e6a31aa",
+                "history": 257,
+                "env": {}
+              },
+              "response": {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "metadata": {
+                  "annotations": {
+                    "deployment.kubernetes.io/revision": "1",
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"name\":\"nginx-deployment\",\"namespace\":\"kui-notebook-1\"},\"spec\":{\"minReadySeconds\":5,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"nginx\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:1.14.2\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}}}\n"
                   },
-                  "execUUID": "515bea74-0aaa-44c2-aa5e-21c7c725fd78",
-                  "cancelled": false,
-                  "evaluatorOptions": { "outputOnly": true, "plugin": "plugin-client-common" },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "execUUID": "515bea74-0aaa-44c2-aa5e-21c7c725fd78",
-                    "history": 144,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "To drill down to the details of a resource, in Kui you may click on the Name cell of any table."
+                  "creationTimestamp": "2020-09-30T18:23:49Z",
+                  "generation": 1,
+                  "name": "nginx-deployment",
+                  "namespace": "kui-notebook-1",
+                  "resourceVersion": "1136302",
+                  "selfLink": "/apis/apps/v1/namespaces/kui-notebook-1/deployments/nginx-deployment",
+                  "uid": "4c0f9760-76b1-4266-8cac-dd52714ef5af"
+                },
+                "spec": {
+                  "minReadySeconds": 5,
+                  "progressDeadlineSeconds": 600,
+                  "replicas": 1,
+                  "revisionHistoryLimit": 10,
+                  "selector": {
+                    "matchLabels": {
+                      "app": "nginx"
                     }
                   },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 144
-                }
-              },
-              {
-                "startTime": 1601054976667,
-                "startEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "route": "/kubeui/kubectl/get/Deployment",
-                  "command": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1",
-                  "evaluatorOptions": {
-                    "flags": {
-                      "configuration": { "short-option-groups": false, "duplicate-arguments-array": false },
-                      "narg": { "w": 0, "watch": 0, "watch-only": 0 },
-                      "boolean": [
-                        "w",
-                        "watch",
-                        "watch-only",
-                        "A",
-                        "all-namespaces",
-                        "ignore-not-found",
-                        "no-headers",
-                        "i",
-                        "it",
-                        "ti",
-                        "stdin",
-                        "t",
-                        "tty",
-                        "R",
-                        "recursive",
-                        "server-print",
-                        "show-kind",
-                        "show-labels"
-                      ]
+                  "strategy": {
+                    "rollingUpdate": {
+                      "maxSurge": "25%",
+                      "maxUnavailable": "25%"
                     },
-                    "plugin": "plugin-kubectl"
+                    "type": "RollingUpdate"
                   },
-                  "execType": 1,
-                  "execUUID": "00db90ab-657f-4347-b65b-a0b74e14ebf9",
-                  "echo": false
+                  "template": {
+                    "metadata": {
+                      "creationTimestamp": null,
+                      "labels": {
+                        "app": "nginx"
+                      }
+                    },
+                    "spec": {
+                      "containers": [
+                        {
+                          "image": "nginx:1.14.2",
+                          "imagePullPolicy": "IfNotPresent",
+                          "name": "nginx",
+                          "ports": [
+                            {
+                              "containerPort": 80,
+                              "protocol": "TCP"
+                            }
+                          ],
+                          "resources": {},
+                          "terminationMessagePath": "/dev/termination-log",
+                          "terminationMessagePolicy": "File"
+                        }
+                      ],
+                      "dnsPolicy": "ClusterFirst",
+                      "restartPolicy": "Always",
+                      "schedulerName": "default-scheduler",
+                      "securityContext": {},
+                      "terminationGracePeriodSeconds": 30
+                    }
+                  }
                 },
-                "completeEvent": {
-                  "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                  "execType": 1,
-                  "command": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1 ",
+                "status": {
+                  "availableReplicas": 1,
+                  "conditions": [
+                    {
+                      "lastTransitionTime": "2020-09-30T18:23:57Z",
+                      "lastUpdateTime": "2020-09-30T18:23:57Z",
+                      "message": "Deployment has minimum availability.",
+                      "reason": "MinimumReplicasAvailable",
+                      "status": "True",
+                      "type": "Available"
+                    },
+                    {
+                      "lastTransitionTime": "2020-09-30T18:23:49Z",
+                      "lastUpdateTime": "2020-09-30T18:23:57Z",
+                      "message": "ReplicaSet \"nginx-deployment-574b87c764\" has successfully progressed.",
+                      "reason": "NewReplicaSetAvailable",
+                      "status": "True",
+                      "type": "Progressing"
+                    }
+                  ],
+                  "observedGeneration": 1,
+                  "readyReplicas": 1,
+                  "replicas": 1,
+                  "updatedReplicas": 1
+                },
+                "isKubeResource": true,
+                "originatingCommand": {
+                  "REPL": {},
+                  "argv": ["kubectl", "get", "Deployment", "nginx-deployment", "-o", "yaml", "-n", "kui-notebook-1"],
+                  "command": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1",
+                  "execOptions": {
+                    "echo": false,
+                    "type": 1,
+                    "execUUID": "b9313254-28e5-4bb2-99bf-3ca03e6a31aa",
+                    "history": 257,
+                    "env": {}
+                  },
                   "argvNoOptions": ["kubectl", "get", "Deployment", "nginx-deployment"],
                   "parsedOptions": {
                     "_": ["kubectl", "get", "Deployment", "nginx-deployment"],
                     "o": "yaml",
                     "n": "kui-notebook-1"
-                  },
-                  "execUUID": "00db90ab-657f-4347-b65b-a0b74e14ebf9",
-                  "cancelled": false,
-                  "echo": false,
-                  "evaluatorOptions": { "plugin": "plugin-kubectl" },
-                  "execOptions": {
-                    "echo": false,
-                    "type": 1,
-                    "tab": "2_0a9586b6-2f57-5d3b-9619-b5cdb6a76d53",
-                    "execUUID": "00db90ab-657f-4347-b65b-a0b74e14ebf9",
-                    "history": 253,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "apps/v1",
-                    "kind": "Deployment",
-                    "metadata": {
-                      "annotations": {
-                        "deployment.kubernetes.io/revision": "1",
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"name\":\"nginx-deployment\",\"namespace\":\"kui-notebook-1\"},\"spec\":{\"minReadySeconds\":5,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"nginx\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:1.14.2\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}}}\n"
-                      },
-                      "creationTimestamp": "2020-09-25T17:29:28Z",
-                      "generation": 1,
-                      "name": "nginx-deployment",
-                      "namespace": "kui-notebook-1",
-                      "resourceVersion": "81846594",
-                      "selfLink": "/apis/apps/v1/namespaces/kui-notebook-1/deployments/nginx-deployment",
-                      "uid": "c323f4b4-1297-42ca-8e58-8e5347bf98fa"
-                    },
-                    "spec": {
-                      "minReadySeconds": 5,
-                      "progressDeadlineSeconds": 600,
-                      "replicas": 1,
-                      "revisionHistoryLimit": 10,
-                      "selector": { "matchLabels": { "app": "nginx" } },
-                      "strategy": {
-                        "rollingUpdate": { "maxSurge": "25%", "maxUnavailable": "25%" },
-                        "type": "RollingUpdate"
-                      },
-                      "template": {
-                        "metadata": { "creationTimestamp": null, "labels": { "app": "nginx" } },
-                        "spec": {
-                          "containers": [
-                            {
-                              "image": "nginx:1.14.2",
-                              "imagePullPolicy": "IfNotPresent",
-                              "name": "nginx",
-                              "ports": [{ "containerPort": 80, "protocol": "TCP" }],
-                              "resources": {},
-                              "terminationMessagePath": "/dev/termination-log",
-                              "terminationMessagePolicy": "File"
-                            }
-                          ],
-                          "dnsPolicy": "ClusterFirst",
-                          "restartPolicy": "Always",
-                          "schedulerName": "default-scheduler",
-                          "securityContext": {},
-                          "terminationGracePeriodSeconds": 30
-                        }
-                      }
-                    },
-                    "status": {
-                      "availableReplicas": 1,
-                      "conditions": [
-                        {
-                          "lastTransitionTime": "2020-09-25T17:29:35Z",
-                          "lastUpdateTime": "2020-09-25T17:29:35Z",
-                          "message": "Deployment has minimum availability.",
-                          "reason": "MinimumReplicasAvailable",
-                          "status": "True",
-                          "type": "Available"
-                        },
-                        {
-                          "lastTransitionTime": "2020-09-25T17:29:28Z",
-                          "lastUpdateTime": "2020-09-25T17:29:35Z",
-                          "message": "ReplicaSet \"nginx-deployment-574b87c764\" has successfully progressed.",
-                          "reason": "NewReplicaSetAvailable",
-                          "status": "True",
-                          "type": "Progressing"
-                        }
-                      ],
-                      "observedGeneration": 1,
-                      "readyReplicas": 1,
-                      "replicas": 1,
-                      "updatedReplicas": 1
-                    },
-                    "isKubeResource": true,
-                    "originatingCommand": {
-                      "REPL": {},
-                      "argv": [
-                        "kubectl",
-                        "get",
-                        "Deployment",
-                        "nginx-deployment",
-                        "-o",
-                        "yaml",
-                        "-n",
-                        "kui-notebook-1"
-                      ],
-                      "command": "kubectl get Deployment nginx-deployment -o yaml -n kui-notebook-1",
-                      "execOptions": {
-                        "echo": false,
-                        "type": 1,
-                        "execUUID": "00db90ab-657f-4347-b65b-a0b74e14ebf9",
-                        "history": 253,
-                        "env": {}
-                      },
-                      "argvNoOptions": ["kubectl", "get", "Deployment", "nginx-deployment"],
-                      "parsedOptions": {
-                        "_": ["kubectl", "get", "Deployment", "nginx-deployment"],
-                        "o": "yaml",
-                        "n": "kui-notebook-1"
-                      }
-                    },
-                    "kuiRawData": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  annotations:\n    deployment.kubernetes.io/revision: \"1\"\n    kubectl.kubernetes.io/last-applied-configuration: |\n      {\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"name\":\"nginx-deployment\",\"namespace\":\"kui-notebook-1\"},\"spec\":{\"minReadySeconds\":5,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"nginx\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:1.14.2\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}}}\n  creationTimestamp: \"2020-09-25T17:29:28Z\"\n  generation: 1\n  name: nginx-deployment\n  namespace: kui-notebook-1\n  resourceVersion: \"81846594\"\n  selfLink: /apis/apps/v1/namespaces/kui-notebook-1/deployments/nginx-deployment\n  uid: c323f4b4-1297-42ca-8e58-8e5347bf98fa\nspec:\n  minReadySeconds: 5\n  progressDeadlineSeconds: 600\n  replicas: 1\n  revisionHistoryLimit: 10\n  selector:\n    matchLabels:\n      app: nginx\n  strategy:\n    rollingUpdate:\n      maxSurge: 25%\n      maxUnavailable: 25%\n    type: RollingUpdate\n  template:\n    metadata:\n      creationTimestamp: null\n      labels:\n        app: nginx\n    spec:\n      containers:\n      - image: nginx:1.14.2\n        imagePullPolicy: IfNotPresent\n        name: nginx\n        ports:\n        - containerPort: 80\n          protocol: TCP\n        resources: {}\n        terminationMessagePath: /dev/termination-log\n        terminationMessagePolicy: File\n      dnsPolicy: ClusterFirst\n      restartPolicy: Always\n      schedulerName: default-scheduler\n      securityContext: {}\n      terminationGracePeriodSeconds: 30\nstatus:\n  availableReplicas: 1\n  conditions:\n  - lastTransitionTime: \"2020-09-25T17:29:35Z\"\n    lastUpdateTime: \"2020-09-25T17:29:35Z\"\n    message: Deployment has minimum availability.\n    reason: MinimumReplicasAvailable\n    status: \"True\"\n    type: Available\n  - lastTransitionTime: \"2020-09-25T17:29:28Z\"\n    lastUpdateTime: \"2020-09-25T17:29:35Z\"\n    message: ReplicaSet \"nginx-deployment-574b87c764\" has successfully progressed.\n    reason: NewReplicaSetAvailable\n    status: \"True\"\n    type: Progressing\n  observedGeneration: 1\n  readyReplicas: 1\n  replicas: 1\n  updatedReplicas: 1\n",
-                    "toolbarText": {
-                      "type": "info",
-                      "text": "Created on **9/25/2020, 1:29:28 PM**. Showing resource version **81846594**."
-                    },
-                    "onclick": {
-                      "kind": "kubectl get Deployment.v1.apps -n kui-notebook-1",
-                      "name": "kubectl get Deployment.v1.apps -n kui-notebook-1 nginx-deployment",
-                      "namespace": "kubectl get ns kui-notebook-1 -o yaml"
-                    },
-                    "modes": []
-                  },
-                  "responseType": "MultiModalResponse",
-                  "historyIdx": 253
-                }
-              },
-              {
-                "startTime": 1601054957655,
-                "startEvent": {
-                  "tab": "2_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                  "route": "/#",
-                  "command": "#  `kubectl diff` also gives you a preview of what changes apply will make.",
-                  "evaluatorOptions": {
-                    "usage": {
-                      "command": "commentary",
-                      "strict": "commentary",
-                      "example": "commentary -f [<markdown file path>]",
-                      "docs": "Commentary",
-                      "optional": [
-                        { "name": "--title", "alias": "-t", "docs": "Title for the commentary" },
-                        { "name": "--file", "alias": "-f", "docs": "File that contains the texts" }
-                      ]
-                    },
-                    "outputOnly": true,
-                    "plugin": "plugin-client-common"
-                  },
-                  "execType": 0,
-                  "execUUID": "8c41ae09-7e34-4c33-8c20-8062cd9f8870"
+                  }
                 },
-                "completeEvent": {
-                  "tab": "2_cd0d8750-9c3b-5e47-bb06-8b8fe6c85bfb",
-                  "execType": 0,
-                  "command": "# `kubectl diff` also gives you a preview of what changes apply will make.",
-                  "argvNoOptions": ["#", "  `kubectl diff` also gives you a preview of what changes apply will make."],
-                  "parsedOptions": {
-                    "_": ["#", "  `kubectl diff` also gives you a preview of what changes apply will make."]
-                  },
-                  "execUUID": "8c41ae09-7e34-4c33-8c20-8062cd9f8870",
-                  "cancelled": false,
-                  "evaluatorOptions": { "outputOnly": true, "plugin": "plugin-client-common" },
-                  "execOptions": {
-                    "type": 0,
-                    "language": "en-US",
-                    "execUUID": "8c41ae09-7e34-4c33-8c20-8062cd9f8870",
-                    "history": 250,
-                    "env": {}
-                  },
-                  "response": {
-                    "apiVersion": "kui-shell/v1",
-                    "kind": "CommentaryResponse",
-                    "props": {
-                      "children": "## Exploring Further\n\n- `kubectl diff` gives you a preview of what changes apply will make."
-                    }
-                  },
-                  "responseType": "ScalarResponse",
-                  "historyIdx": 250
-                }
-              }
-            ]
+                "kuiRawData": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  annotations:\n    deployment.kubernetes.io/revision: \"1\"\n    kubectl.kubernetes.io/last-applied-configuration: |\n      {\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"name\":\"nginx-deployment\",\"namespace\":\"kui-notebook-1\"},\"spec\":{\"minReadySeconds\":5,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"nginx\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:1.14.2\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}}}\n  creationTimestamp: \"2020-09-30T18:23:49Z\"\n  generation: 1\n  name: nginx-deployment\n  namespace: kui-notebook-1\n  resourceVersion: \"1136302\"\n  selfLink: /apis/apps/v1/namespaces/kui-notebook-1/deployments/nginx-deployment\n  uid: 4c0f9760-76b1-4266-8cac-dd52714ef5af\nspec:\n  minReadySeconds: 5\n  progressDeadlineSeconds: 600\n  replicas: 1\n  revisionHistoryLimit: 10\n  selector:\n    matchLabels:\n      app: nginx\n  strategy:\n    rollingUpdate:\n      maxSurge: 25%\n      maxUnavailable: 25%\n    type: RollingUpdate\n  template:\n    metadata:\n      creationTimestamp: null\n      labels:\n        app: nginx\n    spec:\n      containers:\n      - image: nginx:1.14.2\n        imagePullPolicy: IfNotPresent\n        name: nginx\n        ports:\n        - containerPort: 80\n          protocol: TCP\n        resources: {}\n        terminationMessagePath: /dev/termination-log\n        terminationMessagePolicy: File\n      dnsPolicy: ClusterFirst\n      restartPolicy: Always\n      schedulerName: default-scheduler\n      securityContext: {}\n      terminationGracePeriodSeconds: 30\nstatus:\n  availableReplicas: 1\n  conditions:\n  - lastTransitionTime: \"2020-09-30T18:23:57Z\"\n    lastUpdateTime: \"2020-09-30T18:23:57Z\"\n    message: Deployment has minimum availability.\n    reason: MinimumReplicasAvailable\n    status: \"True\"\n    type: Available\n  - lastTransitionTime: \"2020-09-30T18:23:49Z\"\n    lastUpdateTime: \"2020-09-30T18:23:57Z\"\n    message: ReplicaSet \"nginx-deployment-574b87c764\" has successfully progressed.\n    reason: NewReplicaSetAvailable\n    status: \"True\"\n    type: Progressing\n  observedGeneration: 1\n  readyReplicas: 1\n  replicas: 1\n  updatedReplicas: 1\n",
+                "toolbarText": {
+                  "type": "info",
+                  "text": "Created on **9/30/2020, 2:23:49 PM**. Showing resource version **1136302**."
+                },
+                "onclick": {
+                  "kind": "kubectl get Deployment.v1.apps -n kui-notebook-1",
+                  "name": "kubectl get Deployment.v1.apps -n kui-notebook-1 nginx-deployment",
+                  "namespace": "kubectl get ns kui-notebook-1 -o yaml"
+                },
+                "modes": []
+              },
+              "responseType": "MultiModalResponse",
+              "historyIdx": 257
+            },
+            "isExperimental": false,
+            "isReplay": false,
+            "execUUID": "b9313254-28e5-4bb2-99bf-3ca03e6a31aa",
+            "startTime": "2020-09-30T18:24:20.097Z",
+            "prefersTerminalPresentation": false,
+            "outputOnly": false,
+            "state": "valid-response"
           }
         ]
       }


### PR DESCRIPTION
BREAKING CHANGE

Fixes #5750

Edits from @starpit: 

- Note that this PR will temporarily disable snapshot and replay of clicks. This feature will be restored shortly.
- This introduces the final "v1" schema for Notebooks. Notebooks saved prior to the merging of this PR will no longer work.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
