### PR TITLE
chore: move carbon tab scrolling workaround into packages/builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "pty:nodejs": "npm run pty:rebuild node",
     "link": "bash -c \"if [ $OSTYPE != msys ]; then CLIENT=${CLIENT-default}; CLIENT_HOME=$(cd ./node_modules/@kui-shell/client && pwd) ./packages/builder/bin/seticon.js; fi\"",
     "update": "ncu -u -x \"@types/yargs-parser,husky,electron,spectron,@types/webdriverio\" && for i in plugins/*; do (cd $i && ncu -u -x electron,spectron,@types/webdriverio,chokidar,d3,elkjs,xtermjs,strip-ansi && rm -rf node_modules); done && rm -rf node_modules/ package-lock.json  && npm install",
-    "postinstall": "npm rebuild node-sass && npm run compile && ./tools/hackCarbon.sh",
+    "postinstall": "npm rebuild node-sass && npm run compile && npx kui-hack-carbon",
     "open": "electron . shell",
     "start": "WATCH_ARGS='open' npm run watch"
   },

--- a/packages/builder/bin/hackCarbon.sh
+++ b/packages/builder/bin/hackCarbon.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+#
+# Temporary hack workaround for https://github.com/IBM/kui/issues/6014
+#
+# Summary: upstream bug in carbon-components-react that causes
+# undesirable scrolling behavior when switching inline sidecar tabs.
+#
+# Future readers: please get rid of this hack, once the upstream
+# carbon bug fix has been released; hopefully that will happen in
+# carbon-components-react 7.23.x. As of this writing, Kui is on
+# 7.22.x: https://github.com/carbon-design-system/carbon/pull/7111
+#
+
+T=$(mktemp)
+
+node -e 'console.log(require("fs").readFileSync("node_modules/carbon-components-react/es/components/Tabs/Tabs.js").toString().replace(/_tab\$tabAnchor\.scrollIntoView\(false\)/, "_tab$tabAnchor.scrollIntoViewIfNeeded ? _tab$tabAnchor.scrollIntoViewIfNeeded() : _tab$tabAnchor.scrollIntoView(false)"))' > "$T"
+
+mv "$T" node_modules/carbon-components-react/es/components/Tabs/Tabs.js

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -12,6 +12,7 @@
     "url": "git+https://github.com/IBM/kui.git"
   },
   "bin": {
+    "kui-hack-carbon": "./bin/hackCarbon.sh",
     "kui-pty-rebuild": "./bin/pty-rebuild.sh",
     "kui-build-headless": "./dist/headless/build.sh",
     "kui-build-electron": "./dist/electron/build.sh",

--- a/tools/hackCarbon.sh
+++ b/tools/hackCarbon.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-T=$(mktemp)
-
-node -e 'console.log(require("fs").readFileSync("node_modules/carbon-components-react/es/components/Tabs/Tabs.js").toString().replace(/_tab\$tabAnchor\.scrollIntoView\(false\)/, "_tab$tabAnchor.scrollIntoViewIfNeeded ? _tab$tabAnchor.scrollIntoViewIfNeeded() : _tab$tabAnchor.scrollIntoView(false)"))' > "$T"
-
-mv "$T" node_modules/carbon-components-react/es/components/Tabs/Tabs.js


### PR DESCRIPTION
Fixes #6014

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
