### PR TITLE
chore: add --skipLibCheck to our typescript compiler options

### DIFF
--- a/packages/builder/tsconfig-base.json
+++ b/packages/builder/tsconfig-base.json
@@ -9,6 +9,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "target": "ES2016",
+    "skipLibCheck": true,
     "sourceMap": true,
     "declaration": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
On my laptop, this reduces a full `npm run compile` from over 120 seconds, down to around 45 seconds. From what I understand in the article referenced by the associated issue, this will only affect us in a very few places: we have I think 2 or 3 test utility files that are written in javascript, with a side `.d.ts` typing file. With skipLibcheck, typescript will not check those typings files. These only affect a small slice of test code. There will be no direct impact to user-facing code quality.

Fixes #6491

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
