### PR TITLE
fix(packages/builder): electron builder uses the top-level package.json version instead of client version when building electron dists

### DIFF
--- a/packages/builder/dist/electron/build.sh
+++ b/packages/builder/dist/electron/build.sh
@@ -48,7 +48,7 @@ export IGNORE='(~$)|(\.ts$)|(lerna\.json)|(@types)|(tsconfig\.json)|(webpack\.co
 # client version; note rcedit.exe fails if the VERSION is "dev"
 #
 set +e
-export VERSION=$(cat "$CLIENT_HOME"/package.json | jq --raw-output .version)
+export VERSION=$(cat "$CLIENT_HOME"/node_modules/@kui-shell/client/package.json | jq --raw-output .version)
 if [ $? != 0 ]; then VERSION=0.0.1; fi
 set -e
 echo "Using VERSION=$VERSION"


### PR DESCRIPTION
Fixes #6488

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
