### PR TITLE
fix: DIffEditor should render inline when in terminal split

### DIFF
--- a/packages/core/src/core/events.ts
+++ b/packages/core/src/core/events.ts
@@ -46,7 +46,7 @@ export type SnapshotRequestEvent = {
   }
 }
 
-export type TabLayoutChangeEvent = { isSidecarNowHidden: boolean }
+export type TabLayoutChangeEvent = { isSidecarNowHidden: boolean; isWidthConstrained?: boolean }
 type TabLayoutChangeHandler = (evt: TabLayoutChangeEvent) => void
 
 class EventBusBase {
@@ -96,7 +96,10 @@ class WriteEventBus extends EventBusBase {
     this.eventBus.emit('/tab/switch/split', tab)
   }
 
-  public emitTabLayoutChange(tabUUID: string, evt: TabLayoutChangeEvent = { isSidecarNowHidden: false }): void {
+  public emitTabLayoutChange(
+    tabUUID: string,
+    evt: TabLayoutChangeEvent = { isSidecarNowHidden: false, isWidthConstrained: false }
+  ): void {
     setTimeout(() => this.eventBus.emit(`/tab/layout/change/${tabUUID}`, evt))
   }
 

--- a/plugins/plugin-client-common/src/components/Content/Editor/DiffEditor.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Editor/DiffEditor.tsx
@@ -18,7 +18,7 @@ import React from 'react'
 import { extname } from 'path'
 import { editor as Monaco } from 'monaco-editor'
 
-import { eventChannelUnsafe, eventBus, MultiModalResponse } from '@kui-shell/core'
+import { eventChannelUnsafe, eventBus, MultiModalResponse, TabLayoutChangeEvent } from '@kui-shell/core'
 import { isFile } from '@kui-shell/plugin-bash-like/fs'
 
 import getKuiFontSize from './lib/fonts'
@@ -157,12 +157,24 @@ export default class DiffEditor extends React.PureComponent<Props, State> {
         observer.observe(state.wrapper)
         cleaners.push(() => observer.disconnect())
 
-        const onTabLayoutChange = () => sizeToFit()
+        const onTabLayoutChange = (evt: TabLayoutChangeEvent) => {
+          sizeToFit()
+          if (evt.isWidthConstrained) {
+            editor.updateOptions({ renderSideBySide: false })
+          } else {
+            editor.updateOptions({ renderSideBySide: props.renderSideBySide })
+          }
+        }
         eventBus.onTabLayoutChange(props.tabUUID, onTabLayoutChange)
         cleaners.push(() => eventBus.offTabLayoutChange(props.tabUUID, onTabLayoutChange))
       } else {
-        const onTabLayoutChange = () => {
+        const onTabLayoutChange = (evt: TabLayoutChangeEvent) => {
           editor.layout()
+          if (evt.isWidthConstrained) {
+            editor.updateOptions({ renderSideBySide: false })
+          } else {
+            editor.updateOptions({ renderSideBySide: props.renderSideBySide })
+          }
         }
         eventBus.onTabLayoutChange(props.tabUUID, onTabLayoutChange)
         cleaners.push(() => eventBus.offTabLayoutChange(props.tabUUID, onTabLayoutChange))


### PR DESCRIPTION
Fixes #6366

render inline when there's split
![Screen Shot 2020-12-09 at 5 34 47 PM](https://user-images.githubusercontent.com/21212160/101696908-de7f3d80-3a44-11eb-8e95-b2c45011c91a.png)

render back to original when there isn't split
![Screen Shot 2020-12-09 at 5 34 51 PM](https://user-images.githubusercontent.com/21212160/101696911-dfb06a80-3a44-11eb-8978-bf1336b216e0.png)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
