### PR TITLE
9.3.7

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Editor/lib/defaults.ts
+++ b/plugins/plugin-client-common/src/components/Content/Editor/lib/defaults.ts
@@ -34,6 +34,7 @@ export default (options: Options): editor.IEditorConstructionOptions => ({
   contextmenu: false,
   scrollBeyondLastLine: false,
   scrollBeyondLastColumn: 2,
+  scrollbar: { alwaysConsumeMouseWheel: false },
   cursorStyle: 'block',
   fontFamily: 'var(--font-monospace)',
   fontSize: options.fontSize || getKuiFontSize(),


### PR DESCRIPTION
[9.3.7 da2a54725] fix(plugins/plugin-client-common): monaco editor always consumes mouse wheel scrolling events
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Tue Jan 5 10:23:36 2021 -0500
 1 file changed, 1 insertion(+)