### PR TITLE
fix(plugins/plugin-client-common): DiffEditor does not respond to resize events

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Editor/DiffEditor.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/DiffEditor.tsx
@@ -141,10 +141,6 @@ export default class DiffEditor extends React.PureComponent<Props, State> {
           _width?: number,
           height = Math.min(0.4 * window.innerHeight, Math.max(250, editor.getModifiedEditor().getContentHeight()))
         ) => {
-          const widthA = editor.getOriginalEditor().getContentWidth()
-          const widthB = editor.getModifiedEditor().getContentWidth()
-          const width = _width || Math.min(0.9 * window.innerWidth, widthA + widthB)
-          state.wrapper.style.width = width + 'px'
           // if we know 1) the height of the content won't change, and
           // 2) we are running in "simple" mode (this is mostly the case
           // for inline editor components, as opposed to editor

--- a/plugins/plugin-client-common/web/css/static/sidecar.scss
+++ b/plugins/plugin-client-common/web/css/static/sidecar.scss
@@ -20,12 +20,6 @@
 
 $focus-color: var(--color-brand-03);
 
-@include WidthConstrained {
-  @include Sidecar {
-    flex: 1;
-  }
-}
-
 .kui--sidecar.visible.kui--nav-view {
   .kui--sidecar-content {
     width: 70%;

--- a/plugins/plugin-client-common/web/scss/components/Sidecar/Nested.scss
+++ b/plugins/plugin-client-common/web/scss/components/Sidecar/Nested.scss
@@ -25,7 +25,7 @@
 }
 
 @include NestedSidecar {
-  max-width: 100%;
+  flex: 1;
   min-height: 20em;
   height: auto;
 


### PR DESCRIPTION
Fixed by setting sidecar to always be flex:1

Fixes #6365

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
