### PR TITLE
fix: default chart colors should not use blue-red diverging spectrum

### DIFF
--- a/plugins/plugin-carbon-themes/web/scss/charts.scss
+++ b/plugins/plugin-carbon-themes/web/scss/charts.scss
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /* from https://www.carbondesignsystem.com/data-visualization/color-palettes */
 
 @mixin charts-red-blue-diverging {
@@ -27,6 +43,7 @@
   --color-latency-0: #005d5d; /* t70 */
 }
 
+/** citation: https://colorbrewer2.org/ */
 @mixin charts-color-brewer-green-purple-diverging {
   --color-latency-0: #00441b;
   --color-latency-1: #1b7837;

--- a/plugins/plugin-client-common/web/css/static/ui.css
+++ b/plugins/plugin-client-common/web/css/static/ui.css
@@ -1,5 +1,6 @@
 @import "ansi_up";
 @import "master-font-size";
+@import "../../scss/components/Chart/colors";
 
 * {
   box-sizing: border-box;
@@ -1024,6 +1025,14 @@ body[kui-theme-style="dark"] .legend-icon.is-waitTime {
   color: var(--color-base0E);
 }
 
+body[kui-theme-style="light"] {
+  @include charts-light;
+}
+
+body[kui-theme-style="dark"] {
+  @include charts-dark;
+}
+
 body {
   /* define theme bindings; mapping color names to the base16 scheme */
   --color-black: var(--color-ui-01);
@@ -1095,14 +1104,6 @@ body {
   --color-tag-beta-text: var(--color-base01);
   --color-tag-ibm-fill: var(--color-base0D);
   --color-tag-ibm-text: var(--color-base01);
-
-  /* default latency color spectrum */
-  --color-latency-0: #2166ac;
-  --color-latency-1: #67a9cf;
-  --color-latency-2: hsla(201, 51%, 78%, 1); /* #d1e5f0 with lightness reduced from 88% to 78% */
-  --color-latency-3: #fddbc7;
-  --color-latency-4: #ef8a62;
-  --color-latency-5: #b2182b;
 
   /* two-color charts; yellow versus cyan should be a pretty good default */
   --color-chart-0: var(--color-yellow);

--- a/plugins/plugin-client-common/web/scss/components/Chart/_colors.scss
+++ b/plugins/plugin-client-common/web/scss/components/Chart/_colors.scss
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** citation: https://colorbrewer2.org/ */
+@mixin colorbrewer-green-purple-diverging {
+  --color-latency-0: #00441b;
+  --color-latency-1: #1b7837;
+  --color-latency-2: #a6dba0;
+  --color-latency-3: #9970ab;
+  --color-latency-4: #762a83;
+  --color-latency-5: #40004b;
+}
+
+@mixin colorbrewer-blue-red-diverging {
+  --color-latency-0: #2166ac;
+  --color-latency-1: #67a9cf;
+  --color-latency-2: hsla(201, 51%, 78%, 1); /* #d1e5f0 with lightness reduced from 88% to 78% */
+  --color-latency-3: #fddbc7;
+  --color-latency-4: #ef8a62;
+  --color-latency-5: #b2182b;
+}
+
+@mixin charts-light {
+  @include colorbrewer-green-purple-diverging;
+}
+
+@mixin charts-dark {
+  @include colorbrewer-green-purple-diverging;
+}


### PR DESCRIPTION
Fixes #6191

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
