### PR TITLE
9.3.8

### DIFF
--- a/packages/builder/dist/electron/build.sh
+++ b/packages/builder/dist/electron/build.sh
@@ -48,7 +48,7 @@ export IGNORE='(~$)|(\.ts$)|(lerna\.json)|(@types)|(tsconfig\.json)|(webpack\.co
 # client version; note rcedit.exe fails if the VERSION is "dev"
 #
 set +e
-export VERSION=$(cat "$CLIENT_HOME"/package.json | jq --raw-output .version)
+export VERSION=$(cat "$CLIENT_HOME"/node_modules/@kui-shell/client/package.json | jq --raw-output .version)
 if [ $? != 0 ]; then VERSION=0.0.1; fi
 set -e
 echo "Using VERSION=$VERSION"

--- a/plugins/plugin-client-common/web/scss/components/DropDown/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/DropDown/PatternFly.scss
@@ -23,6 +23,7 @@
   .pf-c-dropdown__toggle.pf-m-plain,
   .pf-c-dropdown__toggle-text {
     color: var(--color-text-01);
+    display: flex;
   }
   .pf-c-dropdown__menu {
     background-color: var(--color-base05);


### PR DESCRIPTION
[9.3.8 cbc59bb21] fix(packages/builder): electron builder uses the top-level package.json version instead of client version when building electron dists
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Fri Jan 8 12:09:23 2021 -0500
 1 file changed, 1 insertion(+), 1 deletion(-)

[9.3.8 0aacf4536] fix(plugins/plugin-client-common): in patternfly-based components, the CurrentContext widget has poor alignment
 Date: Wed Jan 6 11:59:17 2021 -0500
 1 file changed, 1 insertion(+)