### PR TITLE
fix(plugins/plugin-client-common): group the notebooks together in the ls -l table

### DIFF
--- a/plugins/plugin-client-common/notebooks/settings.json
+++ b/plugins/plugin-client-common/notebooks/settings.json
@@ -3,6 +3,7 @@
   "kind": "Notebook",
   "metadata": {
     "name": "Kui Settings",
+    "description": "Kui &mdash; `Settings`",
     "preferReExecute": true
   },
   "spec": {

--- a/plugins/plugin-client-common/notebooks/welcome.json
+++ b/plugins/plugin-client-common/notebooks/welcome.json
@@ -3,6 +3,7 @@
   "kind": "Notebook",
   "metadata": {
     "name": "Welcome to Kui",
+    "description": "Kui &mdash; `Welcome to Kui`",
     "preferReExecute": true
   },
   "spec": {

--- a/plugins/plugin-core-support/src/notebooks/vfs/index.ts
+++ b/plugins/plugin-core-support/src/notebooks/vfs/index.ts
@@ -84,7 +84,7 @@ class NotebookVFS implements VFS {
       const name = basename(mount.mountPath)
       const nameForDisplay =
         isLeaf(mount) && mount.data.metadata
-          ? mount.data.metadata.name || mount.data.metadata.description || name
+          ? mount.data.metadata.description || mount.data.metadata.name || name
           : name
       const isDir = !isLeaf(mount)
 

--- a/plugins/plugin-iter8/notebooks/welcome.json
+++ b/plugins/plugin-iter8/notebooks/welcome.json
@@ -2,7 +2,8 @@
   "apiVersion": "kui-shell/v1",
   "kind": "Notebook",
   "metadata": {
-    "name": "Welcome to Iter8"
+    "name": "Welcome to Iter8",
+    "description": "Iter8 &mdash; `Welcome to Iter8`"
   },
   "spec": {
     "splits": [

--- a/plugins/plugin-s3/notebooks/parallelization.json
+++ b/plugins/plugin-s3/notebooks/parallelization.json
@@ -3,7 +3,7 @@
   "kind": "Notebook",
   "metadata": {
     "name": "Parallelization with S3",
-    "description": ""
+    "description": "S3 &mdash; `Parallelization`"
   },
   "spec": {
     "splits": [

--- a/plugins/plugin-s3/notebooks/using-s3.json
+++ b/plugins/plugin-s3/notebooks/using-s3.json
@@ -3,7 +3,7 @@
   "kind": "Notebook",
   "metadata": {
     "name": "Using S3",
-    "description": ""
+    "description": "S3 &mdash; `Using S3 with Kui`"
   },
   "spec": {
     "splits": [

--- a/plugins/plugin-s3/notebooks/welcome.json
+++ b/plugins/plugin-s3/notebooks/welcome.json
@@ -3,6 +3,7 @@
   "kind": "Notebook",
   "metadata": {
     "name": "Getting Started with S3",
+    "description": "S3 &mdash; `Getting Started`",
     "preferReExecute": true
   },
   "spec": {


### PR DESCRIPTION
In this PR, I modified the description of each notebook so they can be grouped together in the `ls -l /kui/**/*.json` table. By preserving the name field, we can make the tab title clean. For example, iter8 welcome notebook can still have the title `Welcome to Iter8`, instead of `Iter8 - Welcome to Iter8`.


![Screen Shot 2020-10-13 at 11 47 38 AM](https://user-images.githubusercontent.com/21212160/95884271-e6bf4300-0d49-11eb-9fb4-db73bb0a07a0.png)
Fixes #5977

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
