### PR TITLE
9.3.1

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- kui-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,5 @@
+aliases:
+  kui-maintainers:
+  	- starpit
+  	- myan9
+  	- mark-nc

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,0 +1,15 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Committee to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+starpit
+myan9
+mark-nc

--- a/packages/core/src/models/command.ts
+++ b/packages/core/src/models/command.ts
@@ -54,6 +54,9 @@ export interface CommandOptions extends CapabilityRequirements {
   /** does this command accept no arguments of any sort (neither positional nor optional)? */
   noArgs?: boolean
 
+  /** Semicolon-expand the command line? Default: true */
+  semiExpand?: boolean
+
   // explicitly provided usage model?
   usage?: UsageModel
 

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -418,7 +418,7 @@ class InProcessExecutor implements Executor {
 
       let response: T | Promise<T> | MixedResponse
 
-      const commands = semiSplit(command)
+      const commands = evaluatorOptions.semiExpand === false ? [] : semiSplit(command)
       if (commands.length > 1) {
         response = await semicolonInvoke(commands, execOptions)
       } else {

--- a/plugins/plugin-client-common/src/components/Client/StatusStripe/DropdownWidget.tsx
+++ b/plugins/plugin-client-common/src/components/Client/StatusStripe/DropdownWidget.tsx
@@ -27,7 +27,7 @@ export type Props = Pick<DropDownProps, 'position'> & {
 
 export default function DropdownWidget(props: Props) {
   return (
-    <div className="kui--status-stripe-element kui--status-stripe-element-clickable" id={props.id}>
+    <div className="kui--status-stripe-element kui--status-stripe-element-clickable" id={props.id} title={props.title}>
       <DropDown isPlain direction="up" toggle="caret" {...props} />
     </div>
   )

--- a/plugins/plugin-client-common/src/components/Views/Sidecar/TopNavSidecarV2.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Sidecar/TopNavSidecarV2.tsx
@@ -142,7 +142,7 @@ export default class TopNavSidecar extends BaseSidecar<MultiModalResponse, TopNa
     state?: TopNavState
   ): TopNavState {
     if (!state || state.response !== response) {
-      return Object.assign(state || {}, { response }, getStateFromMMR(tab, response))
+      return Object.assign(state || {}, { response, toolbarText: response.toolbarText }, getStateFromMMR(tab, response))
     } else {
       return state
     }

--- a/plugins/plugin-client-common/web/scss/components/Table/Lightweight.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/Lightweight.scss
@@ -93,7 +93,18 @@ $row-height: 1.5em;
   }
 
   @include TopTabStripe {
-    height: 3em;
+    height: 2.75em;
     --tab-shadow: inset 0 -2px 0 0;
+
+    @include TopTabStripe_Tab_Active {
+      @include TopTabStripe_Tab_Label {
+        font-weight: 500;
+      }
+    }
+  }
+  @include TopTabStripe_ProductName {
+    opacity: 0;
+    padding: 0;
+    width: 0.5em;
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/TopTabStripe/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/TopTabStripe/_mixins.scss
@@ -20,8 +20,27 @@
   }
 }
 
+@mixin TopTabStripe_ProductName {
+  .kui--header--name {
+    @content;
+  }
+}
+
 @mixin Tab {
   .kui--tab {
+    @content;
+  }
+}
+@mixin TopTabStripe_Tab_Active {
+  @include Tab {
+    &.kui--tab--active {
+      @content;
+    }
+  }
+}
+
+@mixin TopTabStripe_Tab_Label {
+  a {
     @content;
   }
 }

--- a/plugins/plugin-client-test/src/lib/cmds/semicolon.ts
+++ b/plugins/plugin-client-test/src/lib/cmds/semicolon.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import ssc, { Options } from '.'
-import { KResponse, Registrar } from '@kui-shell/core'
+import { Registrar } from '@kui-shell/core'
 
 export default function(registrar: Registrar) {
-  registrar.listen<KResponse, Options>('/ssc', ssc, { requiresLocal: true, semiExpand: false })
+  registrar.listen('/nosemi', ({ command }) => (/;/.test(command) ? 'yes ' + command.slice('nosemi '.length) : 'no'), {
+    semiExpand: false
+  })
 }

--- a/plugins/plugin-client-test/src/plugin.ts
+++ b/plugins/plugin-client-test/src/plugin.ts
@@ -25,20 +25,22 @@ import mmrKind from './lib/cmds/mmr-kind'
 import mmrMode from './lib/cmds/mmr-mode'
 import mmrModeViaRegistration from './lib/cmds/mmr-mode-via-registration'
 import nav from './lib/cmds/NavResponse'
+import noSemi from './lib/cmds/semicolon'
 import table from './lib/cmds/table'
 
-export default async (commandTree: Registrar) => {
+export default async (registrar: Registrar) => {
   // commands
   await Promise.all([
-    sayHello(commandTree),
-    streamHello(commandTree),
-    style(commandTree),
-    mmrName(commandTree),
-    mmrNamespace(commandTree),
-    mmrKind(commandTree),
-    mmrMode(commandTree),
-    mmrModeViaRegistration(commandTree),
-    nav(commandTree),
-    table(commandTree)
+    sayHello(registrar),
+    streamHello(registrar),
+    style(registrar),
+    mmrName(registrar),
+    mmrNamespace(registrar),
+    mmrKind(registrar),
+    mmrMode(registrar),
+    mmrModeViaRegistration(registrar),
+    nav(registrar),
+    noSemi(registrar),
+    table(registrar)
   ])
 }

--- a/plugins/plugin-client-test/src/test/api1/semicolon.ts
+++ b/plugins/plugin-client-test/src/test/api1/semicolon.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CLI, Common, ReplExpect } from '@kui-shell/test'
+
+describe(`no semicolon expansion ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
+  before(Common.before(this))
+  after(Common.after(this))
+
+  it('should correctly detect no semicolon on command line', () =>
+    CLI.command('nosemi test', this.app)
+      .then(ReplExpect.okWithString('no'))
+      .catch(Common.oops(this, true)))
+
+  it('should correctly detect semicolon on command line', () =>
+    CLI.command('nosemi test1;test2', this.app)
+      .then(ReplExpect.okWithString('yes test1;test2'))
+      .catch(Common.oops(this, true)))
+})

--- a/plugins/plugin-kubectl/components/src/CurrentContext.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentContext.tsx
@@ -169,7 +169,10 @@ export default class CurrentContext extends React.PureComponent<{}, State> {
   }
 
   public render() {
-    // FIXME disable the on-hover effect with the icon
+    if (this.state.allContexts.length === 0) {
+      return <React.Fragment />
+    }
+
     return (
       <DropdownWidget
         position="left"

--- a/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
@@ -147,7 +147,6 @@ export default class CurrentNamespace extends React.PureComponent<{}, State> {
   }
 
   public render() {
-    // FIXME disable the on-hover effect with the icon
     if (this.state.allNamespaces.length === 0) {
       return <React.Fragment />
     }


### PR DESCRIPTION
[9.3.1 6f1e1dbd5] fix(plugins/plugin-kubectl): kubernetes CurrentContext widget may display as empty
 Date: Fri Dec 11 13:05:50 2020 -0500
 2 files changed, 4 insertions(+), 2 deletions(-)

[9.3.1 8129aed02] feat: Allow command registrants to specify no semicolon expansion
 Date: Wed Dec 9 18:16:25 2020 -0500
 8 files changed, 100 insertions(+), 20 deletions(-)
 create mode 100644 plugins/plugin-client-test/src/lib/cmds/semicolon.ts
 create mode 100644 plugins/plugin-client-test/src/test/api1/semicolon.ts

[9.3.1 f6ffe0d46] fix(plugins/plugin-client-common): TopTabStripe for Lightweight UI themes could be a bit lighter-weight
 Date: Fri Dec 11 14:10:26 2020 -0500
 2 files changed, 31 insertions(+), 1 deletion(-)

[9.3.1 b6fe5d884] fix(plugins/plugin-client-common): DropdownWidget does not obey `title` property
 Date: Fri Dec 11 13:02:15 2020 -0500
 1 file changed, 1 insertion(+), 1 deletion(-)

[9.3.1 81ee653e5] chore: Add owners and security contacts files (#6400)
 Author: Paul Castro <17145014+paulcastro@users.noreply.github.com>
 Date: Fri Dec 11 15:19:07 2020 -0500
 3 files changed, 24 insertions(+)
 create mode 100644 OWNERS
 create mode 100644 OWNERS_ALIASES
 create mode 100644 SECURITY_CONTACTS
