### PR TITLE
feat: Kui implementation of `watch`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,6 +91,7 @@ export { fromMap as i18nFromMap, default as i18n } from './util/i18n'
 // models
 export {
   hasDisplayName,
+  isAbortableResponse,
   isMarkdownResponse,
   ReactResponse,
   isReactResponse,

--- a/packages/core/src/main/headless-pretty-print.ts
+++ b/packages/core/src/main/headless-pretty-print.ts
@@ -23,7 +23,7 @@ import * as colors from 'colors/safe'
 
 import ElementMimic from '../util/element-mimic'
 import { isTable, Row } from '../webapp/models/table'
-import { isMixedResponse, isMessageBearingEntity, Entity } from '../models/entity'
+import { isMixedResponse, isMessageBearingEntity, isAbortableResponse, Entity } from '../models/entity'
 import { isMultiModalResponse } from '../models/mmr/is'
 import { isNavResponse } from '../models/NavResponse'
 import { isHTML, isPromise } from '../util/types'
@@ -441,6 +441,8 @@ export const print = (
         } else {
           logger(msg.message)
         }
+      } else if (isAbortableResponse(msg)) {
+        logger(msg.response)
       } else if (typeof msg === 'object') {
         prettyJSON(msg, logger)
       } else {

--- a/packages/core/src/models/TreeResponse.ts
+++ b/packages/core/src/models/TreeResponse.ts
@@ -15,8 +15,6 @@
  */
 
 import { Entity } from './entity'
-import { Button } from './mmr/types'
-import { ToolbarText } from '../webapp/views/toolbar-text'
 import { CommandCompleteEvent, CommandStartEvent } from '../repl/events'
 import ExecOptions from './execOptions'
 
@@ -106,10 +104,6 @@ export interface TreeResponse {
 
   /** data of a `TreeResponse` */
   data: TreeItem[]
-  /** update the toolbar text */
-  toolbarText?: ToolbarText
-  /** update the toolbar button */
-  toolbarButtons?: Button[]
 }
 
 export function isTreeResponse(entity: Entity): entity is TreeResponse {

--- a/packages/core/src/models/entity.ts
+++ b/packages/core/src/models/entity.ts
@@ -15,6 +15,7 @@
  */
 
 import { isHTML } from '../util/types'
+import { Abortable } from '../core/jobs/job'
 import { Table, Row, isTable } from '../webapp/models/table'
 import { ToolbarText } from '../webapp/views/toolbar-text'
 import { UsageModel } from '../core/usage-error'
@@ -233,6 +234,11 @@ export function hasSourceReferences(
   return trait && trait.kuiSourceRef !== undefined
 }
 
+type AbortableResponse<T extends ScalarResponse = ScalarResponse> = Abortable & { response: T }
+export function isAbortableResponse(entity: Entity): entity is AbortableResponse {
+  return typeof (entity as AbortableResponse).abort === 'function'
+}
+
 /**
  * A potentially more complex entity with a "spec"
  *
@@ -241,4 +247,4 @@ export type Entity<
   Content = void,
   RowType extends Row = Row,
   SomeSortOfResource extends MetadataBearing<Content> = MetadataBearing<Content>
-> = ScalarResponse | StructuredResponse<Content, SomeSortOfResource>
+> = ScalarResponse | AbortableResponse | StructuredResponse<Content, SomeSortOfResource>

--- a/packages/core/src/models/mmr/types.ts
+++ b/packages/core/src/models/mmr/types.ts
@@ -20,6 +20,7 @@ import { Tab } from '../../webapp/tab'
 import { Content } from './content-types'
 import { MetadataBearing } from '../entity'
 import { EvaluatorArgs as Arguments, ParsedOptions } from '../command'
+import { ToolbarText } from '../../webapp/views/toolbar-text'
 // import { SelectionController } from '../../webapp/bottom-stripe'
 
 /**
@@ -95,6 +96,9 @@ export interface ModeTraits {
   /** registration tie-breaker: if more than one plugin offers the
    * same mode, the one with the highest numeric priority wins */
   priority?: number
+
+  /** Optional toolbar text for a mode */
+  toolbarText?: ToolbarText
 }
 
 /**

--- a/plugins/plugin-bash-like/src/test/bash-like/watch-ls.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/watch-ls.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
+
+describe(`watch directory listing ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  const names = ['ls1foo', 'ls2foo']
+
+  it('should watch ls /tmp', () =>
+    CLI.command(`watch ls /tmp`, this.app)
+      .then(ReplExpect.ok)
+      .then(async res => {
+        const fileName = names[0]
+        await CLI.command(`touch /tmp/${fileName}`, this.app).then(ReplExpect.ok)
+
+        let iter = 0
+        await this.app.client.waitUntil(async () => {
+          const texts = await this.app.client.$(Selectors.OUTPUT_N(res.count)).then(_ => _.getText())
+
+          if (++iter > 5) {
+            console.error(`still waiting for actualText=${texts} expectedText=${fileName}`)
+          }
+          return texts.includes(fileName)
+        })
+      })
+      .catch(Common.oops(this)))
+
+  it('should watch ls -l /tmp', () =>
+    CLI.command(`watch ls /tmp`, this.app)
+      .then(ReplExpect.ok)
+      .then(async res => {
+        const fileName = names[1]
+        await CLI.command(`touch /tmp/${fileName}`, this.app).then(ReplExpect.ok)
+
+        let iter = 0
+        await this.app.client.waitUntil(async () => {
+          if (++iter > 5) {
+            console.error(`still waiting for table to have expectedText=${fileName}`)
+          }
+          return this.app.client.$(`${Selectors.LIST_RESULT_BY_N_FOR_NAME(res.count, fileName)}`).then(() => true)
+        })
+      })
+      .catch(Common.oops(this)))
+
+  names.forEach(_ => {
+    it('should remove the created file', () =>
+      CLI.command(`rm ${_}`, this.app)
+        .then(ReplExpect.ok)
+        .catch(Common.oops(this)))
+  })
+})

--- a/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
+++ b/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
@@ -61,10 +61,28 @@ export type KuiMMRProps = ToolbarProps & {
 }
 
 interface State {
+  mode: Content
   isRendered: boolean
 }
 
-export default class KuiMMRContent extends React.Component<KuiMMRProps, State> {
+export default class KuiContent extends React.Component<KuiMMRProps, State> {
+  public constructor(props: KuiMMRProps) {
+    super(props)
+
+    this.state = {
+      mode: props.mode,
+      isRendered: false
+    }
+  }
+
+  public static getDerivedStateFromProps(props: KuiMMRProps, state: State) {
+    if (state && state.isRendered && state.mode === props.mode) {
+      return state
+    } else {
+      return Object.assign(state || {}, { isRendered: false, mode: props.mode })
+    }
+  }
+
   public shouldComponentUpdate(nextProps: KuiMMRProps) {
     return nextProps.isActive && (!this.state || !this.state.isRendered)
   }
@@ -82,7 +100,8 @@ export default class KuiMMRContent extends React.Component<KuiMMRProps, State> {
       return <React.Fragment />
     }
 
-    const { tab, mode, response, willUpdateToolbar } = this.props
+    const { mode } = this.state
+    const { tab, response, willUpdateToolbar } = this.props
     if (isStringWithOptionalContentType(mode)) {
       if (mode.contentType === 'text/html') {
         return <HTMLString content={mode.content} />
@@ -150,9 +169,6 @@ export default class KuiMMRContent extends React.Component<KuiMMRProps, State> {
             tab={this.props.tab}
             data={mode.content.data}
             response={this.props.response}
-            toolbarText={mode.content.toolbarText}
-            toolbarButtons={mode.content.toolbarButtons}
-            willUpdateToolbar={willUpdateToolbar}
             execUUID={this.props.execUUID}
           />
         )

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -325,7 +325,10 @@ export default class Input extends InputProvider {
 
   private static newCountup(startTime: number, durationDom: HTMLSpanElement) {
     return setInterval(() => {
-      durationDom.innerText = prettyPrintDuration((~~(Date.now() - startTime) / 1000) * 1000)
+      const millisSinceStart = (~~(Date.now() - startTime) / 1000) * 1000
+      if (millisSinceStart > 0) {
+        durationDom.innerText = prettyPrintDuration(millisSinceStart)
+      }
     }, 1000)
   }
 

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
@@ -18,6 +18,7 @@ import React from 'react'
 
 import {
   i18n,
+  isAbortableResponse,
   isCodedError,
   isCommentaryResponse,
   isTabLayoutModificationResponse,
@@ -43,6 +44,7 @@ import {
   FinishedBlock,
   hasUUID,
   hasCommand,
+  isBeingRerun,
   isFinished,
   isProcessing,
   isOk,
@@ -72,6 +74,9 @@ type Props = {
 
   /** Block ordinal to be displayed to user */
   displayedIdx?: number
+
+  /** Are we in the middle of a re-run? */
+  isBeingRerun: boolean
 
   model: ProcessingBlock | FinishedBlock
   onRender: () => void
@@ -118,7 +123,7 @@ export default class Output extends React.PureComponent<Props, State> {
   }
 
   public static getDerivedStateFromProps(props: Props, state: State) {
-    if (isProcessing(props.model) && !state.alreadyListen) {
+    if ((isProcessing(props.model) || isBeingRerun(props.model)) && !state.alreadyListen) {
       const tabUUID = props.uuid
       eventChannelUnsafe.on(`/command/stdout/${tabUUID}/${props.model.execUUID}`, state.streamingConsumer)
       return {
@@ -239,6 +244,7 @@ export default class Output extends React.PureComponent<Props, State> {
       const { response } = block
       return (
         isOops(block) ||
+        isAbortableResponse(response) ||
         isMultiModalResponse(response) ||
         isNavResponse(response) ||
         isCommentaryResponse(response) ||

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
@@ -23,6 +23,7 @@ import Output from './Output'
 import {
   BlockModel,
   isActive,
+  isBeingRerun,
   isEmpty,
   isFinished,
   isOutputOnly,
@@ -58,6 +59,9 @@ type Props = InputOptions & {
 
   /** block model */
   model: BlockModel
+
+  /** Are we in the middle of a re-run? */
+  isBeingRerun?: boolean
 
   /** tab UUID */
   uuid: string
@@ -132,6 +136,7 @@ export default class Block extends React.PureComponent<Props, State> {
           tab={this.props.tab}
           idx={this.props.idx}
           model={this.props.model}
+          isBeingRerun={isBeingRerun(this.props.model)}
           willRemove={this.props.willRemove}
           willChangeSize={this._willChangeSize}
           onRender={this.props.onOutputRender}

--- a/plugins/plugin-client-common/src/components/spi/Tree/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Tree/impl/PatternFly.tsx
@@ -39,13 +39,6 @@ export default class KuiTreeView extends React.PureComponent<Props, State> {
     }
   }
 
-  public static getDerivedStateFromProps(props: Props, state: State) {
-    if (props.toolbarText) {
-      props.willUpdateToolbar(props.toolbarText)
-    }
-    return state
-  }
-
   private diffTag(item: TreeItem) {
     if (!item.children && item.diff !== undefined && item.diff !== DiffState.UNCHANGED && item.diffBadge) {
       const getCss = (state: DiffState) => {

--- a/plugins/plugin-client-common/src/components/spi/Tree/model.ts
+++ b/plugins/plugin-client-common/src/components/spi/Tree/model.ts
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-import { Button, MultiModalResponse, Tab, ToolbarProps, TreeResponse, ToolbarText } from '@kui-shell/core'
+import { MultiModalResponse, Tab, TreeResponse } from '@kui-shell/core'
 
 type Props = {
   response: MultiModalResponse
   tab: Tab
   data: TreeResponse['data']
-  toolbarText: ToolbarText
-  toolbarButtons: Button[]
   execUUID: string // NOTE: we could remove this once this issue is fixed: https://github.com/IBM/kui/issues/6328
-} & ToolbarProps
+}
 
 export default Props

--- a/plugins/plugin-core-support/src/lib/cmds/watch.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/watch.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KResponse, ParsedOptions, Registrar, ScalarResponse } from '@kui-shell/core'
+
+interface Options extends ParsedOptions {
+  n: number
+  interval: number
+
+  t: string
+  'no-title': string
+}
+
+export default function(registrar: Registrar) {
+  registrar.listen<KResponse, Options>(
+    '/watch',
+    async args => {
+      const cmdline = args.command.slice(args.argvNoOptions[0].length + 1)
+      const response = await args.REPL.qexec(cmdline)
+      const interval = args.parsedOptions.n || args.parsedOptions.interval || 2000
+
+      const timeout = setTimeout(async () => {
+        await args.REPL.reexec(args.command, { execUUID: args.execOptions.execUUID })
+      }, interval)
+
+      return {
+        response: response as ScalarResponse,
+        abort: () => {
+          clearTimeout(timeout)
+        }
+      }
+    },
+    {
+      flags: {
+        boolean: ['t', 'no-title']
+      }
+    }
+  )
+}

--- a/plugins/plugin-core-support/src/plugin.ts
+++ b/plugins/plugin-core-support/src/plugin.ts
@@ -21,6 +21,7 @@ import echo from './lib/cmds/echo'
 import quit from './lib/cmds/quit'
 import clear from './lib/cmds/clear'
 import dopar from './lib/cmds/dopar'
+import watch from './lib/cmds/watch'
 import base64 from './lib/cmds/base64'
 import prompt from './lib/cmds/prompt'
 import replay from './lib/cmds/replay'
@@ -42,6 +43,7 @@ export default async (commandTree: Registrar) => {
     quit(commandTree),
     clear(commandTree),
     commandTree.listen('/dopar', dopar),
+    watch(commandTree),
     base64(commandTree),
     prompt(commandTree),
     replay(commandTree),

--- a/plugins/plugin-kubectl/src/controller/kubectl/edit.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/edit.ts
@@ -254,7 +254,7 @@ export async function editable(
 
   const baseView = await getView(args, response)
 
-  const view = Object.assign(baseView, {
+  const view = Object.assign({}, baseView, {
     modes: [editMode(spec, response, yamlMode, yamlModeLabel, yamlModeOrder, 100)], // overwrite the pre-registered yaml tab
     toolbarText: formatToolbarText(args, response)
   })

--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -287,12 +287,8 @@ export async function doTreeMMR(
         namespace: `kubectl get ns ${namespace} -o yaml`
       },
       defaultMode: isDeployed ? deployedMode : dryRunMode,
-      toolbarText: {
-        type: 'info',
-        text: strings('showSource', isDeployed ? strings('live') : strings('offline'))
-      },
       modes: await Promise.all([
-        getSources(args, filepath),
+        getSources(args, filepath, isDeployed),
         isDeployed
           ? doDeployedMode(args, namespace, resourcesWithState, hasChanges)
           : doDryRunMode(args, namespace, resourcesWithState),
@@ -305,7 +301,7 @@ export async function doTreeMMR(
   }
 }
 /**
- * This is the handler of `kubectl get if`, which returns
+ * This is the handler of `kubectl get -f`, which returns
  * `MultiModalResponse` with three tabs:
  * 1. tree of templates
  * 2. tree of applied resources

--- a/plugins/plugin-kubectl/src/lib/util/tree.ts
+++ b/plugins/plugin-kubectl/src/lib/util/tree.ts
@@ -345,12 +345,16 @@ function transformBucketsToTree(buckets: Buckets): TreeResponse['data'] {
  * 3. it transforms the buckets into `TreeResponse` and returns a `MultiModalMode`
  *
  */
-export async function getSources(args: Arguments<KubeOptions>, filepath: string) {
+export async function getSources(args: Arguments<KubeOptions>, filepath: string, isDeployed?: boolean) {
   const table = await args.tab.REPL.qexec<Table>(`ls -l ${filepath}`)
   table.body.forEach(row => (row.onclickIdempotent = true))
   return {
     mode: sourceMode,
     label: strings('sources'),
+    toolbarText: {
+      type: 'info',
+      text: strings('showSource', isDeployed ? strings('live') : strings('offline'))
+    },
     content: table
   }
 }
@@ -367,14 +371,14 @@ export async function doDryRunMode(
     mode: dryRunMode,
     defaultMode: true,
     label: strings('dry run'),
+    toolbarText: {
+      type: 'info',
+      text: strings('showDryRun', 'Offline')
+    },
     content: {
       apiVersion: 'kui-shell/v1' as const,
       kind: 'TreeResponse' as const,
-      data,
-      toolbarText: {
-        type: 'info',
-        text: strings('showDryRun', 'Offline')
-      }
+      data
     }
   }
 }
@@ -397,14 +401,14 @@ export async function doDeployedMode(
   return {
     mode: deployedMode,
     label: strings('deployed resources'),
+    toolbarText: {
+      type: 'info',
+      text: strings(`showDeployedResources`, hasChanges ? strings('pending changes') : strings('no pending changes'))
+    },
     content: {
       apiVersion: 'kui-shell/v1' as const,
       kind: 'TreeResponse' as const,
-      data,
-      toolbarText: {
-        type: 'info',
-        text: strings(`showDeployedResources`, hasChanges ? strings('pending changes') : strings('no pending changes'))
-      }
+      data
     }
   }
 }

--- a/plugins/plugin-kubectl/src/test/k8s4/edit.ts
+++ b/plugins/plugin-kubectl/src/test/k8s4/edit.ts
@@ -89,29 +89,39 @@ commands.forEach(command => {
           // we'll inject some garbage that we expect to fail validation
           const garbage = 'zzzzzz'
 
+          console.error('1')
           await new Promise(resolve => setTimeout(resolve, 2000))
           await this.app.client.keys(`${where}${garbage}`) // <-- injecting garbage
           await new Promise(resolve => setTimeout(resolve, 2000))
           await this.app.client.$(Selectors.SIDECAR_MODE_BUTTON(res.count, 'Save')).then(_ => _.click())
+          console.error('2')
 
           // an error state and the garbage text had better appear in the toolbar text
           await SidecarExpect.toolbarAlert({ type: 'error', text: expectedError || garbage, exact: false })(res)
+          console.error('3')
 
           // expect line number to be highlighted, and for that line to be visible
           await this.app.client
             .$(`${Selectors.SIDECAR_TAB_CONTENT(res.count)} .kui--editor-line-highlight`)
             .then(_ => _.waitForDisplayed())
+          console.error('4')
 
           if (revert) {
             await this.app.client.$(Selectors.SIDECAR_MODE_BUTTON(res.count, 'Revert')).then(_ => _.click())
+            console.error('5')
+            let idx = 0
             await this.app.client.waitUntil(
               async () => {
                 const revertedText = await Util.getValueFromMonaco(res)
+                if (++idx > 5) {
+                  console.error(`still waiting for revertedText=${revertedText} actualText=${actualText}`)
+                }
                 return revertedText === actualText
               },
               { timeout: CLI.waitTimeout }
             )
           }
+          console.error('6')
         } catch (err) {
           await Common.oops(this, true)(err)
         }
@@ -142,12 +152,12 @@ commands.forEach(command => {
           await new Promise(resolve => setTimeout(resolve, 2000))
           await this.app.client.keys(`${Keys.End}${Keys.ENTER}${key}: ${value}${Keys.ENTER}`)
           await new Promise(resolve => setTimeout(resolve, 2000))
-          await this.app.client.$(Selectors.SIDECAR_MODE_BUTTON(res.count, 'Save')).then(_ => _.click())
+
+          const saveButton = await this.app.client.$(Selectors.SIDECAR_MODE_BUTTON(res.count, 'Save'))
+          await saveButton.click()
           // await SidecarExpect.toolbarAlert({ type: 'success', text: 'Successfully Applied', exact: false })(res)
           console.error('1')
-          await this.app.client
-            .$(Selectors.SIDECAR_MODE_BUTTON(res.count, 'Save'))
-            .then(_ => _.waitForDisplayed({ timeout: 10000, reverse: true }))
+          await saveButton.waitForExist({ timeout: 10000, reverse: true })
           console.error('2')
         } catch (err) {
           await Common.oops(this, true)(err)
@@ -192,7 +202,7 @@ commands.forEach(command => {
           // edit button should not exist
           await this.app.client
             .$(Selectors.SIDECAR_MODE_BUTTON(res.count, 'edit-button'))
-            .then(_ => _.waitForDisplayed({ timeout: 5000, reverse: true }))
+            .then(_ => _.waitForExist({ timeout: 5000, reverse: true }))
 
           // should still be showing pod {name}, but now with the yaml tab selected
           console.error('2')
@@ -204,11 +214,11 @@ commands.forEach(command => {
           console.error('4')
           await this.app.client
             .$(Selectors.SIDECAR_BACK_BUTTON(res.count))
-            .then(_ => _.waitForDisplayed({ timeout: 5000, reverse: true }))
+            .then(_ => _.waitForExist({ timeout: 5000, reverse: true }))
           console.error('5')
           await this.app.client
             .$(Selectors.SIDECAR_FORWARD_BUTTON(res.count))
-            .then(_ => _.waitForDisplayed({ timeout: 5000, reverse: true }))
+            .then(_ => _.waitForExist({ timeout: 5000, reverse: true }))
           console.error('6')
         } catch (err) {
           await Common.oops(this, true)(err)
@@ -238,7 +248,7 @@ commands.forEach(command => {
           // edit button should not exist
           await this.app.client
             .$(Selectors.SIDECAR_MODE_BUTTON(res.count, 'edit-button'))
-            .then(_ => _.waitForDisplayed({ timeout: 5000, reverse: true }))
+            .then(_ => _.waitForExist({ timeout: 5000, reverse: true }))
 
           // try editing the summary mode
           const actualText = await Util.getValueFromMonaco(res)
@@ -259,7 +269,7 @@ commands.forEach(command => {
 
           await this.app.client
             .$(Selectors.SIDECAR_MODE_BUTTON(res.count, 'Save'))
-            .then(_ => _.waitForDisplayed({ timeout: 10000, reverse: true })) // should not have apply button
+            .then(_ => _.waitForExist({ timeout: 10000, reverse: true })) // should not have apply button
         } catch (err) {
           await Common.oops(this, true)(err)
         }


### PR DESCRIPTION
Fixes #6379

This PR removes the toolbarText hacks in TreeResponse in favor of a general solution for MMR modes providing a toolbarTexte

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
