### PR TITLE
fix(plugins/plugin-client-common): hovering over error block turns red to blue

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -104,7 +104,7 @@ body[kui-theme-style='dark'] {
     }
     &.error:before {
       opacity: 1;
-      background-color: var(--color-error);
+      background-color: var(--color-red);
     }
     &:hover .repl-output .repl-context:after {
       border-color: var(--color-base03);
@@ -135,6 +135,12 @@ body[kui-theme-style='dark'] {
     &[data-is-output-only] {
       &:before {
         background-color: $focus-color;
+      }
+    }
+
+    &.error {
+      &:before {
+        background-color: hsl(0, 100%, 70%);
       }
     }
   }


### PR DESCRIPTION

Hovering the first block:
![Screen Shot 2020-10-13 at 5 01 34 PM](https://user-images.githubusercontent.com/21212160/95915832-c1e0c500-0d75-11eb-8f06-05c09211b2d8.png)

Hovering the 4th block:

![Screen Shot 2020-10-13 at 5 02 03 PM](https://user-images.githubusercontent.com/21212160/95915886-d2913b00-0d75-11eb-920a-463d44c68f89.png)
Fixes #5979

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
