### PR TITLE
fix(plugins/plugin-client-common): double clicking on Commentary in minisplit often has the editor completely off screen

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Commentary.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Commentary.tsx
@@ -202,6 +202,7 @@ export default class Commentary extends React.PureComponent<Props, State> {
         simple
         onContentChange={this._onContentChange}
         contentType="markdown"
+        scrollIntoView={this.props.isPartOfMiniSplit}
       />
     )
   }

--- a/plugins/plugin-client-common/src/components/Content/Editor/SimpleEditor.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/SimpleEditor.tsx
@@ -32,6 +32,7 @@ type Props = Pick<MonacoOptions, 'fontSize'> & {
   className?: string
   readonly?: boolean
   onContentChange?: (content: string) => void
+  scrollIntoView?: boolean
 
   /** Use a light theme? Default: false */
   light?: boolean
@@ -173,7 +174,18 @@ export default class SimpleEditor extends React.PureComponent<Props, State> {
       return <div className="oops"> {this.state.catastrophicError.toString()}</div>
     } else {
       const className = 'monaco-editor-wrapper' + (this.props.className ? ' ' + this.props.className : '')
-      return <div className={className} ref={wrapper => this.setState({ wrapper })}></div>
+      return (
+        <div
+          className={className}
+          ref={wrapper => {
+            if (this.props.scrollIntoView && wrapper) {
+              wrapper.scrollIntoView()
+            }
+
+            this.setState({ wrapper })
+          }}
+        ></div>
+      )
     }
   }
 }


### PR DESCRIPTION
Fixes #5897

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
