### PR TITLE
fix: Notebook title "Kui Setting" should be "Kui Settings"

### DIFF
--- a/packages/core/src/main/menu.ts
+++ b/packages/core/src/main/menu.ts
@@ -71,6 +71,7 @@ export const install = (createWindow: (executeThisArgvPlease?: string[]) => void
       label: 'Notebooks',
       submenu: [
         notebook('Welcome to Kui', '/kui/welcome.json'),
+        { type: 'separator' },
         {
           label: 'Learning Kubernetes',
           submenu: [
@@ -226,6 +227,7 @@ export const install = (createWindow: (executeThisArgvPlease?: string[]) => void
     const separator: MenuItemConstructorOptions = { type: 'separator' }
     const submenu: MenuItemConstructorOptions[] = [
       about,
+      notebook('Configure Kui', '/kui/settings.json'),
       separator,
       { role: 'services', submenu: [] as MenuItemConstructorOptions[] },
       separator,

--- a/plugins/plugin-client-common/notebooks/settings.json
+++ b/plugins/plugin-client-common/notebooks/settings.json
@@ -2,7 +2,7 @@
   "apiVersion": "kui-shell/v1",
   "kind": "Notebook",
   "metadata": {
-    "name": "Kui Setting",
+    "name": "Kui Settings",
     "preferReExecute": true
   },
   "spec": {


### PR DESCRIPTION
This also adds an OS menu for the settings notebook

Fixes #5870

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
