### PR TITLE
fix: block timestamp in Light theme/lightweight ui has low contrast

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Table/Lightweight.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/Lightweight.scss
@@ -106,6 +106,12 @@ $row-height: 1.5em;
     padding: $block-padding 0;
   }
 
+  @include WidthConstrained {
+    @include BlockDuration {
+      opacity: 1;
+    }
+  }
+
   @include BlockTimestamp {
     color: var(--color-base0A);
 

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -167,6 +167,15 @@ $action-hover-delay: 210ms;
   }
 }
 
+/** Duration of block */
+@mixin BlockDuration {
+  @include BlockTimestamp {
+    .sub-text {
+      @content;
+    }
+  }
+}
+
 /** Block action buttons, e.g. remove block, re-run command, ... */
 @mixin BlockActions {
   .kui--block-actions-buttons {

--- a/plugins/plugin-core-themes/web/scss/light.scss
+++ b/plugins/plugin-core-themes/web/scss/light.scss
@@ -88,14 +88,12 @@ body[kui-theme='Light'] {
   --color-base07: #fff;
   --color-base08: #e71d32;
   --color-base09: #bf5b17;
-  --color-base0A: #fdd13a;
+  --color-base0A: hsl(46, 87%, 37%); /* #fdd13a; */
   --color-base0B: #1dbd5a;
   --color-base0C: #399cd6;
   --color-base0D: #0072c3;
   --color-base0E: #d12764;
   --color-base0F: #8a3ffc;
-
-  --color-yellow-text: hsl(46, 87%, 37%);
 
   --color-name: var(--color-base0D);
   --color-map-key: var(--color-base0D);


### PR DESCRIPTION
Fixes #6226

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
