### PR TITLE
feat: add unit support of TreeResponse as one of the contents in MultiModalResponse

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -210,6 +210,7 @@ export {
   FunctionThatProducesContent
 } from './models/mmr/content-types'
 export { ToolbarText, ToolbarAlert, isSupportedToolbarTextType } from './webapp/views/toolbar-text'
+export { TreeResponse, isTreeResponse, TreeItem } from './models/TreeResponse'
 
 // low-level UI
 export { default as doCancel } from './webapp/cancel'

--- a/packages/core/src/models/TreeResponse.ts
+++ b/packages/core/src/models/TreeResponse.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from './entity'
+import { SupportedStringContent } from './mmr/content-types'
+
+export type TreeItem = {
+  /** unique string to distinguish a tree item */
+  id: string
+
+  /** label of a tree item */
+  name: string
+
+  /** content of a tree item */
+  content: string
+
+  /** type of the tree item content */
+  contentType: SupportedStringContent
+
+  /** Child nodes of a tree item */
+  children?: TreeItem[]
+
+  /** Flag indicating if node is expanded by default */
+  defaultExpanded?: boolean
+}
+
+export interface TreeResponse {
+  apiVersion: 'kui-shell/v1'
+  kind: 'TreeResponse'
+
+  /** data of a `TreeResponse` */
+  data: TreeItem[]
+}
+
+export function isTreeResponse(entity: Entity): entity is TreeResponse {
+  const tree = entity as TreeResponse
+  return (
+    tree.apiVersion === 'kui-shell/v1' &&
+    tree.kind === 'TreeResponse' &&
+    tree.data &&
+    Array.isArray(tree.data) &&
+    tree.data.length > 0
+  )
+}

--- a/packages/core/src/models/mmr/content-types.ts
+++ b/packages/core/src/models/mmr/content-types.ts
@@ -22,6 +22,7 @@ import { Entity, MetadataBearing } from '../entity'
 import { isHTML } from '../../util/types'
 import { ModeOrButton, Button } from './types'
 import { ToolbarText } from '../../webapp/views/toolbar-text'
+import { TreeResponse, isTreeResponse } from '../TreeResponse'
 import { Editable } from '../editable'
 
 /**
@@ -30,7 +31,7 @@ import { Editable } from '../editable'
  * function call.
  *
  */
-export type ScalarResource = string | HTMLElement | Table
+export type ScalarResource = string | HTMLElement | Table | TreeResponse
 export interface ScalarContent<T = ScalarResource> {
   content: T
 }
@@ -56,7 +57,8 @@ export function isScalarContent<T extends MetadataBearing>(entity: ScalarLike<T>
   const content = (entity as ScalarContent).content
   return (
     isReactProvider(entity) ||
-    (content !== undefined && (typeof content === 'string' || isTable(content) || isHTML(content)))
+    (content !== undefined &&
+      (typeof content === 'string' || isTable(content) || isHTML(content) || isTreeResponse(content)))
   )
 }
 

--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -118,6 +118,21 @@ export const SIDECAR_FULLY_CLOSED = (N: number) => `${SIDECAR(N)} .kui--sidecar:
 export const INVERTED_COLORS = '.kui--inverted-color-context'
 
 /**
+ * Tree
+ *
+ */
+export const TREE = (N: number) => `${SIDECAR_TAB_CONTENT(N)} .kui--treeview`
+export const TREE_VIEWS_AND_BODY = (N: number) => `${TREE(N)} .kui--treeview-nav-and-body`
+export const TREE_VIEWS = (N: number) => `${TREE_VIEWS_AND_BODY(N)} ul[role="tree"]`
+export const _TREE_LIST = (id: string) => `li[id="${id}"]`
+export const TREE_LIST = (N: number, id: string) => `${TREE_VIEWS(N)} ${_TREE_LIST(id)}`
+export const TREE_LIST_EXPANDED = (N: number, id: string) => `${TREE_VIEWS(N)} ${_TREE_LIST(id)}[aria-expanded="true"]`
+export const TREE_LIST_AS_BUTTON = (N: number, id: string) => `${TREE_LIST(N, id)} button.pf-c-tree-view__node`
+export const TREE_LIST_AS_BUTTON_SELECTED = (N: number, id: string) => `${TREE_LIST_AS_BUTTON(N, id)}.pf-m-current`
+export const TREE_LIST_IN_A_LIST = (N: number, id: string, parentId: string) =>
+  `${TREE_LIST_EXPANDED(N, parentId)} ul[role="group"] ${_TREE_LIST}`
+
+/**
  * Terminal splits
  *
  */

--- a/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/index.tsx
@@ -357,7 +357,9 @@ export default class Editor extends React.PureComponent<Props, State> {
       }
 
       const subscription = Editor.subscribeToChanges(props, editor, options.readOnly)
-      cleaners.push(() => subscription.dispose())
+      if (subscription) {
+        cleaners.push(() => subscription.dispose())
+      }
 
       cleaners.push(() => {
         editor.dispose()

--- a/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
+++ b/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
@@ -27,6 +27,7 @@ import {
   isReactProvider,
   isStringWithOptionalContentType,
   isTable,
+  isTreeResponse,
   isCommandStringContent,
   isFunctionContent,
   isScalarContent,
@@ -37,6 +38,7 @@ import {
 import Eval from './Eval'
 import Editor from './Editor'
 import renderTable from './Table'
+import TreeView from './TreeView'
 import Markdown from './Markdown'
 import HTMLString from './HTMLString'
 import HTMLDom from './Scalar/HTMLDom'
@@ -128,6 +130,8 @@ export default class KuiMMRContent extends React.Component<KuiMMRProps, State> {
         // <PaginatedTable {...props} />
       } else if (isHTML(mode.content)) {
         return <HTMLDom content={mode.content} />
+      } else if (isTreeResponse(mode.content)) {
+        return <TreeView tab={this.props.tab} data={mode.content.data} response={this.props.response} />
       } else {
         console.error('Unsupported scalar content', mode)
       }

--- a/plugins/plugin-client-common/src/components/Content/TreeView.tsx
+++ b/plugins/plugin-client-common/src/components/Content/TreeView.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react'
+import { TreeView } from '@patternfly/react-core'
+
+import { MultiModalResponse, Tab, TreeItem, TreeResponse } from '@kui-shell/core'
+import Editor from '../Content/Editor'
+
+import '../../../web/scss/components/TreeView/PatternFly.scss'
+
+interface Props {
+  response: MultiModalResponse
+  tab: Tab
+  data: TreeResponse['data']
+}
+
+interface State {
+  activeItems: TreeItem[]
+}
+
+export default class KuiTreeView extends React.PureComponent<Props, State> {
+  public constructor(props) {
+    super(props)
+
+    this.state = {
+      activeItems: [this.props.data[0]]
+    }
+  }
+
+  /** render tree item content in `Editor` */
+  private editor() {
+    return (
+      <React.Suspense fallback={<div />}>
+        <Editor
+          key={this.state.activeItems[0].id}
+          content={{ content: this.state.activeItems[0].content, contentType: this.state.activeItems[0].contentType }}
+          readOnly={false}
+          sizeToFit
+          response={this.props.response}
+          repl={this.props.tab.REPL}
+          tabUUID={this.props.tab.uuid}
+        />
+      </React.Suspense>
+    )
+  }
+
+  private tree() {
+    return (
+      <TreeView
+        data={this.props.data}
+        activeItems={this.state.activeItems}
+        onSelect={(_, treeViewItem, parentItem) => {
+          this.setState({
+            activeItems: [treeViewItem as TreeItem, parentItem as TreeItem]
+          })
+        }}
+        hasBadges
+      />
+    )
+  }
+
+  public render() {
+    return (
+      <div className="kui--treeview">
+        <div className="kui--treeview-nav-and-body">
+          {this.tree()}
+          {this.editor()}
+        </div>
+      </div>
+    )
+  }
+}

--- a/plugins/plugin-client-common/web/scss/components/TreeView/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/TreeView/PatternFly.scss
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '_mixins';
+
+.kui--treeview-nav-and-body {
+  display: flex;
+
+  @include TreeViewNav {
+    background-color: var(--color-sidecar-header);
+
+    @include TreeViewBadge {
+      color: var(--color-text-01);
+    }
+
+    @include TreeViewItemNotSelected {
+      color: var(--color-text-01);
+    }
+
+    @include TeeViewItem {
+      background-color: var(--color-sidecar-header);
+      font-size: 0.875rem;
+    }
+  }
+}

--- a/plugins/plugin-client-common/web/scss/components/TreeView/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/TreeView/_mixins.scss
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@mixin TreeViewNav {
+  .pf-c-tree-view {
+    @content;
+  }
+}
+
+@mixin TreeViewBadge {
+  .pf-c-badge {
+    @content;
+  }
+}
+
+@mixin TeeViewItem {
+  .pf-c-tree-view__node {
+    @content;
+  }
+}
+
+@mixin TreeViewItemNotSelected {
+  .pf-c-tree-view__node:not(.pf-m-current) {
+    @content;
+  }
+}

--- a/plugins/plugin-client-test/src/lib/cmds/content/tree.ts
+++ b/plugins/plugin-client-test/src/lib/cmds/content/tree.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TreeResponse } from '@kui-shell/core'
+
+const tree: TreeResponse = {
+  apiVersion: 'kui-shell/v1',
+  kind: 'TreeResponse',
+  data: [
+    {
+      id: 'without children',
+      name: 'without children',
+      content: 'without children',
+      contentType: 'text/plain'
+    },
+    {
+      name: 'with children',
+      id: 'with children',
+      content: 'with children',
+      contentType: 'text/plain',
+      children: [
+        {
+          name: 'Foo',
+          id: 'Foo',
+          content: 'Foo',
+          contentType: 'text/plain',
+          children: [
+            {
+              name: 'a',
+              id: 'a',
+              content: 'a',
+              contentType: 'text/plain'
+            },
+            {
+              name: 'b',
+              id: 'b',
+              content: `data: b`,
+              contentType: 'yaml',
+              children: [
+                {
+                  name: 'c',
+                  id: 'c',
+                  content: 'c',
+                  contentType: 'text/plain'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          name: 'Bar',
+          id: 'Bar',
+          content: 'Bar',
+          contentType: 'text/plain'
+        }
+      ]
+    }
+  ]
+}
+
+export default tree

--- a/plugins/plugin-client-test/src/lib/cmds/mmr-mode.ts
+++ b/plugins/plugin-client-test/src/lib/cmds/mmr-mode.ts
@@ -25,6 +25,7 @@ import { Arguments, ParsedOptions, Registrar, Tab, MultiModalResponse } from '@k
 import { metadataWithNameOnly as metadata } from './metadata'
 import { modeOrderVariants } from './content/modes'
 import reactContent from './content/react'
+import tree from './content/tree'
 import { MyResource } from '../models'
 
 // exporting this for consumption in tests
@@ -83,12 +84,25 @@ const doModes = (idx: number): ((args: Arguments<Options>) => MultiModalResponse
   }
 }
 
+/** This is the handler of command: `mmr test react` */
 function doReact() {
   return Object.assign(metadata, {
     modes: [
       {
         mode: 'react',
         react: reactContent()
+      }
+    ]
+  })
+}
+
+/** This is the handler of command: `mmr test tree` */
+async function doTree() {
+  return Object.assign(metadata, {
+    modes: [
+      {
+        mode: 'tree',
+        content: tree
       }
     ]
   })
@@ -104,6 +118,12 @@ export default (commandTree: Registrar) => {
   commandTree.listen('/test/mmr/react', doReact, {
     usage: {
       docs: 'A test of MultiModalResponse mode that presents a React component'
+    }
+  })
+
+  commandTree.listen('/test/mmr/tree', doTree, {
+    usage: {
+      docs: 'A test of MultiModalResponse mode that presents a TreeResponse'
     }
   })
 

--- a/plugins/plugin-client-test/src/test/api1/mmr-mode.ts
+++ b/plugins/plugin-client-test/src/test/api1/mmr-mode.ts
@@ -26,6 +26,7 @@ import { TestMMR, MMRExpectMode } from '@kui-shell/test'
 
 import { MyResource } from '../../lib/models'
 import { metadata as _meta } from '../../lib/cmds/mmr-mode'
+import tree from '../../lib/cmds/content/tree'
 
 const { metadata } = _meta
 
@@ -109,6 +110,12 @@ const testReact = new TestMMR({
   command: 'test mmr react'
 })
 
+const testTree = new TestMMR({
+  metadata,
+  testName: 'test mmr tree',
+  command: 'test mmr tree'
+})
+
 const testOrder = new TestMMR({
   testName: 'change order',
   metadata,
@@ -148,6 +155,7 @@ testReact.toolbarText({
   text: 'hello this is iter',
   exact: false
 })
+testTree.tree(tree, 'tree')
 testDefault.name({ heroName: true })
 testDefault.modes(expectModes, expectModes[0], { testWindowButtons: true })
 testDefault2.modes(expectModes2, expectModes2[0])


### PR DESCRIPTION
Fixes #6132
![Screen Shot 2020-11-09 at 5 26 07 PM](https://user-images.githubusercontent.com/21212160/98603837-c767f700-22b0-11eb-9648-7093296718c3.png)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
