### PR TITLE
feat: Allow command registrants to specify no semicolon expansion

### DIFF
--- a/packages/core/src/models/command.ts
+++ b/packages/core/src/models/command.ts
@@ -54,6 +54,9 @@ export interface CommandOptions extends CapabilityRequirements {
   /** does this command accept no arguments of any sort (neither positional nor optional)? */
   noArgs?: boolean
 
+  /** Semicolon-expand the command line? Default: true */
+  semiExpand?: boolean
+
   // explicitly provided usage model?
   usage?: UsageModel
 

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -418,7 +418,7 @@ class InProcessExecutor implements Executor {
 
       let response: T | Promise<T> | MixedResponse
 
-      const commands = semiSplit(command)
+      const commands = evaluatorOptions.semiExpand === false ? [] : semiSplit(command)
       if (commands.length > 1) {
         response = await semicolonInvoke(commands, execOptions)
       } else {

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/TopNavSidecarV2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/TopNavSidecarV2.tsx
@@ -142,7 +142,7 @@ export default class TopNavSidecar extends BaseSidecar<MultiModalResponse, TopNa
     state?: TopNavState
   ): TopNavState {
     if (!state || state.response !== response) {
-      return Object.assign(state || {}, { response }, getStateFromMMR(tab, response))
+      return Object.assign(state || {}, { response, toolbarText: response.toolbarText }, getStateFromMMR(tab, response))
     } else {
       return state
     }

--- a/plugins/plugin-client-test/src/lib/cmds/semicolon.ts
+++ b/plugins/plugin-client-test/src/lib/cmds/semicolon.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import ssc, { Options } from '.'
-import { KResponse, Registrar } from '@kui-shell/core'
+import { Registrar } from '@kui-shell/core'
 
 export default function(registrar: Registrar) {
-  registrar.listen<KResponse, Options>('/ssc', ssc, { requiresLocal: true, semiExpand: false })
+  registrar.listen('/nosemi', ({ command }) => (/;/.test(command) ? 'yes ' + command.slice('nosemi '.length) : 'no'), {
+    semiExpand: false
+  })
 }

--- a/plugins/plugin-client-test/src/plugin.ts
+++ b/plugins/plugin-client-test/src/plugin.ts
@@ -25,20 +25,22 @@ import mmrKind from './lib/cmds/mmr-kind'
 import mmrMode from './lib/cmds/mmr-mode'
 import mmrModeViaRegistration from './lib/cmds/mmr-mode-via-registration'
 import nav from './lib/cmds/NavResponse'
+import noSemi from './lib/cmds/semicolon'
 import table from './lib/cmds/table'
 
-export default async (commandTree: Registrar) => {
+export default async (registrar: Registrar) => {
   // commands
   await Promise.all([
-    sayHello(commandTree),
-    streamHello(commandTree),
-    style(commandTree),
-    mmrName(commandTree),
-    mmrNamespace(commandTree),
-    mmrKind(commandTree),
-    mmrMode(commandTree),
-    mmrModeViaRegistration(commandTree),
-    nav(commandTree),
-    table(commandTree)
+    sayHello(registrar),
+    streamHello(registrar),
+    style(registrar),
+    mmrName(registrar),
+    mmrNamespace(registrar),
+    mmrKind(registrar),
+    mmrMode(registrar),
+    mmrModeViaRegistration(registrar),
+    nav(registrar),
+    noSemi(registrar),
+    table(registrar)
   ])
 }

--- a/plugins/plugin-client-test/src/test/api1/semicolon.ts
+++ b/plugins/plugin-client-test/src/test/api1/semicolon.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CLI, Common, ReplExpect } from '@kui-shell/test'
+
+describe(`no semicolon expansion ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  it('should correctly detect no semicolon on command line', () =>
+    CLI.command('nosemi test', this.app)
+      .then(ReplExpect.okWithString('no'))
+      .catch(Common.oops(this, true)))
+
+  it('should correctly detect semicolon on command line', () =>
+    CLI.command('nosemi test1;test2', this.app)
+      .then(ReplExpect.okWithString('yes test1;test2'))
+      .catch(Common.oops(this, true)))
+})


### PR DESCRIPTION
Fixes #6396

the registration option is `semiExpand: false`, e.g.

```typescript
import { Registrar } from '@kui-shell/core'
export default function(registrar: Registrar) {
  registrar.listen('/my/command', args => 'hi', { semiExpand: false })
}
```

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
