### PR TITLE
8.10.17

### DIFF
--- a/plugins/plugin-kubectl/src/lib/model/states.ts
+++ b/plugins/plugin-kubectl/src/lib/model/states.ts
@@ -45,6 +45,7 @@ const States = {
   NotProvisioned: 'NotProvisioned',
   Unschedulable: 'Unschedulable',
   ErrImagePull: 'ErrImagePull',
+  PropagationFailed: 'PropagationFailed',
 
   // pending-like
   ImagePullBackOff: 'ImagePullBackOff',
@@ -102,6 +103,7 @@ stateGroups[FinalState.OfflineLike] = groupOf([
   States.Disparity,
   States.NotProvisioned,
   States.Unschedulable,
+  States.PropagationFailed,
   States.ErrImagePull
 ])
 const isOfflineLike = (state: State): boolean => !!stateGroups[FinalState.OfflineLike][state]

--- a/plugins/plugin-kubectl/src/lib/view/css-for-value.ts
+++ b/plugins/plugin-kubectl/src/lib/view/css-for-value.ts
@@ -45,9 +45,10 @@ export default {
   // kube lifecycle
   CrashLoopBackOff: TrafficLight.Red,
   Failed: TrafficLight.Red,
+  Fail: TrafficLight.Red,
   Running: TrafficLight.Green,
   Pending: TrafficLight.Yellow,
-  Succeeded: TrafficLight.Gray, // successfully terminated; don't use a color
+  Succeeded: TrafficLight.Green,
   Completed: TrafficLight.Gray, // successfully terminated; don't use a color
   Unknown: '',
   Propagated: TrafficLight.Green,

--- a/plugins/plugin-kubectl/src/lib/view/css-for-value.ts
+++ b/plugins/plugin-kubectl/src/lib/view/css-for-value.ts
@@ -45,6 +45,7 @@ export default {
   // kube lifecycle
   CrashLoopBackOff: TrafficLight.Red,
   Failed: TrafficLight.Red,
+  PropagationFailed: TrafficLight.Red,
   Fail: TrafficLight.Red,
   Running: TrafficLight.Green,
   Pending: TrafficLight.Yellow,


### PR DESCRIPTION
[8.10.17 391beaef2] fix(plugins/plugin-kubectl): Fail should be TrafficLight.Red and Succeeded should be TrafficLight.Green
 Date: Thu Aug 13 13:27:27 2020 -0400
 1 file changed, 2 insertions(+), 1 deletion(-)

[8.10.17 c9d67c333] fix(plugins/plugin-kubectl): kubectl table should show PropagationFailed status as offline
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Thu Oct 1 10:07:40 2020 -0400
 2 files changed, 3 insertions(+)