### PR TITLE
fix(plugins/plugin-client-notebook): notebook client's version widget has a hard-wired version

### DIFF
--- a/plugins/plugin-client-notebook/src/index.tsx
+++ b/plugins/plugin-client-notebook/src/index.tsx
@@ -17,6 +17,7 @@
 import React from 'react'
 
 import { ContextWidgets, Icons, Kui, KuiProps, MeterWidgets, TextWithIconWidget } from '@kui-shell/plugin-client-common'
+import { version } from '@kui-shell/client/package.json'
 
 /**
  * Format our body, with extra status stripe widgets
@@ -26,7 +27,7 @@ import { ContextWidgets, Icons, Kui, KuiProps, MeterWidgets, TextWithIconWidget 
  */
 export default function renderMain(props: KuiProps) {
   const kuiVersion = () => {
-    return <TextWithIconWidget text="Kui v9.0.0" viewLevel="normal" title="Kui version 9.0.0" />
+    return <TextWithIconWidget text={`Kui v${version}`} viewLevel="normal" title={`Kui version ${version}`} />
   }
 
   const githubIcon = () => {


### PR DESCRIPTION
Fixes #5942

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
