### PR TITLE
fix(plugins/plugin-client-common): minisplit has leftover css border rule

### DIFF
--- a/plugins/plugin-client-common/web/scss/PatternFly/kui-alignment.scss
+++ b/plugins/plugin-client-common/web/scss/PatternFly/kui-alignment.scss
@@ -85,7 +85,7 @@
   --pf-global--BackgroundColor--light-100: var(--color-ui-01);
   --pf-global--BackgroundColor--light-200: var(--color-ui-02);
   --pf-global--BackgroundColor--light-300: var(--color-ui-03);
-  --pf-global--BackgroundColor--dark-100: var(--color-base02);
+  --pf-global--BackgroundColor--dark-100: var(--color-base01);
   --pf-global--BackgroundColor--dark-200: var(--color-ui-03);
   --pf-global--BackgroundColor--dark-300: var(--color-ui-02);
   --pf-global--BackgroundColor--dark-400: var(--color-ui-01);

--- a/plugins/plugin-client-common/web/scss/components/Terminal/MiniSplit.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/MiniSplit.scss
@@ -19,8 +19,6 @@
 /** distinguish the mini splits */
 @include MiniSplit {
   background-color: var(--color-base02);
-  box-shadow: 1px 1px var(--color-base01);
-  border: 1px dotted var(--color-base03);
   display: flex;
   flex-direction: column;
 

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Scrollback.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Scrollback.scss
@@ -22,7 +22,7 @@
   display: grid;
   grid-gap: 6px;
   overflow: hidden;
-  background-color: var(--color-stripe-01);
+  background-color: var(--color-base00);
 }
 
 .kui--scrollback {


### PR DESCRIPTION
Fixes #5989

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
