### PR TITLE
8.10.16

### DIFF
--- a/plugins/plugin-kubectl/src/lib/model/states.ts
+++ b/plugins/plugin-kubectl/src/lib/model/states.ts
@@ -29,6 +29,8 @@ const States = {
   Completed: 'Completed',
   Succeeded: 'Succeeded',
   ProvisionedSuccessfully: 'ProvisionedSuccessfully',
+  Propagated: 'Propagated',
+  Subscribed: 'Subscribed',
 
   // online-like from knative
   Deployed: 'Deployed',
@@ -86,6 +88,8 @@ stateGroups[FinalState.OnlineLike] = groupOf([
   States.ChannelReady,
   States.Addressable,
   States.Completed,
+  States.Propagated,
+  States.Subscribed,
   States.Succeeded
 ])
 const isOnlineLike = (state: State): boolean => stateGroups[FinalState.OnlineLike][state]

--- a/plugins/plugin-kubectl/src/lib/view/css-for-value.ts
+++ b/plugins/plugin-kubectl/src/lib/view/css-for-value.ts
@@ -50,6 +50,8 @@ export default {
   Succeeded: TrafficLight.Gray, // successfully terminated; don't use a color
   Completed: TrafficLight.Gray, // successfully terminated; don't use a color
   Unknown: '',
+  Propagated: TrafficLight.Green,
+  Subscribed: TrafficLight.Green,
 
   // AWS events
   Ready: TrafficLight.Green,


### PR DESCRIPTION
[8.10.16 9abb448b5] fix(plugins/plugin-kubectl): k8s table should display status Propagated and Subscribed as green
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Wed Sep 30 17:39:23 2020 -0400
 2 files changed, 6 insertions(+)
