### PR TITLE
fix(plugins/plugin-bashlike): when an XtermResponse is not an error, …

### DIFF
--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -631,7 +631,8 @@ async function initOnMessage(
           respondToRepl({
             apiVersion: 'kui-shell/v1',
             kind: 'XtermResponse',
-            rows: copy(terminal)
+            rows: copy(terminal),
+            code: 0 // to be over-written in the case of an error response
           })
         })
       }


### PR DESCRIPTION
…it has no `code` field

Fixes #6177

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
