### PR TITLE
fix(packages/webpack): webpack builds may have fonts in the wrong place

### DIFF
--- a/packages/webpack/webpack.config.js
+++ b/packages/webpack/webpack.config.js
@@ -150,7 +150,9 @@ console.log('clientHome', process.env.CLIENT_HOME)
  * Note: these are _webpack plugins_ not Kui plugins; we will assemble
  * this list of webpack plugins as we go.
  */
-const plugins = [new FontConfigWebpackPlugin()]
+const fontConfigOptions = contextRoot ? { name: `${contextRoot}/[name].[hash].[ext]` } : undefined
+console.log('fontConfig', fontConfigOptions || 'using the default settings')
+const plugins = [new FontConfigWebpackPlugin(fontConfigOptions)]
 
 // any compression plugins?
 if (CompressionPlugin) {


### PR DESCRIPTION
Fixes #6036

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
