### PR TITLE
feat: Expand kubectl direct watching to support heterogeneous use cases

### DIFF
--- a/packages/test/src/api/table.ts
+++ b/packages/test/src/api/table.ts
@@ -208,7 +208,7 @@ export class TestTable {
             selector: Selectors.TABLE_HEADER_CELL(expectTable.header.name)
           })
         )
-        .catch(Common.oops(ctx)))
+        .catch(Common.oops(ctx, true)))
 
     if (validation) {
       if (validation.cells) {
@@ -251,7 +251,8 @@ export class TestTable {
           const cell = await ctx.app.client.$(
             `${Selectors.OUTPUT_N(self.cmdIdx)} ${Selectors.TABLE_CELL(row.name, expectTable.header.name)}`
           )
-          await cell.waitForExist()
+          await cell.waitForExist({ timeout: 10000 })
+          await cell.scrollIntoView()
           await cell.click()
         } catch (err) {
           await Common.oops(ctx, true)(err)

--- a/plugins/plugin-bash-like/fs/src/lib/glob.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/glob.ts
@@ -94,7 +94,7 @@ async function isDir(filepath: string): Promise<Stats> {
   return new Promise((resolve, reject) => {
     stat(filepath, (err, stats) => {
       if (err) {
-        if (err.code === 'ENOENT') {
+        if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
           resolve(undefined)
         } else {
           reject(err)
@@ -168,14 +168,16 @@ export async function kuiglob({
   const globbedEntries =
     toGlob.length === 0 && inputs.length > 0
       ? []
-      : ((await globby(toGlob.length === 0 ? '*' : toGlob, {
-          followSymbolicLinks: false,
+      : (((await globby(toGlob.length === 0 ? ['*'] : toGlob, {
           onlyFiles: false,
+          suppressErrors: true,
+          expandDirectories: false, // see https://github.com/sindresorhus/globby/issues/166
+          followSymbolicLinks: false,
           dot: parsedOptions.a || parsedOptions.all,
           stats: needStats,
           objectMode: !needStats,
           cwd: isHeadless() ? process.cwd() : tab.state.cwd
-        })) as RawGlobStats[])
+        })) as any) as RawGlobStats[])
   //  ^^^^^^ re: type conversion; globby type declaration issue #139
 
   // handle -d; fast-glob doesn't seem to handle this very well on its

--- a/plugins/plugin-client-common/web/scss/components/Table/badges.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/badges.scss
@@ -169,8 +169,8 @@ $grid-cell-size: 1.25rem;
     }
 
     &.red-background {
-      /* if it's red, then blink around 6 times */
-      animation: var(--animation-medium-repeating-pulse);
+      /* if it's red, then blink around 3 times */
+      animation: var(--animation-short-repeating-pulse);
     }
   }
 }

--- a/plugins/plugin-ibmcloud/plugin/src/controller/available.ts
+++ b/plugins/plugin-ibmcloud/plugin/src/controller/available.ts
@@ -30,7 +30,7 @@ export default async function getAvailablePlugins(
   tab: Tab,
   url = defaultURL
 ): Promise<{ plugins: AvailablePluginRaw[] }> {
-  return JSON.parse((await fetchFileString(tab.REPL, `${url}/plugins`))[0])
+  return JSON.parse((await fetchFileString(tab.REPL, `${url}/plugins`))[0] || '{ "plugins": [] }')
 }
 
 /**

--- a/plugins/plugin-kubectl-flow-views/tekton/src/lib/read.ts
+++ b/plugins/plugin-kubectl-flow-views/tekton/src/lib/read.ts
@@ -38,7 +38,7 @@ export const parse = async (raw: string | PromiseLike<string>): Promise<KubeReso
  */
 export const read = async (tab: Tab, filepath: string): Promise<string> => {
   const data = await fetchFileString(tab.REPL, filepath)
-  if (data.length === 1) {
+  if (data.length === 1 && data[0]) {
     return data[0]
   } else {
     throw new Error(`Failed to fetch ${filepath}`)

--- a/plugins/plugin-kubectl/src/controller/client/direct/404.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/404.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Row, Table } from '@kui-shell/core'
+
+import { rowWith, standardStatusHeader } from './unify'
+import TrafficLight from '../../../lib/model/traffic-light'
+
+/**
+ * @return a Row for the given name in `names` with an Offline status.
+ *
+ */
+function fabricate404Row(name: string, kind: string): Row {
+  return rowWith(name, kind, 'Offline', TrafficLight.Red)
+}
+
+/**
+ * @return a Table with one row per given name in `names`, each row
+ * with an Offline status.
+ *
+ */
+export default function fabricate404Table(names: string[], kind: string): Table {
+  return {
+    header: standardStatusHeader,
+    body: names.map(name => fabricate404Row(name, kind))
+  }
+}

--- a/plugins/plugin-kubectl/src/controller/client/direct/create.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/create.ts
@@ -98,7 +98,9 @@ export default async function createDirect(
         ]
 
         const watchPart = await status(args, groups, FinalState.OnlineLike)
-        return withErrors(watchPart, errors)
+        if (watchPart) {
+          return withErrors(watchPart, errors)
+        }
       }
     }
   }

--- a/plugins/plugin-kubectl/src/controller/client/direct/unify.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/unify.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Table, Row } from '@kui-shell/core'
+import TrafficLight, { toTrafficLight } from '../../../lib/model/traffic-light'
+
+/** Do not i18n! */
+export const Kind = 'Kind'
+export const Status = 'Status'
+
+export const standardStatusHeader: Table['header'] = {
+  name: 'Name',
+  attributes: [
+    {
+      key: Kind,
+      value: Kind
+    },
+    {
+      key: Status,
+      value: Status
+    }
+  ]
+}
+
+export function rowWith(
+  name: string,
+  kind: string,
+  status: string,
+  trafficLight: TrafficLight,
+  originalRow?: Row
+): Row {
+  const overlay: Row = {
+    name,
+    attributes: [
+      {
+        key: Kind,
+        value: kind
+      },
+      {
+        key: Status,
+        value: status,
+        tag: 'badge',
+        css: trafficLight
+      }
+    ]
+  }
+
+  if (originalRow) {
+    return Object.assign({}, originalRow, overlay)
+  } else {
+    return overlay
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function unifyHeaders(headers: Table['header'][]): Table['header'] {
+  return standardStatusHeader
+}
+
+export function unifyRow(row: Row, kind: string): Row {
+  const name = row.name
+
+  const badgeColumnIdx = row.attributes.findIndex(_ => _.tag === 'badge')
+  const status = badgeColumnIdx >= 0 ? row.attributes[badgeColumnIdx].value : 'Unknown'
+  const trafficLight = badgeColumnIdx >= 0 ? toTrafficLight(row.attributes[badgeColumnIdx].css) : TrafficLight.Gray
+
+  return rowWith(name, kind, status, trafficLight, row)
+}
+
+export function unifyRows(rows: Table['body'], kinds: string | string[]): Table['body'] {
+  return rows.map((row, idx) => {
+    const kind = Array.isArray(kinds) ? kinds[idx] : kinds
+    return unifyRow(row, kind)
+  })
+}
+
+export function unifyTable(table: Table, kind: string): Table {
+  const overlay: Table = {
+    header: unifyHeaders([table.header]),
+    body: unifyRows(table.body, kind)
+  }
+  return Object.assign({}, table, overlay)
+}

--- a/plugins/plugin-kubectl/src/controller/fetch-file.ts
+++ b/plugins/plugin-kubectl/src/controller/fetch-file.ts
@@ -56,11 +56,11 @@ async function fetchKustomizeString(repl: REPL, uri: string): Promise<{ data: st
     const [isFile1, isFile2, isFile3] = await Promise.all([isFile(k1), isFile(k2), isFile(k3)])
     const dir = uri // if we are here, then `uri` is a directory
     if (isFile1) {
-      return { data: (await fetchFileString(repl, k1))[0], dir }
+      return { data: (await fetchFileString(repl, k1))[0] || '', dir }
     } else if (isFile2) {
-      return { data: (await fetchFileString(repl, k2))[0], dir }
+      return { data: (await fetchFileString(repl, k2))[0] || '', dir }
     } else if (isFile3) {
-      return { data: (await fetchFileString(repl, k3))[0], dir }
+      return { data: (await fetchFileString(repl, k3))[0] || '', dir }
     }
   }
 }

--- a/plugins/plugin-kubectl/src/controller/kubectl/source.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/source.ts
@@ -31,9 +31,11 @@ export default async function withSourceRefs(
 
   if (filepath && isTableRequest(args)) {
     try {
-      const data = (await fetchFile(args.REPL, filepath))[0]
-      return {
-        templates: [{ filepath, data, isFor, kind: 'source', contentType: 'yaml' }]
+      const data = (await fetchFile(args.REPL, filepath)).filter(_ => _)[0]
+      if (data) {
+        return {
+          templates: [{ filepath, data, isFor, kind: 'source', contentType: 'yaml' }]
+        }
       }
     } catch (err) {
       console.error('Error fetching source ref', err)

--- a/plugins/plugin-kubectl/src/lib/model/traffic-light.ts
+++ b/plugins/plugin-kubectl/src/lib/model/traffic-light.ts
@@ -26,4 +26,18 @@ enum TrafficLight {
   Green = 'green-background'
 }
 
+export function toTrafficLight(str: string): TrafficLight {
+  if (str.indexOf(TrafficLight.Red) >= 0) {
+    return TrafficLight.Red
+  } else if (str.indexOf(TrafficLight.Yellow) >= 0) {
+    return TrafficLight.Yellow
+  } else if (str.indexOf(TrafficLight.Blue) >= 0) {
+    return TrafficLight.Blue
+  } else if (str.indexOf(TrafficLight.Green) >= 0) {
+    return TrafficLight.Green
+  } else {
+    return TrafficLight.Gray
+  }
+}
+
 export default TrafficLight

--- a/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
+++ b/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
@@ -234,11 +234,15 @@ export async function fetchFile(
 }
 
 /** same as fetchFile, but returning a string rather than a Buffer */
-export async function fetchFileString(repl: REPL, url: string, headers?: Record<string, string>): Promise<string[]> {
+export async function fetchFileString(
+  repl: REPL,
+  url: string,
+  headers?: Record<string, string>
+): Promise<(void | string)[]> {
   const files = await fetchFile(repl, url, { headers })
   return files.map(_ => {
     try {
-      return _.toString()
+      return _ ? _.toString() : undefined
     } catch (err) {
       console.error('Unable to convert fetched file to string', err, _)
       return ''

--- a/plugins/plugin-kubectl/src/test/k8s3/source-ref.ts
+++ b/plugins/plugin-kubectl/src/test/k8s3/source-ref.ts
@@ -20,10 +20,14 @@ import { createNS, allocateNS, deleteNS } from '@kui-shell/plugin-kubectl/tests/
 import { dirname } from 'path'
 const ROOT = dirname(require.resolve('@kui-shell/plugin-kubectl/tests/package.json'))
 
+const timeout = 8000
+
 /** confirm the given toggler state */
 async function confirmState(this: Common.ISuite, res: ReplExpect.AppAndCount, isExpanded: boolean) {
   // confirm the toggler UI
-  await this.app.client.$(Selectors.SOURCE_REF_TOGGLE_N(res.count, isExpanded)).then(_ => _.waitForDisplayed())
+  console.error('C1')
+  await this.app.client.$(Selectors.SOURCE_REF_TOGGLE_N(res.count, isExpanded)).then(_ => _.waitForExist({ timeout }))
+  console.error('C2')
 
   if (isExpanded) {
     // if it is expanded, also confirm the expanded editor state
@@ -39,7 +43,13 @@ async function confirmState(this: Common.ISuite, res: ReplExpect.AppAndCount, is
 
 /** click to toggle state */
 async function clickToToggle(this: Common.ISuite, res: ReplExpect.AppAndCount, isExpanded: boolean) {
-  await this.app.client.$(Selectors.SOURCE_REF_TOGGLE_N(res.count, isExpanded)).then(_ => _.click())
+  console.error('T1')
+  const toggler = await this.app.client.$(Selectors.SOURCE_REF_TOGGLE_N(res.count, isExpanded))
+  console.error('T2')
+  await toggler.waitForExist({ timeout })
+  console.error('T2')
+  await toggler.click()
+  console.error('T3')
   return !isExpanded
 }
 


### PR DESCRIPTION
This PR updates the duration over which red badges flash from 6 cycles down to 3.

This PR also works around an issue in globby. https://github.com/sindresorhus/globby/issues/166

Fixes #6504

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
