### PR TITLE
feat(plugins/plugin-kubectl): Port kubectl pollers to use push, for h…

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,7 +65,7 @@ export { ExecOptions, ExecOptionsWithUUID, withLanguage } from './models/execOpt
 export { Streamable, Stream } from './models/streamable'
 
 // Errors
-export { isCodedError, is404, CodedError } from './models/errors'
+export { isCodedError, is404, is409, is404or409, CodedError } from './models/errors'
 export { isUsageError, UsageError, UsageModel, UsageRow } from './core/usage-error'
 
 // TODO remove these soon; see plugin-client-common/src/components/Scalar/index.ts

--- a/packages/core/src/models/errors.ts
+++ b/packages/core/src/models/errors.ts
@@ -34,3 +34,14 @@ export function is404<Code = number>(err: string | object | Error): err is Coded
   const error = err as CodedError<404>
   return !!(error.code === 404 || error.statusCode === 404)
 }
+
+export function is409<Code = number>(err: string | object | Error): err is CodedError<409> {
+  const error = err as CodedError<409>
+  return !!(error.code === 409 || error.statusCode === 409)
+}
+
+export function is404or409<Code = number>(err: string | object | Error): err is CodedError<404 | 409> {
+  const error = err as CodedError<404 | 409>
+  const code = error.code || error.statusCode
+  return code === 404 || code === 409
+}

--- a/packages/core/tests/lib/headless.js
+++ b/packages/core/tests/lib/headless.js
@@ -114,7 +114,7 @@ class CLI {
    */
   command(cmd, env = {}, { errOk = undefined } = {}) {
     return new Promise(resolve => {
-      const command = `${this.exe} ${cmd} --no-color`
+      const command = `${this.exe} ${cmd} ` + (/kui/.test(this.exe) ? ' --no-color' : '')
       debug('executing command', command)
 
       const ourEnv = Object.assign({}, process.env, env, {

--- a/plugins/plugin-bash-like/src/pty/server.ts
+++ b/plugins/plugin-bash-like/src/pty/server.ts
@@ -301,6 +301,7 @@ export const onConnection = (exitNow: ExitHandler, uid?: number, gid?: number) =
           debug(`kill requested. hasShell=${shell !== undefined} hasJob=${job !== undefined}`)
           if (job) {
             job.abort()
+            jobs[msg.uuid] = undefined
           }
           break
         }
@@ -322,7 +323,7 @@ export const onConnection = (exitNow: ExitHandler, uid?: number, gid?: number) =
           const execOptions = Object.assign({}, msg.execOptions, { rethrowErrors: true })
           if (msg.stream) {
             // then we will stream back the output; otherwise, we will use a request/response style of execution
-            debug('initializing streaming exec')
+            debug('initializing streaming exec', msg.uuid)
             execOptions.onInit = (job: Abortable & FlowControllable) => {
               jobs[msg.uuid] = job
               return chunk =>

--- a/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
@@ -196,7 +196,7 @@ export default class PaginatedTable<P extends Props, S extends State> extends Re
     // ... except when we're displaying asGrid by default
     if (!(!lightweightTables && !this.props.asGrid && this.state.asGrid)) {
       const nRows = this.props.response.body.length
-      if (!lightweightTables && breadcrumbs.length > 0 && (nRows > 5 || isWatchable(this.props.response))) {
+      if (!lightweightTables && breadcrumbs.length > 0 && (nRows > 1 || isWatchable(this.props.response))) {
         breadcrumbs.push({
           label: nRows === 1 ? strings('nRows1') : strings('nRows', nRows),
           className: 'kui--secondary-breadcrumb kui--nrows-breadcrumb'

--- a/plugins/plugin-client-common/web/scss/components/Table/badges.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/badges.scss
@@ -157,13 +157,20 @@ $grid-cell-size: 1.25rem;
 }
 
 [data-table-watching='true'] .bx--data-table {
-  [data-tag='badge-circle'][data-just-updated] {
+  [data-tag='badge-circle'] {
     &.yellow-background {
-      animation: var(--animation-infinite-repeating-pulse);
+      /* if it's yellow, but we're not sure if it was just updated, blink around 20 times */
+      animation: var(--animation-long-repeating-pulse);
+
+      &[data-just-updated] {
+        /* if we know the resource was just updated, blink until we get new information */
+        animation: var(--animation-infinite-repeating-pulse);
+      }
     }
 
     &.red-background {
-      animation: pulse 1000ms 6 alternate-reverse;
+      /* if it's red, then blink around 6 times */
+      animation: var(--animation-medium-repeating-pulse);
     }
   }
 }

--- a/plugins/plugin-kubectl/src/controller/client/direct/status.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/status.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Debug from 'debug'
+import { Abortable, Arguments, CodedError, FlowControllable, Table, Watcher, WatchPusher } from '@kui-shell/core'
+
+import { getTable } from './get'
+import makeWatchable from './watch'
+import { kindPart } from '../../kubectl/fqn'
+import { Explained } from '../../kubectl/explain'
+import { KubeOptions } from '../../kubectl/options'
+import URLFormatter, { urlFormatterFor } from './url'
+import { FinalState } from '../../../lib/model/states'
+import { isResourceReady } from '../../kubectl/status'
+import { getCommandFromArgs } from '../../../lib/util/util'
+
+const debug = Debug('plugin-kubectl/controller/client/direct/status')
+
+interface Group {
+  names: string[]
+  namespace: string
+  explainedKind: Explained
+}
+
+// this is still TODO; for now, we only handle the homogeneous case
+class MultiKindWatcher implements Abortable, Watcher {
+  /** The table push API */
+  private pusher: WatchPusher
+
+  /** The current stream jobs. These will be aborted/flow-controlled as directed by the associated view. */
+  private jobs: (Abortable & FlowControllable)[] = []
+
+  // eslint-disable-next-line no-useless-constructor
+  public constructor(
+    private readonly drilldownCommand: string,
+    private readonly args: Pick<Arguments<KubeOptions>, 'REPL' | 'execOptions' | 'parsedOptions'>,
+    private readonly resourceVersion: Table['resourceVersion'][],
+    private readonly formatUrl: URLFormatter[],
+    private readonly finalState: FinalState,
+    private nNotReady: number, // number of resources to wait on
+    private readonly monitorEvents = true
+  ) {}
+
+  public abort() {
+    debug('abort requested', this.jobs.length)
+    this.jobs.forEach(job => job.abort())
+  }
+
+  public init(pusher: WatchPusher) {
+    this.pusher = pusher
+  }
+}
+
+interface WithIndex<T extends string | Table> {
+  idx: number
+  table: T
+}
+
+function isString(response: WithIndex<string | Table>): response is WithIndex<string> {
+  return typeof response.table === 'string'
+}
+
+function isTable(response: WithIndex<string | Table>): response is WithIndex<Table> {
+  return !isString(response)
+}
+
+/** for apply/delete use cases, the caller may identify a FinalState and a countdown goal */
+export default async function watchMulti(args: Arguments<KubeOptions>, groups: Group[], finalState: FinalState) {
+  const myArgs = { REPL: args.REPL, execOptions: { type: args.execOptions.type }, parsedOptions: {} }
+  const drilldownCommand = getCommandFromArgs(args)
+  const nResources = groups.reduce((N, group) => N + group.names.length, 0)
+
+  const tables: WithIndex<string | Table>[] = await Promise.all(
+    groups.map(async (_, idx) => ({
+      idx,
+      table: await getTable(drilldownCommand, _.namespace, _.names, _.explainedKind, 'default', myArgs).catch(
+        (err: CodedError) => {
+          if (err.code === 404) {
+            // This means every single name in _.names is missing
+            if (finalState === FinalState.OfflineLike) {
+              // Then that's what we want! we are done!
+              return _.names
+                .map(name => `${kindPart(_.explainedKind.version, _.explainedKind.kind)} "${name}" deleted`)
+                .join('\n')
+            } else {
+              // Otherwise, we are waiting till they are online, so
+              // return an empty table. This table will subsequently
+              // be filled in by the watcher (makeWatchable, below)
+              return {
+                body: []
+              } as Table
+            }
+          }
+        }
+      )
+    }))
+  )
+
+  const { stringParts, tableParts } = tables.reduce(
+    (pair, response) => {
+      if (isString(response)) {
+        pair.stringParts.push(response)
+      } else if (isTable(response)) {
+        pair.tableParts.push(response)
+      }
+      return pair
+    },
+    { stringParts: [] as WithIndex<string>[], tableParts: [] as WithIndex<Table>[] }
+  )
+
+  if (tableParts.length > 0) {
+    if (groups.length === 1 && tableParts.length === 1) {
+      // HOMOGENEOUS CASE
+      const nNotReady = tableParts[0].table.body.reduce((N, row) => (isResourceReady(row, finalState) ? N : N + 1), 0)
+      if (nNotReady === 0) {
+        // sub-case 1: nothing to watch, as everything is already "ready"
+        debug('special case: single-group watching, all-ready all ready!', nNotReady, groups[0])
+        return tableParts[0].table
+      } else {
+        // sub-case 2: a subset may be done, but we need to fire up a
+        // watcher to monitor the rest
+        debug('special case: single-group watching with some not yet ready', nNotReady, groups[0])
+        return makeWatchable(
+          drilldownCommand,
+          myArgs,
+          groups[0].explainedKind.kind,
+          tableParts[0].table,
+          urlFormatterFor(groups[0].namespace, myArgs, groups[0].explainedKind),
+          finalState,
+          nNotReady
+        )
+      }
+    }
+
+    // HETEROGENEOUS CASE
+    // we need to assemble a unifiedTable facade
+    // NOT YET DONE. for now, we handle only the single-kind/homogeneous cases
+    const firstTableWithHeader = tableParts.find(_ => _.table.header)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const unifiedTable = {
+      header: firstTableWithHeader ? firstTableWithHeader.table.header : undefined,
+      body: [].concat(...tableParts.map(_ => _.table.body)),
+      watcher: new MultiKindWatcher(
+        drilldownCommand,
+        args,
+        tableParts.map(_ => _.table.resourceVersion),
+        await Promise.all(
+          tableParts.map(_ => {
+            const group = groups[_.idx]
+            return urlFormatterFor(group.namespace, myArgs, group.explainedKind)
+          })
+        ),
+        finalState,
+        nResources
+      )
+    }
+    throw new Error('Unsupported use case')
+  } else if (stringParts.length > 0) {
+    // all strings, which will be the messages from the apiServer, e.g. conveying the state "this resource that you asked to watch until it was deleted... well it is already deleted"
+    return stringParts.map(_ => _.table)
+  } else {
+    throw new Error('nothing to watch')
+  }
+}

--- a/plugins/plugin-kubectl/src/controller/fetch-file.ts
+++ b/plugins/plugin-kubectl/src/controller/fetch-file.ts
@@ -72,14 +72,14 @@ async function fetchKustomizeString(repl: REPL, uri: string): Promise<{ data: st
  */
 export default (registrar: Registrar) => {
   registrar.listen(
-    `/${commandPrefix}/_fetchstream`,
+    `/${commandPrefix}/_openstream`,
     async (args: Arguments<Options>) => {
-      const uri = args.argvNoOptions[args.argvNoOptions.indexOf('_fetchstream') + 1]
+      const uri = args.argvNoOptions[args.argvNoOptions.indexOf('_openstream') + 1]
       const headers =
         typeof args.execOptions.data === 'object' && !Buffer.isBuffer(args.execOptions.data)
           ? args.execOptions.data.headers
           : undefined
-      debug('fetchstream', uri)
+      debug('openstream', uri)
 
       if (!args.execOptions.onInit) {
         throw new Error('Internal Error: onInit required')

--- a/plugins/plugin-kubectl/src/controller/kubectl/create.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/create.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import Debug from 'debug'
 import { Registrar, Arguments, WithSourceReferences, Table, isTable } from '@kui-shell/core'
 
 import defaultFlags from './flags'
@@ -27,9 +28,10 @@ import { isUsage, doHelp } from '../../lib/util/help'
 import getSourceRefs from './source'
 import { doGetAsEntity, viewTransformer } from './get'
 
-const verbs = ['create' as const, 'apply' as const]
+const debug = Debug('plugin-kubectl/controller/kubectl/create')
 
-// export const doCreate = (verb: string, command = 'kubectl') => doExecWithStatus(verb, FinalState.OnlineLike, command)
+/** The create-like verbs we will handle */
+const verbs = ['create' as const, 'apply' as const]
 
 export const doCreate = (verb: 'create' | 'apply', command = 'kubectl') => async (args: Arguments<KubeOptions>) => {
   if (isUsage(args)) {
@@ -48,6 +50,8 @@ export const doCreate = (verb: 'create' | 'apply', command = 'kubectl') => async
         const response = await createDirect(args, verb)
         if (response) {
           return response
+        } else {
+          debug('createDirect falling through to CLI impl')
         }
       } catch (err) {
         if (err.code === 404) {

--- a/plugins/plugin-kubectl/src/controller/kubectl/explain.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/explain.ts
@@ -298,7 +298,7 @@ async function fetch(command: string, args: Arguments, kindAsProvidedByUser: str
     }
   } catch (err) {
     if (!/does not exist/i.test(err.message)) {
-      console.error(`error explaining kind ${kindAsProvidedByUser}`, err)
+      console.error(`error explaining kind ${kindAsProvidedByUser}`, args, err)
       throw err
     }
   }

--- a/plugins/plugin-kubectl/src/controller/kubectl/options.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/options.ts
@@ -76,8 +76,8 @@ export function getFileFromArgv(args: Arguments<KubeOptions>): string {
   }
 }
 
-export function formatOf(args: Arguments<KubeOptions>): OutputFormat {
-  return args.parsedOptions.o || args.parsedOptions.output
+export function formatOf({ parsedOptions }: Pick<Arguments<KubeOptions>, 'parsedOptions'>): OutputFormat {
+  return parsedOptions.o || parsedOptions.output
 }
 
 /** @return is request file and without format */
@@ -115,11 +115,11 @@ export function isHelpRequest(args: Arguments<KubeOptions>) {
   )
 }
 
-export function isTableRequest(args: Arguments<KubeOptions>) {
+export function isTableRequest(args: Pick<Arguments<KubeOptions>, 'parsedOptions'>) {
   return isTableFormat(formatOf(args))
 }
 
-export function isWatchRequest(args: Arguments<KubeOptions>) {
+export function isWatchRequest(args: Pick<Arguments<KubeOptions>, 'parsedOptions'>) {
   return args.parsedOptions.w || args.parsedOptions.watch || args.parsedOptions['watch-only']
 }
 
@@ -141,16 +141,16 @@ export function isTableWatchRequest(args: Arguments<KubeOptions>) {
   return isWatchRequest(args) && isTableRequest(args)
 }
 
-export function getLabel(args: Arguments<KubeOptions>) {
-  const label = args.parsedOptions.l || args.parsedOptions.label
+export function getLabel({ parsedOptions }: Pick<Arguments<KubeOptions>, 'parsedOptions'>) {
+  const label = parsedOptions.l || parsedOptions.label
   if (label) {
     return label
   } else {
     // yargs-parser doesn't handle -lname=nginx without the space
     // after -l; or least not the way we've configured it
-    for (const key in args.parsedOptions) {
+    for (const key in parsedOptions) {
       if (/^l.+/.test(key) && key !== 'limit') {
-        const value = args.parsedOptions[key]
+        const value = parsedOptions[key]
         if (value) {
           return `${key.slice(1)}=${value}`
         }
@@ -186,7 +186,7 @@ export function hasLabel(args: Arguments<KubeOptions>) {
 }
 
 /** @return the namespace as expressed in the command line, or undefined if not */
-export function getNamespaceAsExpressed(args: Arguments<KubeOptions>): string {
+export function getNamespaceAsExpressed(args: Pick<Arguments<KubeOptions>, 'parsedOptions'>): string {
   return args.parsedOptions.n || args.parsedOptions.namespace
 }
 

--- a/plugins/plugin-kubectl/src/lib/view/formatTable.ts
+++ b/plugins/plugin-kubectl/src/lib/view/formatTable.ts
@@ -33,7 +33,6 @@ import TrafficLight from '../model/traffic-light'
 import { isClusterScoped, MetaTable } from '../model/resource'
 import { getCurrentDefaultNamespace } from '../../'
 import { RawResponse } from '../../controller/kubectl/response'
-import { getCommandFromArgs } from '../util/util'
 import KubeOptions, {
   formatOf,
   isForAllNamespaces,
@@ -182,7 +181,10 @@ function cssForReadyCount(ready: string): string {
 }
 
 /** @return a namespace breadcrumb, either from the one given by args, or using the default from context */
-export async function getNamespaceBreadcrumbs(entityType: string, args: Arguments<KubeOptions>): Promise<Breadcrumb[]> {
+export async function getNamespaceBreadcrumbs(
+  entityType: string,
+  args: Pick<Arguments<KubeOptions>, 'parsedOptions' | 'execOptions' | 'REPL'>
+): Promise<Breadcrumb[]> {
   const ns = await (isClusterScoped(entityType)
     ? undefined
     : getNamespaceAsExpressed(args) ||
@@ -609,14 +611,14 @@ export function hideWithSidecar(attr: number | string, table: Table) {
 export async function toKuiTable(
   table: MetaTable,
   kind: string | Promise<string>,
-  args: Arguments<KubeOptions>
+  args: Pick<Arguments<KubeOptions>, 'parsedOptions' | 'execOptions' | 'REPL'>,
+  drilldownCommand: string
 ): Promise<Table> {
   const format = formatOf(args)
   const forAllNamespaces = isForAllNamespaces(args.parsedOptions)
   const includedColumns = table.columnDefinitions.map(_ => format === 'wide' || _.priority === 0)
   const columnDefinitions = table.columnDefinitions.filter(_ => format === 'wide' || _.priority === 0)
 
-  const drilldownCommand = getCommandFromArgs(args)
   const drilldownVerb = 'get'
   const drilldownKind = await kind
   const drilldownFormat = '-o yaml'

--- a/plugins/plugin-kubectl/src/test/k8s1/config-map.ts
+++ b/plugins/plugin-kubectl/src/test/k8s1/config-map.ts
@@ -17,7 +17,6 @@
 import { Common, CLI, ReplExpect, Selectors, SidecarExpect, Util } from '@kui-shell/test'
 import {
   waitForGreen,
-  waitForRed,
   defaultModeForGet,
   createNS,
   allocateNS,
@@ -81,7 +80,7 @@ describe(`kubectl configmap ${process.env.MOCHA_RUN_TARGET || ''}`, function(thi
             await expectContent(res, content)
           }
         } catch (err) {
-          return Common.oops(this)(err)
+          return Common.oops(this, true)(err)
         }
       })
     }
@@ -90,12 +89,8 @@ describe(`kubectl configmap ${process.env.MOCHA_RUN_TARGET || ''}`, function(thi
     const deleteIt = (name: string) => {
       it(`should delete the configmap ${name} via ${kubectl} `, () => {
         return CLI.command(`${kubectl} delete cm ${name} ${inNamespace}`, this.app)
-          .then(
-            ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME(name) })
-          )
-          .then(selector => waitForRed(this.app, selector))
           .then(() => waitTillNone('configmap', undefined, name, undefined, inNamespace))
-          .catch(Common.oops(this))
+          .catch(Common.oops(this, true))
       })
     }
 
@@ -107,7 +102,7 @@ describe(`kubectl configmap ${process.env.MOCHA_RUN_TARGET || ''}`, function(thi
             ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME(name) })
           )
           .then(selector => waitForGreen(this.app, selector))
-          .catch(Common.oops(this))
+          .catch(Common.oops(this, true))
       })
     }
 

--- a/plugins/plugin-kubectl/src/test/k8s3/secrets.ts
+++ b/plugins/plugin-kubectl/src/test/k8s3/secrets.ts
@@ -15,7 +15,13 @@
  */
 
 import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
-import { waitForRed, waitForGreen, createNS, allocateNS, deleteNS } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
+import {
+  waitTillNone,
+  waitForGreen,
+  createNS,
+  allocateNS,
+  deleteNS
+} from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
 
 const kubectl = 'kubectl'
 const name = 'foo-secret'
@@ -44,12 +50,8 @@ describe('kubectl secrets', function(this: Common.ISuite) {
 
   it('should delete a generic secret', async () => {
     try {
-      const selector = await CLI.command(`${kubectl} delete secret ${name} ${inNamespace}`, this.app).then(
-        ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME(name) })
-      )
-
-      // wait for the badge to become green
-      await waitForRed(this.app, selector)
+      await CLI.command(`${kubectl} delete secret ${name} ${inNamespace}`, this.app)
+      await waitTillNone('secret', undefined, name, undefined, inNamespace)(this.app)
     } catch (err) {
       await Common.oops(this, true)(err)
     }

--- a/plugins/plugin-kubectl/src/test/k8s4/job.ts
+++ b/plugins/plugin-kubectl/src/test/k8s4/job.ts
@@ -16,7 +16,7 @@
 
 import { dirname, join } from 'path'
 import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
-import { waitForRed, createNS, allocateNS, deleteNS } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
+import { waitTillNone, createNS, allocateNS, deleteNS } from '@kui-shell/plugin-kubectl/tests/lib/k8s/utils'
 
 const ROOT = dirname(require.resolve('@kui-shell/plugin-kubectl/tests/package.json'))
 const jobYaml = join(ROOT, 'data/k8s/job.yaml')
@@ -71,11 +71,8 @@ synonyms.forEach(kubectl => {
 
     it('should delete a job', async () => {
       try {
-        const selector: string = await CLI.command(`${kubectl} delete job ${jobName} ${inNamespace}`, this.app).then(
-          ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME(jobName) })
-        )
-
-        await waitForRed(this.app, selector)
+        await CLI.command(`${kubectl} delete job ${jobName} ${inNamespace}`, this.app)
+        await waitTillNone('job', undefined, jobName, undefined, inNamespace)(this.app)
       } catch (err) {
         return Common.oops(this, true)(err)
       }

--- a/plugins/plugin-kubectl/tests/lib/k8s/utils.js
+++ b/plugins/plugin-kubectl/tests/lib/k8s/utils.js
@@ -130,19 +130,22 @@ exports.deletePodByName = (ctx, pod, ns, command = 'kubectl', theCli = CLI) => {
  * Keep poking the given kind till no more such entities exist
  *
  */
-exports.waitTillNone = (kind, theCli = CLI, name = '', okToSurvive, inNamespace = '') => app =>
+exports.waitTillNone = (kind, theCli = makeCLI('kubectl'), name = '', okToSurvive, inNamespace = '') => app =>
   new Promise(resolve => {
     // fetch the entities
-    const fetch = () =>
-      theCli.command(`kubectl get "${kind}" ${name} ${inNamespace}`, app, {
-        errOk: theCli.exitCode(404)
+    const fetch = async () => {
+      const response = await theCli.command(`get "${kind}" ${name} ${inNamespace}`, app, {
+        errOk: 1
       })
+      return response
+    }
+
     // verify the entities
     const verify = okToSurvive
       ? theCli === ReplExpect
         ? theCli.expectOKWith(okToSurvive)
         : theCli.expectOK(okToSurvive)
-      : theCli.expectError(theCli.exitCode(404))
+      : theCli.expectError(1, 'not found')
 
     const iter = () => {
       return fetch()

--- a/plugins/plugin-proxy-support/src/lib/proxy-executor.ts
+++ b/plugins/plugin-proxy-support/src/lib/proxy-executor.ts
@@ -139,15 +139,15 @@ class ProxyEvaluator implements ReplEval {
             ? await execOptions.onInit({
                 write: (data: string) => channel.send(JSON.stringify({ type: 'data', data, uuid })),
                 xon: () => {
-                  debug('xon requested')
+                  debug('xon requested on streaming proxy exec')
                   channel.send(JSON.stringify({ type: 'xon', uuid }))
                 },
                 xoff: () => {
-                  debug('xoff requested')
+                  debug('xoff requested on streaming proxy exec')
                   channel.send(JSON.stringify({ type: 'xoff', uuid }))
                 },
                 abort: () => {
-                  debug('abort requested')
+                  debug('abort requested on streaming proxy exec')
                   channel.send(JSON.stringify({ type: 'kill', uuid }))
                 }
               })
@@ -191,6 +191,11 @@ class ProxyEvaluator implements ReplEval {
 
                       channel.removeEventListener('message', onMessage)
                       const code = response.response.code || response.response.statusCode
+
+                      if (execOptions.onExit) {
+                        execOptions.onExit(code)
+                      }
+
                       if (code !== undefined && code !== 200) {
                         if (isUsageError(response.response)) {
                           // e.g. k get -h


### PR DESCRIPTION
…omogeneous deletes

This touches more files than you'd expect, but most of the changes are to refine the liberal use of Arguments<KubeOptions> to a minimal typing

Fixes #6481

Also fixes an underlying bug in the way proxied direct/watch are terminated when inBrowser.
Fixes #6486

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
