### PR TITLE
9.2.4

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Sidecar/Nested.scss
+++ b/plugins/plugin-client-common/web/scss/components/Sidecar/Nested.scss
@@ -25,7 +25,6 @@
 }
 
 @include NestedSidecar {
-  min-width: 70rem;
   max-width: 100%;
   min-height: 20em;
   height: auto;

--- a/plugins/plugin-kubectl-flow-views/tekton/src/lib/read.ts
+++ b/plugins/plugin-kubectl-flow-views/tekton/src/lib/read.ts
@@ -16,7 +16,7 @@
 
 import Debug from 'debug'
 import { Tab } from '@kui-shell/core'
-import { KubeResource } from '@kui-shell/plugin-kubectl'
+import { KubeResource, fetchFileString } from '@kui-shell/plugin-kubectl'
 import { Task } from '../model/resource'
 
 const debug = Debug('plugins/tekton/lib/read')
@@ -37,10 +37,12 @@ export const parse = async (raw: string | PromiseLike<string>): Promise<KubeReso
  *
  */
 export const read = async (tab: Tab, filepath: string): Promise<string> => {
-  const stats = (await tab.REPL.rexec<{ data: string }>(`vfs fstat ${tab.REPL.encodeComponent(filepath)} --with-data`))
-    .content
-
-  return stats.data
+  const data = await fetchFileString(tab.REPL, filepath)
+  if (data.length === 1) {
+    return data[0]
+  } else {
+    throw new Error(`Failed to fetch ${filepath}`)
+  }
 }
 
 /**

--- a/plugins/plugin-kubectl-flow-views/tekton/src/view/flow.ts
+++ b/plugins/plugin-kubectl-flow-views/tekton/src/view/flow.ts
@@ -91,10 +91,10 @@ export default async (
   const duration = startTime && endTime && endTime.getTime() - startTime.getTime()
 
   return {
-    type: 'custom',
-    isEntity: true,
     isFromFlowCommand: true,
-    name: filepath ? basename(filepath) : jsons[0].metadata.name,
+    metadata: {
+      name: filepath ? basename(filepath) : jsons[0].metadata.name
+    },
     packageName: filepath && dirname(filepath),
     prettyType: run ? 'PipelineRun' : 'Pipeline',
     duration,


### PR DESCRIPTION
[9.2.4 be156c735] fix(plugins/plugin-kubectl-flow-views): `tekton flow` command fails
 Date: Mon Nov 30 15:52:48 2020 -0500
 1 file changed, 3 insertions(+), 3 deletions(-)

[9.2.4 785880b30] fix(plugins/plugin-kubectl-flow-views): `tekton flow` command does not support previewing a remote url
 Date: Mon Nov 30 15:57:08 2020 -0500
 1 file changed, 7 insertions(+), 5 deletions(-)

[9.2.4 60dcd1a01] fix(plugins/plugin-client-common): inline sidecar should not have a min-width
 Date: Mon Nov 30 15:49:51 2020 -0500
 1 file changed, 1 deletion(-)