### PR TITLE
fix: tweak the input background and border to enhance the readability of notebooks

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -258,7 +258,7 @@ body[kui-theme-style='dark'] {
         }
       }
       .repl-input-element-wrapper {
-        border: 1px solid transparent;
+        border: 1px solid hsla(0, 0%, 39.2%, 0.1);
         align-items: stretch;
         padding-left: 0.5rem;
         position: relative; /* for repl-block-actions' position: absolute */

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-$input-bg-light: var(--color-base00);
+$input-bg-light: rgba(27, 31, 35, 0.05);
 $input-bg-dark: var(--color-base02);
 $input-bg-minisplit: var(--color-base01);
 $input-border: rgba(100, 100, 100, 0.05);


### PR DESCRIPTION
Fixes #5982

Screenshots of how the input looks in different scenario:
![Screen Shot 2020-10-13 at 2 12 00 PM](https://user-images.githubusercontent.com/21212160/95899114-10826500-0d5e-11eb-8798-21a76005d130.png)
![Screen Shot 2020-10-13 at 2 12 29 PM](https://user-images.githubusercontent.com/21212160/95899154-21cb7180-0d5e-11eb-9358-c7a6813de84c.png)
![Screen Shot 2020-10-13 at 2 12 43 PM](https://user-images.githubusercontent.com/21212160/95899178-2abc4300-0d5e-11eb-85f6-04881d07fe27.png)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
