### PR TITLE
feat(plugins/plugin-client-common): SourceRef should be default-expan…

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Editor/SimpleEditor.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/SimpleEditor.tsx
@@ -118,13 +118,18 @@ export default class SimpleEditor extends React.PureComponent<Props, State> {
       )
       const editor = Monaco.create(state.wrapper, options)
 
+      if (props.simple) {
+        // size to fit
+        state.wrapper.style.height = Math.min(400, editor.getContentHeight()) + 'px'
+      }
+
       state.wrapper['getValueForTests'] = () => {
         return editor.getValue()
       }
 
       editor.onDidChangeModelContent(SimpleEditor.onChange(props, editor))
 
-      if (!props.readonly) {
+      if (!options.readOnly) {
         setTimeout(() => editor.focus())
       }
 

--- a/plugins/plugin-client-common/src/components/Content/Editor/lib/defaults.ts
+++ b/plugins/plugin-client-common/src/components/Content/Editor/lib/defaults.ts
@@ -46,5 +46,6 @@ export default (options: Options): editor.IEditorConstructionOptions => ({
   folding: !options.simple || !/markdown|text|shell/i.test(options.language),
   lineNumbers: options.simple ? 'off' : 'on',
   wordWrap: options.simple ? 'on' : undefined,
+  renderFinalNewline: !options.simple,
   lineDecorationsWidth: options.simple ? 0 : undefined
 })

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
@@ -38,6 +38,9 @@ export type BlockViewTraits = {
   isPartOfMiniSplit?: boolean
   isWidthConstrained?: boolean
 
+  /** Is this Block being displayed as part of a Notebook? */
+  isPartOfNotebook?: boolean
+
   /** Handler for: User clicked to focus on this block */
   willFocusBlock?: (evt: React.SyntheticEvent) => void
 

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -141,6 +141,9 @@ type ScrollbackState = ScrollbackOptions & {
 interface State {
   focusedIdx: number
   splits: ScrollbackState[]
+
+  /** Is this Tab showing a Notebook? */
+  isNotebook?: boolean
 }
 
 /** get the selected texts in window */
@@ -180,7 +183,10 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
     this.initClipboardEvents()
     this.state = {
       focusedIdx: 0,
-      splits: this.props.snapshot ? this.replaySnapshot() : [this.scrollbackWithWelcome()]
+      splits: this.props.snapshot ? this.replaySnapshot() : [this.scrollbackWithWelcome()],
+
+      // are we loading a notebook from a snapshot?
+      isNotebook: !!this.props.snapshot
     }
 
     this.initSnapshotEvents()
@@ -1106,6 +1112,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
                     willFocusBlock={willFocusBlock}
                     isExperimental={hasCommand(_) && _.isExperimental}
                     isFocused={isFocused}
+                    isPartOfNotebook={this.state.isNotebook}
                     prefersTerminalPresentation={isOk(_) && _.prefersTerminalPresentation}
                     isPartOfMiniSplit={isMiniSplit}
                     isVisibleInMiniSplit={idx === showThisIdxInMiniSplit || idx === nBlocks - 1}

--- a/plugins/plugin-client-common/web/css/static/ui.css
+++ b/plugins/plugin-client-common/web/css/static/ui.css
@@ -119,6 +119,7 @@ body.still-loading .repl {
 }
 .flex-fill {
   flex: 1;
+  min-width: 0; /* so that reducing the width of the window causes a reflow; sigh */
 }
 .kui--rotate-180 {
   transform: rotate(180deg);


### PR DESCRIPTION
…ded in Notebooks?

This PR updates SimpleEditor so that, for `simple` props, it is sized to fit, in terms of height.

Fixes #5866

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
