### PR TITLE
fix(plugins/plugin-client-common): when double clicking on commentary, only enter edit mode if no text is selected

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Commentary.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Commentary.tsx
@@ -21,6 +21,7 @@ import Card from '../spi/Card'
 import Markdown from './Markdown'
 import Button from '../spi/Button'
 import SimpleEditor from './Editor/SimpleEditor'
+import { getSelectionText } from '../../util/selection'
 
 const strings = i18n('plugin-client-common')
 
@@ -157,7 +158,10 @@ export default class Commentary extends React.PureComponent<Props, State> {
 
   /** Enter isEdit mode */
   private setEdit() {
-    this.setState({ isEdit: true })
+    // when double clicking on commentary, we only enter edit mode if no text is selected
+    if (getSelectionText().trim().length === 0) {
+      this.setState({ isEdit: true })
+    }
   }
 
   private readonly _setEdit = this.setEdit.bind(this)


### PR DESCRIPTION
Fixes #5930

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
