### PR TITLE
fix(plugins/plugin-kubectl): use PaginatedTable instead of RadioTable for `contexts` and `get namespaces` commands

### DIFF
--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -253,6 +253,7 @@ export const TABLE_TITLE = (N: number) => `${OUTPUT_N(N)} ${_TABLE_TITLE}`
 export const TABLE_TITLE_SECONDARY = (N: number) => `${OUTPUT_N(N)} .kui--secondary-breadcrumb:first-child`
 export const TABLE_TITLE_NROWS = (N: number) => `${OUTPUT_N(N)} .kui--nrows-breadcrumb`
 export const BY_NAME = (name: string) => `tbody [data-name="${name}"]`
+export const BY_KEY = (key: string) => `tbody [data-key="${key}"]`
 export const GRID_CELL_BY_NAME = (name: string) => `.grid-layout > div[data-name="${name}"]`
 export const LIST_RESULT_FIRST = 'tbody tr:first-child .clickable'
 export const LIST_RESULT_BY_N_AND_NAME = (N: number, name: string, splitIndex = 1) =>

--- a/plugins/plugin-kubectl/oc/src/controller/oc/get/projects.ts
+++ b/plugins/plugin-kubectl/oc/src/controller/oc/get/projects.ts
@@ -14,26 +14,17 @@
  * limitations under the License.
  */
 
-import { Arguments, Registrar } from '@kui-shell/core'
+import { Registrar } from '@kui-shell/core'
 import {
   defaultFlags,
-  KubeOptions,
   commandPrefix,
   doGet,
   doExecWithStdout,
-  getNamespacesTransformer,
   emitKubectlConfigChangeEvent
 } from '@kui-shell/plugin-kubectl'
 
-/** Actuate a project switch by using `oc project set` */
-function doSwitchViaOc(ns: string, args: Arguments<KubeOptions>) {
-  return `oc project ${args.REPL.encodeComponent(ns)}`
-}
-
 // we use the fetcher from 'kubectl get', and the viewTransformer from 'kubectl get namespaces'
 export default function registerOcProjectGet(registrar: Registrar) {
-  const viewTransformer = getNamespacesTransformer.bind(undefined, doSwitchViaOc)
-
   registrar.listen(`/${commandPrefix}/oc/project`, async args => {
     const response = await doExecWithStdout(args, undefined, 'oc')
     emitKubectlConfigChangeEvent(args)
@@ -43,15 +34,11 @@ export default function registerOcProjectGet(registrar: Registrar) {
   registrar.listen(
     `/${commandPrefix}/oc/projects`,
     args => args.REPL.qexec('oc get projects', undefined, undefined, args.execOptions),
-    Object.assign({}, defaultFlags, { viewTransformer })
+    defaultFlags
   )
 
   const aliases = ['project', 'projects', 'ns', 'namespace', 'namespaces']
   aliases.forEach(ns => {
-    registrar.listen(
-      `/${commandPrefix}/oc/get/${ns}`,
-      doGet('oc'),
-      Object.assign({}, defaultFlags, { viewTransformer })
-    )
+    registrar.listen(`/${commandPrefix}/oc/get/${ns}`, doGet('oc'), defaultFlags)
   })
 }

--- a/plugins/plugin-kubectl/src/index.ts
+++ b/plugins/plugin-kubectl/src/index.ts
@@ -123,7 +123,6 @@ export { register as registerConfig } from './controller/kubectl/config'
 export { registerApplySubcommands } from './controller/kubectl/apply-subcommands'
 
 export { viewTransformer as getTransformer, doGetAsMMR as getAsMMRTransformer } from './controller/kubectl/get'
-export { viewTransformer as getNamespacesTransformer } from './controller/kubectl/get-namespaces'
 
 /** A channel that covers *possible* changes to kubectl config */
 export {

--- a/plugins/plugin-kubectl/src/test/k8s/namespace.ts
+++ b/plugins/plugin-kubectl/src/test/k8s/namespace.ts
@@ -96,29 +96,21 @@ describe(`kubectl namespace CRUD ${process.env.MOCHA_RUN_TARGET || ''}`, functio
           .catch(Common.oops(this, true))
       })
 
-      it(`should initiate namespace switch via click`, () => {
-        const radioButton = Selectors.RADIO_BUTTON
-        const radioButtonSelected = Selectors.RADIO_BUTTON_SELECTED
+      it('should initiate namespace switch via click', async () => {
+        try {
+          await CLI.command(`kubectl config set-context --current --namespace=${ns1}`, this.app).then(ReplExpect.ok)
 
-        return CLI.command(`${kubectl} get ns ${ns1}`, this.app)
-          .then(
-            ReplExpect.okWithCustom<string>({ selector: radioButton })
-          )
-          .then(selector =>
-            this.app.client.waitUntil(async () => {
-              console.error('1', selector)
-              await this.app.client.$(selector).then(_ => _.click())
-              console.error('2', Selectors.STATUS_STRIPE_DROPDOWN_LABEL('kui--plugin-kubeui--current-namespace'))
-              const actualNamespace = await this.app.client
-                .$(Selectors.STATUS_STRIPE_DROPDOWN_LABEL('kui--plugin-kubeui--current-namespace'))
-                .then(_ => _.getText())
-              console.error('3', actualNamespace)
-              await this.app.client.$(selector.replace(radioButton, radioButtonSelected)).then(_ => _.waitForExist())
-              console.error('4')
-              return actualNamespace === ns1
-            })
-          )
-          .catch(Common.oops(this, true))
+          this.app.client.waitUntil(async () => {
+            console.error('1', Selectors.STATUS_STRIPE_DROPDOWN_LABEL('kui--plugin-kubeui--current-namespace'))
+            const actualNamespace = await this.app.client
+              .$(Selectors.STATUS_STRIPE_DROPDOWN_LABEL('kui--plugin-kubeui--current-namespace'))
+              .then(_ => _.getText())
+            console.error('2', actualNamespace)
+            return actualNamespace === ns1
+          })
+        } catch (err) {
+          await Common.oops(this, true)(err)
+        }
       })
 
       it(`should show ${ns1} as current namespace`, () => {


### PR DESCRIPTION
BREAKING CHANGE: the `contexts` and `kubectl get ns` commands will no longer return radio tables after this PR. Instead, users are encouraged to use the selection UI in the bottom status stripe:
<img width="285" alt="Screen Shot 2021-01-06 at 10 53 36 AM" src="https://user-images.githubusercontent.com/4741620/104074583-7c9a2b00-51de-11eb-9d35-aaf86b6c6ca9.png">


# Screenshots of new contexts and kubectl get ns behavior

![Screen Shot 2021-01-08 at 5 28 38 PM](https://user-images.githubusercontent.com/21212160/104071332-f4645780-51d6-11eb-914a-5526904474f7.png)
Fixes #6517

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
