### PR TITLE
fix: preferReExecute is lost when re-saving a notebook

### DIFF
--- a/packages/core/src/repl/events.ts
+++ b/packages/core/src/repl/events.ts
@@ -69,6 +69,7 @@ export interface Notebook {
   metadata?: {
     name?: string
     description?: string
+    preferReExecute?: boolean
   }
 }
 

--- a/plugins/plugin-client-common/notebooks/welcome.json
+++ b/plugins/plugin-client-common/notebooks/welcome.json
@@ -2,7 +2,8 @@
   "apiVersion": "kui-shell/v1",
   "kind": "Notebook",
   "metadata": {
-    "name": "Welcome to Kui"
+    "name": "Welcome to Kui",
+    "preferReExecute": true
   },
   "spec": {
     "splits": [

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Snapshot.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Snapshot.ts
@@ -42,7 +42,6 @@ export type Split = {
 type NotebookSpec = {
   spec: {
     splits: Split[]
-    preferReExecute?: boolean
   }
 }
 

--- a/plugins/plugin-s3/notebooks/welcome.json
+++ b/plugins/plugin-s3/notebooks/welcome.json
@@ -3,10 +3,9 @@
   "kind": "Notebook",
   "metadata": {
     "name": "Getting Started with S3",
-    "description": ""
+    "preferReExecute": true
   },
   "spec": {
-    "preferReExecute": true,
     "splits": [
       {
         "uuid": "2_c57e811f-2da8-557e-a402-9f0950407675",


### PR DESCRIPTION
Add preferReExecute to Notebook metadata

Fixes #5954

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
