### PR TITLE
fix(plugins/plugin-client-common): If a command is issued in a mini split, the next block (in the mini split) is not focused

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -1153,9 +1153,13 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
               },
 
               blocks.map((_, idx) => {
+                /** To find the focused block, we check:
+                 *  1. the block is in a focused scrollback
+                 *  2. the block idx matches scrollback.focusedBlockIdx (considering blocks that were hidden)
+                 *  3. return the active block if there's no scrollback.focusedBlockIdx */
                 const isFocused =
                   sbidx === this.state.focusedIdx &&
-                  (idx === scrollback.focusedBlockIdx ||
+                  (idx === scrollback.focusedBlockIdx - (scrollback.blocks.length - nBlocks) ||
                     (scrollback.focusedBlockIdx === undefined && idx === this.findActiveBlock(scrollback)))
 
                 /** Interior view wants to focus this block based on non-browser activity */


### PR DESCRIPTION
Fixes #6067

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
