### PR TITLE
9.2.3

### DIFF
--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -42,6 +42,7 @@ interface App extends EventEmitter {
   quit(): void
   exit(exitCode?: number): void
   requestSingleInstanceLock(): boolean
+  allowRendererProcessReuse: boolean
 }
 
 /**
@@ -528,7 +529,9 @@ export async function initElectron(
     debug('loading electron')
     const Electron = await import('electron')
     app = Electron.app
-    Electron.app.allowRendererProcessReuse = false
+    if (app) {
+      app.allowRendererProcessReuse = false
+    }
 
     if (!app) {
       // then we're still in pure headless mode; we'll need to fork ourselves to spawn electron

--- a/plugins/plugin-client-common/src/components/Client/InputStripe.tsx
+++ b/plugins/plugin-client-common/src/components/Client/InputStripe.tsx
@@ -39,6 +39,8 @@ interface State {
 }
 
 export default class InputStripe extends React.PureComponent<Props, State> {
+  private _blockRef = React.createRef<Block>()
+
   public constructor(props: Props) {
     super(props)
 
@@ -55,17 +57,25 @@ export default class InputStripe extends React.PureComponent<Props, State> {
     this.setState(curState => ({ idx: curState.idx + 1, model: Active() }))
   }
 
+  public doFocus() {
+    if (this._blockRef.current) {
+      this._blockRef.current.doFocus()
+    }
+  }
+
   public render() {
     return (
       <KuiContext.Provider value={{ prompt: this.props.prompt || '\u276f' }}>
         <div className="kui--input-stripe repl">
           <Block
+            ref={this._blockRef}
             idx={this.state.idx}
             uuid={this.props.uuid}
             tab={this.props.tab}
             model={this.state.model}
             noOutput
             noPromptContext
+            isFocused
             promptPlaceholder={this.props.promptPlaceholder}
           >
             {this.props.children}

--- a/plugins/plugin-client-common/src/components/Client/Popup.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Popup.tsx
@@ -30,6 +30,7 @@ interface Props {
 }
 
 interface State {
+  tab: KuiTab
   model: TabModel
   promptPlaceholder: string
 }
@@ -57,12 +58,14 @@ export default class Popup extends React.PureComponent<Props, State> {
     })
 
     this.state = {
+      tab: undefined,
       model: tabModel,
       promptPlaceholder: ''
     }
   }
 
   private onTabReady(tab: KuiTab) {
+    this.setState({ tab })
     tab.REPL.pexec(this.props.commandLine.join(' '), { tab })
   }
 
@@ -78,7 +81,13 @@ export default class Popup extends React.PureComponent<Props, State> {
         ></TabContent>
         <StatusStripe>
           <ContextWidgets className="kui--input-stripe-in-status-stripe">
-            <InputStripe promptPlaceholder={this.state.promptPlaceholder} uuid={this.state.model.uuid} />
+            {this.state.tab && (
+              <InputStripe
+                promptPlaceholder={this.state.promptPlaceholder}
+                uuid={this.state.model.uuid}
+                tab={this.state.tab}
+              />
+            )}
           </ContextWidgets>
           {this.props.children}
         </StatusStripe>

--- a/plugins/plugin-client-common/src/components/Client/Popup.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Popup.tsx
@@ -36,6 +36,8 @@ interface State {
 }
 
 export default class Popup extends React.PureComponent<Props, State> {
+  private _inputStripeRef = React.createRef<InputStripe>()
+
   public constructor(props: Props) {
     super(props)
 
@@ -55,6 +57,7 @@ export default class Popup extends React.PureComponent<Props, State> {
       }
 
       this.setState({ promptPlaceholder: command })
+      this.doFocusInput()
     })
 
     this.state = {
@@ -67,6 +70,13 @@ export default class Popup extends React.PureComponent<Props, State> {
   private onTabReady(tab: KuiTab) {
     this.setState({ tab })
     tab.REPL.pexec(this.props.commandLine.join(' '), { tab })
+    this.doFocusInput()
+  }
+
+  private doFocusInput() {
+    if (this._inputStripeRef.current) {
+      setTimeout(() => this._inputStripeRef.current.doFocus())
+    }
   }
 
   public render() {
@@ -83,6 +93,7 @@ export default class Popup extends React.PureComponent<Props, State> {
           <ContextWidgets className="kui--input-stripe-in-status-stripe">
             {this.state.tab && (
               <InputStripe
+                ref={this._inputStripeRef}
                 promptPlaceholder={this.state.promptPlaceholder}
                 uuid={this.state.model.uuid}
                 tab={this.state.tab}

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -413,21 +413,27 @@ export default class Input extends InputProvider {
 
   private readonly _onRef = this.onRef.bind(this)
 
+  private willFocusBlock(evt: React.SyntheticEvent<HTMLInputElement>) {
+    if (this.props.willFocusBlock) {
+      this.props.willFocusBlock(evt)
+    }
+  }
+
   /** This is the onFocus property of the active prompt */
   private readonly _onFocus = (evt: React.FocusEvent<HTMLInputElement>) => {
     this.props.onInputFocus && this.props.onInputFocus(evt)
-    this.props.willFocusBlock(evt)
+    this.willFocusBlock(evt)
   }
 
   /** This is the onClick property of the prompt for Active blocks */
   private readonly _onClickActive = (evt: React.MouseEvent<HTMLInputElement>) => {
     this.props.onInputClick && this.props.onInputClick(evt)
-    this.props.willFocusBlock(evt)
+    this.willFocusBlock(evt)
   }
 
   /** This is the onClick property of the prompt for Finished blocks */
   private readonly _onClickFinished = whenNothingIsSelected((evt: React.MouseEvent<HTMLInputElement>) => {
-    this.props.willFocusBlock(evt)
+    this.willFocusBlock(evt)
     this.setState(curState => {
       if (!curState.isReEdit) {
         return {

--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -55,7 +55,8 @@ export default function renderMain(props: KuiProps) {
       {...props}
       toplevel={!inBrowser() && <Search />}
       commandLine={
-        props.commandLine || [
+        props.commandLine ||
+        (!isPopup() && [
           'tab',
           'new',
           '-s',
@@ -72,7 +73,7 @@ export default function renderMain(props: KuiProps) {
           `kuiconfig not set ${welcomeBit}`,
           '--onClose',
           `kuiconfig set ${welcomeBit}`
-        ]
+        ])
       }
     >
       <ContextWidgets>

--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -24,7 +24,7 @@ import { CurrentContext, CurrentNamespace } from '@kui-shell/plugin-kubectl/comp
 // import { ClusterUtilization } from '@kui-shell/plugin-kubectl/view-utilization'
 import { ProxyOfflineIndicator } from '@kui-shell/plugin-proxy-support'
 import { Screenshot, Search, UpdateChecker } from '@kui-shell/plugin-electron-components'
-import { GridWidget as OpenWhiskGridWidget } from '@kui-shell/plugin-openwhisk'
+// import { GridWidget as OpenWhiskGridWidget } from '@kui-shell/plugin-openwhisk'
 
 import { productName } from '@kui-shell/client/config.d/name.json'
 
@@ -85,7 +85,7 @@ export default function renderMain(props: KuiProps) {
 
       <MeterWidgets>
         {/* <ClusterUtilization /> */}
-        <OpenWhiskGridWidget />
+        {/* !isPopup() && <OpenWhiskGridWidget /> */}
         {inBrowser() && <ProxyOfflineIndicator />}
         {!isPopup() && !inBrowser() && <UpdateChecker />}
         <Screenshot />

--- a/plugins/plugin-s3/src/test/core/s3.ts
+++ b/plugins/plugin-s3/src/test/core/s3.ts
@@ -156,7 +156,8 @@ if (process.env.NEEDS_MINIO) {
       ls(README, bucketName, '*') // ls /s3/minio/bucketName/*, expect README
       ls(README, bucketName, 'R*') // ls /s3/minio/bucketName/R*, expect README
       ls(README, bucketName, '*EADME.md') // ls /s3/minio/bucketName/*EADME.md, expect README
-      ls(README, bucketName, '*EADME*') // ls /s3/minio/bucketName/*EADME*, expect README
+      ls(README, bucketName, 'README{,}.md') // ls /s3/minio/bucketName/README{,}.md, expect README <-- brace expansion
+      ls(README, bucketName, 'README{,}.m*') // ls /s3/minio/bucketName/README{,}.m*, expect README <-- brace expansion
       copyToS3(bucketName, README2)
       ls(README2, bucketName) // ls /s3/minio/bucketName, expect README2
       copyFromS3(bucketName, README2.replace(/.md$/, '*'), tmpdir()) // wildcard in source

--- a/plugins/plugin-s3/src/vfs/index.ts
+++ b/plugins/plugin-s3/src/vfs/index.ts
@@ -100,7 +100,7 @@ class S3VFSResponder extends S3VFS implements VFS {
 
   /** Enumerate matching objects */
   private async listObjects(filepath: string, dashD = false): Promise<DirEntry[]> {
-    const [, bucketName, bucketNameSlash, prefix, wildcardSuffix] = filepath.match(/([^/*]+)(\/?)([^*]*)(.*)/)
+    const [, bucketName, bucketNameSlash, prefix, wildcardSuffix] = filepath.match(/([^/*{]+)(\/?)([^*{]*)(.*)/)
 
     const pattern =
       prefix.length === 0 && (wildcardSuffix.length === 0 || wildcardSuffix === '*')
@@ -146,7 +146,7 @@ class S3VFSResponder extends S3VFS implements VFS {
         })
 
         objectStream.on('data', ({ name, size, lastModified }) => {
-          if ((!pattern && name === prefix) || (pattern && micromatch.isMatch(name, pattern))) {
+          if ((!pattern && name === prefix) || (pattern && micromatch.isMatch(name, prefix + pattern))) {
             const path = join(this.mountPath, bucketName, name)
 
             objects.push({


### PR DESCRIPTION
[9.2.3 0de9b09f1] fix: keyboard history navigation does not work in Popup clients
 Date: Thu Nov 26 11:56:06 2020 -0500
 3 files changed, 22 insertions(+), 6 deletions(-)

[9.2.3 123978fe3] fix(packages/core): kubectl-kui popup can fail when setting allowRendererProcessReuse
 Date: Thu Nov 26 10:59:06 2020 -0500
 1 file changed, 4 insertions(+), 1 deletion(-)

[9.2.3 781259463] fix(plugins/plugin-s3): ls against s3 vfs does not properly handle brace expansion
 Date: Thu Nov 26 07:05:25 2020 -0500
 2 files changed, 4 insertions(+), 3 deletions(-)

[9.2.3 143b3b4e8] fix(plugins/plugin-client-common): Popup mode input stripe does not have reliable auto-focus behavior
 Date: Thu Nov 26 18:09:28 2020 -0500
 2 files changed, 21 insertions(+)

[9.2.3 31d097f3d] fix(plugins/plugin-client-default): Don't use OpenWhisk status stripe widget in popup mode
 Date: Thu Nov 26 18:10:54 2020 -0500
 1 file changed, 2 insertions(+), 2 deletions(-)