### PR TITLE
feat: clicking changed files in the `git status widget` should show git diff` result in a DiffEditor

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -206,6 +206,8 @@ export {
   isStringWithOptionalContentType,
   isSupportedContentType,
   SupportedStringContent,
+  StringDiffContent,
+  isStringDiffContent,
   isFunctionContent,
   FunctionThatProducesContent
 } from './models/mmr/content-types'

--- a/packages/core/src/models/mmr/content-types.ts
+++ b/packages/core/src/models/mmr/content-types.ts
@@ -108,6 +108,31 @@ export function isStringWithOptionalContentType<T extends MetadataBearing>(
 }
 
 /**
+ * Compare 2 `StringContent`
+ *
+ */
+export type StringDiffContent<ContentType = SupportedStringContent> = {
+  content: {
+    a: string
+    b: string
+  }
+  contentType: ContentType
+}
+
+export function isStringDiffContent<T extends MetadataBearing>(
+  entity: Entity | Content<T> | MetadataBearing | ModeOrButton<T>
+): entity is StringDiffContent {
+  const str = entity as StringDiffContent
+  return !!(
+    str &&
+    str.content &&
+    typeof str.content.a === 'string' &&
+    typeof str.content.b === 'string' &&
+    isSupportedContentType(str.contentType)
+  )
+}
+
+/**
  * `Content` as `FunctionThatProducesContent<T>` is a function that
  * takes a `T` and produces either a resource or some { content,
  * contentType } wrapper.
@@ -171,6 +196,7 @@ export function isCommandStringContent<T extends MetadataBearing>(
 export type Content<T extends MetadataBearing = MetadataBearing> =
   | ScalarContent
   | StringContent
+  | StringDiffContent
   | FunctionContent<T>
   | CommandStringContent
   | ReactProvider

--- a/packages/test/src/api/mmr.ts
+++ b/packages/test/src/api/mmr.ts
@@ -428,6 +428,23 @@ export class TestMMR {
     })
   }
 
+  public diffPlainText(mode: string, textB: string) {
+    const { command, testName } = this.param
+
+    describe(`diff ${testName} ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+      before(Common.before(this))
+      after(Common.after(this))
+
+      it('should should open sidecar with tree view', () =>
+        CLI.command(command, this.app)
+          .then(ReplExpect.ok)
+          .then(SidecarExpect.open)
+          .then(SidecarExpect.mode(mode))
+          .then(SidecarExpect.textPlainContentFromMonaco(textB))
+          .catch(Common.oops(this, true)))
+    })
+  }
+
   /**
    * toolbarButtons() starts a Mocha Test Suite
    * toolbarButtons() executes `command` and expects the `buttons` shown in Sidecar having correct labels and drildown handlers

--- a/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
+++ b/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
@@ -31,12 +31,14 @@ import {
   isCommandStringContent,
   isFunctionContent,
   isScalarContent,
+  isStringDiffContent,
   MultiModalResponse,
   ToolbarProps
 } from '@kui-shell/core'
 
 import Eval from './Eval'
 import Editor from './Editor'
+import DiffEditor from './Editor/DiffEditor'
 import renderTable from './Table'
 import Tree from '../spi/Tree'
 import Markdown from './Markdown'
@@ -81,7 +83,6 @@ export default class KuiMMRContent extends React.Component<KuiMMRProps, State> {
     }
 
     const { tab, mode, response, willUpdateToolbar } = this.props
-
     if (isStringWithOptionalContentType(mode)) {
       if (mode.contentType === 'text/html') {
         return <HTMLString content={mode.content} />
@@ -107,6 +108,18 @@ export default class KuiMMRContent extends React.Component<KuiMMRProps, State> {
           />
         )
       }
+    } else if (isStringDiffContent(mode)) {
+      return (
+        <DiffEditor
+          contentType={mode.contentType}
+          originalContent={mode.content.a}
+          modifiedContent={mode.content.b}
+          sizeToFit
+          response={response}
+          renderSideBySide
+          tabUUID={tab.uuid}
+        />
+      )
     } else if (isCommandStringContent(mode)) {
       return <Eval {...this.props} command={mode.contentFrom} contentType={mode.contentType} />
     } else if (isFunctionContent(mode)) {

--- a/plugins/plugin-client-test/src/lib/cmds/mmr-mode.ts
+++ b/plugins/plugin-client-test/src/lib/cmds/mmr-mode.ts
@@ -108,6 +108,21 @@ async function doTree() {
   })
 }
 
+async function doDiff() {
+  return Object.assign(metadata, {
+    modes: [
+      {
+        mode: 'diff',
+        content: {
+          a: 'foooooooooo',
+          b: 'barrrrrrrrr'
+        },
+        contentType: 'text/plain'
+      }
+    ]
+  })
+}
+
 export default (commandTree: Registrar) => {
   commandTree.listen('/test/mmr/mode', doModes(0), {
     usage: {
@@ -124,6 +139,12 @@ export default (commandTree: Registrar) => {
   commandTree.listen('/test/mmr/tree', doTree, {
     usage: {
       docs: 'A test of MultiModalResponse mode that presents a TreeResponse'
+    }
+  })
+
+  commandTree.listen('/test/mmr/diff', doDiff, {
+    usage: {
+      docs: 'A test of MultiModalResponse mode that presents a StringDiffResponse'
     }
   })
 

--- a/plugins/plugin-client-test/src/test/api1/mmr-mode.ts
+++ b/plugins/plugin-client-test/src/test/api1/mmr-mode.ts
@@ -116,6 +116,12 @@ const testTree = new TestMMR({
   command: 'test mmr tree'
 })
 
+const testDiff = new TestMMR({
+  metadata,
+  testName: 'test mmr diff',
+  command: 'test mmr diff'
+})
+
 const testOrder = new TestMMR({
   testName: 'change order',
   metadata,
@@ -156,6 +162,7 @@ testReact.toolbarText({
   exact: false
 })
 testTree.tree(tree, 'tree')
+testDiff.diffPlainText('diff', 'barrrrrrrrr')
 testDefault.name({ heroName: true })
 testDefault.modes(expectModes, expectModes[0], { testWindowButtons: true })
 testDefault2.modes(expectModes2, expectModes2[0])

--- a/plugins/plugin-git/i18n/resources_en_US.json
+++ b/plugins/plugin-git/i18n/resources_en_US.json
@@ -3,5 +3,7 @@
   "Switch branch": "Switch branch",
   "Your current git branch": "Your current git branch.",
   "You have made no changes to this branch.": "You have made no changes to this branch.",
-  "You have made the following changes to this branch.": "You have made the following changes to this branch."
+  "You have made the following changes to this branch.": "You have made the following changes to this branch.",
+  "Git Diff": "Git Diff",
+  "Showing changes between the working tree and previous commit.": "Showing changes between the working tree and previous commit."
 }

--- a/plugins/plugin-git/src/controller/git/diff.ts
+++ b/plugins/plugin-git/src/controller/git/diff.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Arguments,
+  expandHomeDir,
+  findFile,
+  i18n,
+  KResponse,
+  Registrar,
+  SupportedStringContent,
+  Mode,
+  MultiModalResponse
+} from '@kui-shell/core'
+import { doExecWithPty } from '@kui-shell/plugin-bash-like'
+import { File, FStat } from '@kui-shell/plugin-bash-like/fs'
+
+import { basename, dirname } from 'path'
+
+const strings = i18n('plugin-git')
+
+/** Important for alignment to the Editor view component */
+function contentTypeOf(suffix: string): SupportedStringContent {
+  switch (suffix) {
+    case 'sh':
+      return 'shell'
+    case 'md':
+      return 'text/markdown'
+    case 'html':
+      return 'text/html'
+    case 'yaml':
+    case 'json':
+      return suffix
+    default:
+      return 'text/plain'
+  }
+}
+
+async function gitDiff(args: Arguments): Promise<KResponse> {
+  try {
+    const { argvNoOptions, REPL } = args
+    const filepath = argvNoOptions[argvNoOptions.indexOf('diff') + 1]
+    const fullpath = findFile(expandHomeDir(filepath))
+    const name = basename(filepath)
+    const suffix = filepath.substring(filepath.lastIndexOf('.') + 1)
+    const enclosingDirectory = dirname(filepath)
+    const packageName = enclosingDirectory === '.' ? undefined : enclosingDirectory
+    const contentType = contentTypeOf(suffix)
+
+    const [previousCommit, workingTree] = await Promise.all([
+      REPL.qexec<string>(`git show HEAD:${filepath}`),
+      REPL.rexec<FStat>(`vfs fstat ${REPL.encodeComponent(filepath)} --with-data`)
+    ])
+
+    const mode: Mode = {
+      mode: 'git diff',
+      label: strings('Git Diff'),
+      content: { a: previousCommit, b: workingTree.content.data },
+      contentType
+    }
+
+    const response: MultiModalResponse<File> = {
+      apiVersion: 'kui-shell/v1',
+      kind: 'File',
+      metadata: {
+        name,
+        namespace: packageName
+      },
+      toolbarText: { type: 'info', text: strings('Showing changes between the working tree and previous commit.') },
+      modes: [mode],
+      spec: {
+        filepath,
+        fullpath
+      }
+    }
+
+    return response
+  } catch (err) {
+    console.error('failed at git diff', err)
+    return doExecWithPty(args)
+  }
+}
+
+export default function(registrar: Registrar) {
+  registrar.listen('/git/diff', gitDiff)
+}

--- a/plugins/plugin-git/src/plugin.ts
+++ b/plugins/plugin-git/src/plugin.ts
@@ -16,7 +16,9 @@
 
 import { Registrar } from '@kui-shell/core'
 import gitBranch from './controller/git/branch'
+import gitDiff from './controller/git/diff'
 
 export default function(registrar: Registrar) {
   gitBranch(registrar)
+  gitDiff(registrar)
 }


### PR DESCRIPTION
Fixes #6348
![Screen Shot 2020-12-07 at 5 24 27 PM](https://user-images.githubusercontent.com/21212160/101412829-4866de00-38b1-11eb-8d1e-8c9f97107937.png)


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
