### PR TITLE
fix: don't show "Created a split" when clicking on the New Split button

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -161,12 +161,7 @@ export { disableInputQueueing } from './webapp/queueing'
 export { isPopup } from './webapp/popup-core'
 export { removeAllDomChildren as empty } from './webapp/util/dom'
 export { default as Presentation } from './webapp/views/presentation'
-export {
-  CommentaryResponse,
-  ElsewhereCommentaryResponse,
-  isCommentaryResponse,
-  isElsewhereCommentaryResponse
-} from './models/CommentaryResponse'
+export { CommentaryResponse, isCommentaryResponse } from './models/CommentaryResponse'
 
 export {
   default as TabLayoutModificationResponse,

--- a/packages/core/src/models/CommentaryResponse.ts
+++ b/packages/core/src/models/CommentaryResponse.ts
@@ -16,41 +16,24 @@
 
 import { Entity } from './entity'
 import REPL from './repl'
-import Tab from '../webapp/tab'
 
-/** Commentary describing actions in a different tab/split */
-type Elsewhere = {
-  elsewhere: true
-  tabUUID: string
-  tab?: () => Tab
-}
-
-type DefaultProps = Partial<Elsewhere> & {
-  /** Content rendered inside the CardTitle */
-  title?: string
-
-  /** Body of the Card. It will be passed through as the source <Markdown source="..." /> */
-  children: string
-
-  /** [Optional] REPL controller, but required if you want your Card
-   * to have functional kuiexec?command=... links via Markdown */
-  repl?: REPL
-}
-
-type ElsewhereProps = DefaultProps & Required<Elsewhere>
-export type ElsewhereCommentaryResponse = CommentaryResponse<ElsewhereProps>
-
-export type CommentaryResponse<Props extends DefaultProps = DefaultProps> = {
+export type CommentaryResponse = {
   apiVersion: 'kui-shell/v1'
   kind: 'CommentaryResponse'
-  props: Props
+  props: {
+    /** Content rendered inside the CardTitle */
+    title?: string
+
+    /** Body of the Card. It will be passed through as the source <Markdown source="..." /> */
+    children: string
+
+    /** [Optional] REPL controller, but required if you want your Card
+     * to have functional kuiexec?command=... links via Markdown */
+    repl?: REPL
+  }
 }
 
 export function isCommentaryResponse(entity: Entity): entity is CommentaryResponse {
   const response = entity as CommentaryResponse
   return response.apiVersion === 'kui-shell/v1' && response.kind === 'CommentaryResponse'
-}
-
-export function isElsewhereCommentaryResponse(entity: Entity): entity is ElsewhereCommentaryResponse {
-  return isCommentaryResponse(entity) && entity.props.elsewhere === true
 }

--- a/packages/core/src/models/TabLayoutModificationResponse.ts
+++ b/packages/core/src/models/TabLayoutModificationResponse.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity } from './entity'
-import { ElsewhereCommentaryResponse } from './CommentaryResponse'
+import { Entity, MarkdownResponse } from './entity'
 
 /**
  * If your controller wants to manipulate the tab layout, this is your
@@ -26,7 +25,7 @@ type TabLayoutModificationResponse<Request extends ModificationRequest = Modific
   apiVersion: 'kui-shell/v1'
   kind: 'TabLayoutModificationResponse'
   spec: Request & {
-    ok: ElsewhereCommentaryResponse
+    ok: MarkdownResponse
   }
 }
 

--- a/packages/core/src/models/entity.ts
+++ b/packages/core/src/models/entity.ts
@@ -126,7 +126,7 @@ export type SimpleEntity =
   | MarkdownResponse
   | ReactResponse
 
-type MarkdownResponse = { content: string; contentType: 'text/markdown' }
+export type MarkdownResponse = { content: string; contentType: 'text/markdown' }
 
 export function isMarkdownResponse(entity: Entity): entity is MarkdownResponse {
   const md = entity as MarkdownResponse

--- a/packages/core/src/webapp/tab.ts
+++ b/packages/core/src/webapp/tab.ts
@@ -90,10 +90,11 @@ export const getTab = (idx: Tab | number): Tab => {
 /**
  * Execute the given command in the current (or given) tab.
  *
- * @param quiet Execute the command quietly, i.e. without echo
+ * @param isInternalCallPath This is one plugin calling another
+ * @param incognito Execute the command quietly but do not display the result in the Terminal
  *
  */
-export function pexecInCurrentTab(command: string, topLevelTab?: Tab, quiet = false) {
+export function pexecInCurrentTab(command: string, topLevelTab?: Tab, isInternalCallpath = false, incognito = false) {
   const scrollback = ((topLevelTab || document).querySelector(
     (topLevelTab ? '' : '.kui--tab-content.visible') + ' .kui--scrollback:not([data-is-minisplit])'
   ) as any) as {
@@ -101,7 +102,9 @@ export function pexecInCurrentTab(command: string, topLevelTab?: Tab, quiet = fa
   }
   if (scrollback) {
     const { facade: tab } = scrollback
-    return quiet ? tab.REPL.qexec(command, undefined, undefined, { tab }) : tab.REPL.pexec(command, { tab })
+    return isInternalCallpath
+      ? tab.REPL.qexec(command, undefined, undefined, { tab })
+      : tab.REPL.pexec(command, { tab, echo: !incognito })
   } else {
     return Promise.reject(
       new Error(

--- a/packages/test/src/api/repl-expect.ts
+++ b/packages/test/src/api/repl-expect.ts
@@ -298,7 +298,7 @@ export function elsewhere(expectedBody: string, N?: number) {
     let idx = 0
     await res.app.client.waitUntil(async () => {
       const actualBody = await res.app.client.getText(
-        `${Selectors.OUTPUT_N(res.count, N === undefined ? res.splitIndex : N)} .kui--repl-result-else`
+        Selectors.OUTPUT_N(res.count, N === undefined ? res.splitIndex : N)
       )
       if (++idx > 5) {
         console.error(`still waiting for body; actual=${actualBody}; expected=${expectedBody}`)

--- a/plugins/plugin-client-common/src/components/Client/TabContent.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContent.tsx
@@ -222,7 +222,6 @@ export default class TabContent extends React.PureComponent<Props, State> {
                 tab={this.state.tab}
                 config={config}
                 sidecarWidth={this.state.sidecarWidth}
-                closeSidecar={() => this.setState({ sidecarWidth: Width.Closed })}
                 onClear={() => {
                   this.setState({ showSessionInitDone: false })
 

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/SplitTerminalButton.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/SplitTerminalButton.tsx
@@ -40,7 +40,7 @@ export default class SplitTerminalButton extends React.PureComponent {
               aria-label="Split terminal"
               tabIndex={0}
               title={strings('Split the Terminal')}
-              onClick={() => pexecInCurrentTab('split')}
+              onClick={() => pexecInCurrentTab('split', undefined, false, true)}
             >
               <Icons icon="Split" />
             </a>

--- a/plugins/plugin-client-common/src/components/Content/Commentary.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Commentary.tsx
@@ -18,7 +18,6 @@ import React from 'react'
 import { CommentaryResponse, REPL, i18n } from '@kui-shell/core'
 
 import Card from '../spi/Card'
-import Markdown from './Markdown'
 import Button from '../spi/Button'
 import SimpleEditor from './Editor/SimpleEditor'
 
@@ -32,6 +31,7 @@ interface State {
 }
 
 type Props = CommentaryResponse['props'] & {
+  tabUUID: string
   isPartOfMiniSplit: boolean
   willUpdateResponse?: (text: string) => void
   willRemove?: () => void
@@ -208,18 +208,10 @@ export default class Commentary extends React.PureComponent<Props, State> {
   }
 
   public render() {
-    if (this.props.elsewhere) {
-      return (
-        <span className="kui--repl-result-else">
-          <Markdown source={this.props.children} repl={this.props.repl} />
-        </span>
-      )
-    } else {
-      return (
-        <div className="kui--commentary" data-is-editing={this.state.isEdit || undefined}>
-          {this.card()}
-        </div>
-      )
-    }
+    return (
+      <div className="kui--commentary" data-is-editing={this.state.isEdit || undefined}>
+        {this.card()}
+      </div>
+    )
   }
 }

--- a/plugins/plugin-client-common/src/components/Content/Scalar/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Scalar/index.tsx
@@ -32,7 +32,6 @@ import {
   isRandomErrorResponse1,
   isRandomErrorResponse2,
   isTable,
-  isTabLayoutModificationResponse,
   isMixedResponse,
   isXtermResponse,
   isUsageError
@@ -140,8 +139,6 @@ export default class Scalar extends React.PureComponent<Props, State> {
             />
           </span>
         )
-      } else if (isTabLayoutModificationResponse(response)) {
-        return <Commentary {...response.spec.ok.props} isPartOfMiniSplit={this.props.isPartOfMiniSplit} />
       } else if (isRadioTable(response)) {
         return (
           <KuiContext.Consumer>

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/BlockModel.ts
@@ -257,12 +257,6 @@ export function Finished(
   }
 }
 
-export function isHidden(block: BlockModel) {
-  if (isActive(block) || isAnnouncement(block) || isCancelled(block) || isEmpty(block)) {
-    return false
-  }
-}
-
 export function isOutputOnly(block: BlockModel) {
   if (isProcessing(block)) {
     return block.startEvent.echo === false
@@ -282,10 +276,15 @@ export function hasStartEvent(block: BlockModel): block is BlockModel & WithComm
 
 /** @return whether the block has a completeEvent trait */
 export function isWithCompleteEvent(block: BlockModel): block is CompleteBlock {
-  return isOk(block) || isOops(block)
+  return (isOk(block) || isOops(block)) && block.completeEvent !== undefined
+}
+
+/** @return whether this block was asked to be incognito */
+export function isHidden(block: BlockModel): boolean {
+  return isWithCompleteEvent(block) && block.completeEvent.execOptions && block.completeEvent.execOptions.echo === false
 }
 
 /** @return whether the block is from replay */
-export function isReplay(block: BlockModel) {
+export function isReplay(block: BlockModel): boolean {
   return (isProcessing(block) || isWithCompleteEvent(block)) && block.isReplay
 }

--- a/plugins/plugin-client-common/src/controller/split.ts
+++ b/plugins/plugin-client-common/src/controller/split.ts
@@ -43,14 +43,8 @@ export default function split(args?: Arguments<CommandLineOptions>): TabLayoutMo
       modification: 'NewSplit',
       options,
       ok: {
-        apiVersion: 'kui-shell/v1',
-        kind: 'CommentaryResponse',
-        props: {
-          elsewhere: true,
-          tabUUID: '0',
-          tab: undefined,
-          children: strings(args.parsedOptions.inverse ? 'Created a split with inverted colors' : 'Created a split')
-        }
+        content: strings(args.parsedOptions.inverse ? 'Created a split with inverted colors' : 'Created a split'),
+        contentType: 'text/markdown'
       }
     }
   }

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -169,13 +169,6 @@ body[kui-theme-style='dark'] {
       padding: 0.875rem 0;
     }
 
-    &[data-is-quietly-elsewhere] {
-      padding: 0.1875rem;
-      repl-output {
-        margin-top: 0;
-      }
-    }
-
     /* special bg color for Actions inside of output-only versus input blocks, to occlude repl-input-element */
     .kui--block-actions-buttons {
       background-color: var(--color-base03);

--- a/plugins/plugin-core-support/src/lib/cmds/tab-management.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/tab-management.ts
@@ -125,16 +125,10 @@ export default function plugin(commandTree: Registrar) {
       // this is our response to the user if the tab was created
       // successfully
       const ok = {
-        apiVersion: 'kui-shell/v1',
-        kind: 'CommentaryResponse',
-        props: {
-          elsewhere: true,
-          tabUUID: '0',
-          tab: undefined,
-          children: args.parsedOptions.title
-            ? strings('Created a new tab named X', args.parsedOptions.title)
-            : strings('Created a new tab')
-        }
+        content: args.parsedOptions.title
+          ? strings('Created a new tab named X', args.parsedOptions.title)
+          : strings('Created a new tab'),
+        contentType: 'text/markdown'
       }
 
       const file = args.parsedOptions.snapshot || args.parsedOptions.s

--- a/plugins/plugin-core-support/src/test/core-support2/split-terminals.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/split-terminals.ts
@@ -33,8 +33,6 @@ import {
   splitViaCommand
 } from './split-helpers'
 
-import { doClear } from '../core-support/clear'
-
 /** Report Version */
 function version(this: Common.ISuite, splitIndex: number) {
   it(`should report proper version with splitIndex=${splitIndex}`, () =>
@@ -76,35 +74,6 @@ function changeDir(this: Common.ISuite, dir: string, splitIndex: number) {
       .then(ReplExpect.okWithString(dir))
       .catch(Common.oops(this, true)))
 }
-
-// ensure that the "created split" block disappears when the new split is closed
-describe(`split terminals created split check ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
-  before(Common.before(this))
-  after(Common.after(this))
-  Util.closeAllExceptFirstTab.bind(this)()
-
-  const clear = doClear.bind(this)
-  const count = expectSplits.bind(this)
-  const closeTheSplit = close.bind(this)
-  const verifyBlockCount = ReplExpect.blockCount
-    .bind(this)()
-    .inSplit(1)
-  const splitTheTerminalViaCommand = splitViaCommand.bind(this)
-
-  it('should clear the console', () => clear(1, 1))
-  verifyBlockCount.is(1)
-  splitTheTerminalViaCommand(2)
-  count(2)
-
-  it('should clear the console', () => clear(2, 1))
-  verifyBlockCount.is(2) // the "created split" message should persist, since the split is still alive
-
-  closeTheSplit(1, 2) // expect 1 residual split, and execute the `exit` command in split 2
-
-  verifyBlockCount.is(1) // the "created split" message should be gone!
-  it('should clear the console', () => clear())
-  verifyBlockCount.is(1) // the "created split" message should be gone!
-})
 
 describe(`split terminals spliceIndex variant 1 ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
   before(Common.before(this))

--- a/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
@@ -177,7 +177,7 @@ export class EventWatcher implements Abortable, Watcher {
           const eventName = row[3].value
           const onClick = `#kuiexec?command=${encodeURIComponent(
             withKubeconfigFrom(this.args, `kubectl get event ${eventName} -o yaml`)
-          )}&quiet`
+          )}`
           return `[[${agos[idx]}]](${onClick})` + ` **${involvedObjectName}**: ${message}`
         })
 


### PR DESCRIPTION
This PR also:
1. cleans up some unneeded code around this issue, too.
2. removes ElsewhereCommentaryResponse
2. changes TabLayoutModificationResponse to use MarkdownResponse

Fixes #6001
Closes #6068 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
