### PR TITLE
fix(plugins/plugin-client-common): markdown code has incorrect color in a split with inverse color

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/CodeSnippet/Carbon.scss
+++ b/plugins/plugin-client-common/web/scss/components/CodeSnippet/Carbon.scss
@@ -24,3 +24,7 @@ body[kui-theme-style] .bx--snippet {
 body[kui-theme-style='dark'] .bx--snippet {
   color: var(--color-base00);
 }
+
+body[kui-theme-style='light'] .kui--inverted-color-context .bx--snippet {
+  color: var(--color-base00);
+}

--- a/plugins/plugin-client-common/web/scss/components/CodeSnippet/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/CodeSnippet/PatternFly.scss
@@ -23,3 +23,7 @@
 [kui-theme-style='dark'] .pf-c-clipboard-copy__expandable-content {
   color: var(--pf-global--Color--300);
 }
+
+body[kui-theme-style='light'] .kui--inverted-color-context .pf-c-clipboard-copy__expandable-content {
+  color: var(--pf-global--Color--300);
+}


### PR DESCRIPTION
Fixes #5902

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
