### PR TITLE
feat: use new Dropdown status stripe for CurrentNamespace widget

### DIFF
--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -278,10 +278,12 @@ export const NOSPLIT_ALT_BUFFER_N = (N: number) => `${CURRENT_TAB}.xterm-alt-buf
 const STATUS_STRIPE = '#kui--status-stripe'
 export const STATUS_STRIPE_TYPE = (type: 'default' | 'blue') => `${STATUS_STRIPE}[data-type="${type}"]`
 export const STATUS_STRIPE_MESSAGE = `${STATUS_STRIPE} .kui--status-stripe-message-element`
-export const STATUS_STRIPE_WIDGET = (which: string) => `${STATUS_STRIPE} .${which}`
+export const STATUS_STRIPE_WIDGET = (which: string, dot: '.' | '#' = '.') => `${STATUS_STRIPE} ${dot}${which}`
 export const STATUS_STRIPE_WIDGET_WITH_ATTR = (which: string, key: string, value: string) =>
   `${STATUS_STRIPE_WIDGET(which)}[data-${key}="${value}"]`
 export const STATUS_STRIPE_WIDGET_LABEL = (which: string) => `${STATUS_STRIPE_WIDGET(which)} .kui--status-stripe-text`
+export const STATUS_STRIPE_DROPDOWN_LABEL = (which: string) =>
+  `${STATUS_STRIPE_WIDGET(which, '#')} .bx--list-box__label`
 export const STATUS_STRIPE_WIDGET_ICON_WITH_ATTR = (which: string, key: string, value: string) =>
   `${STATUS_STRIPE_WIDGET_WITH_ATTR(which, key, value)} .kui--status-stripe-icon`
 export const STATUS_STRIPE_WIDGET_LABEL_WITH_ATTR = (which: string, key: string, value: string) =>

--- a/plugins/plugin-client-common/src/components/Client/StatusStripe/DropdownWidget.tsx
+++ b/plugins/plugin-client-common/src/components/Client/StatusStripe/DropdownWidget.tsx
@@ -16,17 +16,25 @@
 
 import React from 'react'
 import { DropDown, DropDownAction } from '../../..'
+import { DropDownProps } from '../../spi/DropDown'
 
-export interface Props {
+export type Props = Pick<DropDownProps, 'position'> & {
   id?: string
-  position?: 'left' | 'right'
+  icon?: React.ReactNode
   actions: DropDownAction[]
 }
 
 export default function DropdownWidget(props: Props) {
   return (
-    <div className="kui--status-stripe-element" data-padding="none" id={props.id}>
-      <DropDown isPlain direction="up" toggle="caret" position={props.position} actions={props.actions} />
+    <div className="kui--status-stripe-element" id={props.id}>
+      <DropDown
+        isPlain
+        direction="up"
+        toggle="caret"
+        position={props.position}
+        actions={props.actions}
+        icon={props.icon}
+      />
     </div>
   )
 }

--- a/plugins/plugin-client-common/src/components/spi/DropDown/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/DropDown/impl/PatternFly.tsx
@@ -97,7 +97,12 @@ export default class PatternFlyDropDown extends React.PureComponent<Props, State
           !this.props.toggle || this.props.toggle === 'kebab' ? (
             <KebabToggle className="kui--dropdown__toggle" onToggle={this._onToggle} />
           ) : (
-            <DropdownToggle className="kui--dropdown__toggle" onToggle={this._onToggle} toggleIndicator={CaretUpIcon}>
+            <DropdownToggle
+              className="kui--dropdown__toggle"
+              onToggle={this._onToggle}
+              toggleIndicator={CaretUpIcon}
+              icon={this.props.icon}
+            >
               {this.currentLabel()}
             </DropdownToggle>
           )

--- a/plugins/plugin-client-common/src/components/spi/DropDown/index.tsx
+++ b/plugins/plugin-client-common/src/components/spi/DropDown/index.tsx
@@ -22,7 +22,7 @@ import Props from './model'
 import Carbon from './impl/Carbon'
 import PatternFly4 from './impl/PatternFly'
 
-export { Action as DropDownAction } from './model'
+export { Action as DropDownAction, Props as DropDownProps } from './model'
 
 export default function DropDownSpi(props: Props): React.ReactElement {
   return (

--- a/plugins/plugin-client-common/src/components/spi/DropDown/model.ts
+++ b/plugins/plugin-client-common/src/components/spi/DropDown/model.ts
@@ -21,7 +21,7 @@ export interface Action {
   hasDivider?: boolean
 }
 
-interface Props {
+export interface Props {
   /** Render more plain/inline style? */
   isPlain?: boolean
 
@@ -30,6 +30,9 @@ interface Props {
 
   /** Should the Dropdown "pointer" be positioned on the left or on the right? Default is left */
   position?: 'left' | 'right'
+
+  /** Icon to include in the dropdown toggler */
+  icon?: React.ReactNode
 
   /** Use kebab or regular caret-style dropdown toggler? Default is kebab */
   toggle?: 'kebab' | 'caret'

--- a/plugins/plugin-client-common/src/index.ts
+++ b/plugins/plugin-client-common/src/index.ts
@@ -39,6 +39,7 @@ export { default as ContextWidgets } from './components/Client/StatusStripe/Cont
 export { ViewLevel, default as TextWithIconWidget } from './components/Client/StatusStripe/TextWithIconWidget'
 export { default as Settings } from './components/Client/StatusStripe/Settings'
 export { default as TagWidget } from './components/Client/StatusStripe/TagWidget'
+export { default as DropdownWidget } from './components/Client/StatusStripe/DropdownWidget'
 export { default as KuiContext } from './components/Client/context'
 
 // Content components

--- a/plugins/plugin-client-common/web/scss/components/DropDown/Carbon.scss
+++ b/plugins/plugin-client-common/web/scss/components/DropDown/Carbon.scss
@@ -25,6 +25,14 @@ $button-hover-color: var(--color-table-border3);
 $option-hover-color: var(--color-base02);
 
 @include StatusStripeElement {
+  .bx--dropdown .bx--list-box__field {
+    padding-left: 0;
+    padding-right: 2rem;
+    max-width: 13rem;
+  }
+  .bx--list-box__menu-icon {
+    right: 0;
+  }
   .bx--dropdown__wrapper--inline {
     display: flex;
   }

--- a/plugins/plugin-client-common/web/scss/components/DropDown/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/DropDown/PatternFly.scss
@@ -14,6 +14,17 @@
  * limitations under the License.
  */
 
+@import '../StatusStripe/mixins';
+
+@include StatusStripeElement {
+  .kui--dropdown__toggle {
+    padding: 0;
+  }
+  .pf-c-dropdown__toggle-icon {
+    margin-right: 0;
+  }
+}
+
 body[kui-theme-style] {
   .pf-c-dropdown__toggle {
     /* see https://github.com/IBM/kui/issues/4649 */

--- a/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
+++ b/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
@@ -149,7 +149,7 @@ $element-padding: 1rem;
     .kui--status-stripe-element:last-child {
       border-right: $element-border;
     }
-    .kui--status-stripe-element:not(:first-child) {
+    .kui--status-stripe-element:not(:first-child):not([data-padding='none']) {
       padding-left: $element-padding;
     }
   }

--- a/plugins/plugin-kubectl/src/test/k8s3/namespace.ts
+++ b/plugins/plugin-kubectl/src/test/k8s3/namespace.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { strictEqual } from 'assert'
 import { Common, CLI, ReplExpect, SidecarExpect, Selectors } from '@kui-shell/test'
 import { waitForGreen, waitForRed, createNS, waitTillNone } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
 
@@ -109,9 +108,9 @@ describe(`kubectl namespace CRUD ${process.env.MOCHA_RUN_TARGET || ''}`, functio
             this.app.client.waitUntil(async () => {
               console.error('1', selector)
               await this.app.client.$(selector).then(_ => _.click())
-              console.error('2')
+              console.error('2', Selectors.STATUS_STRIPE_DROPDOWN_LABEL('kui--plugin-kubeui--current-namespace'))
               const actualNamespace = await this.app.client
-                .$(Selectors.STATUS_STRIPE_WIDGET_LABEL('kui--plugin-kubeui--current-namespace'))
+                .$(Selectors.STATUS_STRIPE_DROPDOWN_LABEL('kui--plugin-kubeui--current-namespace'))
                 .then(_ => _.getText())
               console.error('3', actualNamespace)
               await this.app.client.$(selector.replace(radioButton, radioButtonSelected)).then(_ => _.waitForExist())
@@ -134,21 +133,15 @@ describe(`kubectl namespace CRUD ${process.env.MOCHA_RUN_TARGET || ''}`, functio
     /** click on status stripe namespace widget */
     const listItViaStatusStripe = () => {
       it('should list namespaces by clicking on status stripe widget', async () => {
-        const res = await CLI.command('echo hi', this.app)
-        await ReplExpect.okWithPtyOutput('hi')(res)
+        try {
+          const widget = await this.app.client.$('#kui--plugin-kubeui--current-namespace button')
+          await widget.click()
 
-        await this.app.client
-          .$(Selectors.STATUS_STRIPE_WIDGET('kui--plugin-kubeui--current-namespace'))
-          .then(_ => _.click())
-
-        // await ReplExpect.okWith('default')({ app: this.app, count: res.count + 1 })
-        await this.app.client
-          .$(`${Selectors.OUTPUT_N(res.count + 1)} .kui--data-table-title`)
-          .then(_ => _.waitForExist())
-        const title = await this.app.client
-          .$(`${Selectors.OUTPUT_N(res.count + 1)} .kui--data-table-title`)
-          .then(_ => _.getText())
-        strictEqual(title, 'Namespaces')
+          const menuItem = await this.app.client.$(`.bx--list-box__menu-item[title="default"]`)
+          await menuItem.waitForDisplayed()
+        } catch (err) {
+          await Common.oops(this, true)(err)
+        }
       })
     }
 


### PR DESCRIPTION
This PR refines the Dropdown widget API a small bit.

Fixes #6351

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [ ] Multiple commits are squashed into one commit.
- [ ] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [ ] All npm dependencies are pinned.
