### PR TITLE
fix: kubectl get -f --watch doesn't watch

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
@@ -93,7 +93,7 @@ export default class LivePaginatedTable extends PaginatedTable<LiveProps, LiveSt
   private offline(rowKey: string) {
     const existingRows = this.state.rows
 
-    const foundIndex = existingRows.findIndex(_ => _.NAME === rowKey)
+    const foundIndex = existingRows.findIndex(_ => (_.rowKey ? _.rowKey === rowKey : _.NAME === rowKey))
     if (foundIndex === -1) {
       console.error('table row went offline, but not found in view model', rowKey, existingRows)
     } else {
@@ -142,11 +142,11 @@ export default class LivePaginatedTable extends PaginatedTable<LiveProps, LiveSt
     const existingRows = this._deferredUpdate || this.state.rows
     const nRowsBefore = existingRows.length
 
-    const foundIndex = existingRows.findIndex(
-      _ => (_.rowKey && _.rowKey === newKuiRow.rowKey) || _.NAME === newKuiRow.name
-      // the _.rowKey existence check here is important
-      // because we didn't ask rowKey to be a required field
-      // if both of the rowKey are undefined, we will get a wrong foundIndex
+    // the _.rowKey existence check here is important
+    // because we didn't ask rowKey to be a required field
+    // if both of the rowKey are undefined, we will get a wrong foundIndex
+    const foundIndex = existingRows.findIndex(_ =>
+      _.rowKey && newKuiRow.rowKey ? _.rowKey === newKuiRow.rowKey : _.NAME === newKuiRow.name
     )
 
     const insertionIndex = foundIndex === -1 ? nRowsBefore : foundIndex

--- a/plugins/plugin-kubectl/src/controller/client/direct/get.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/get.ts
@@ -134,7 +134,7 @@ export async function get(
 
   /** 1. file request with table output, e.g. `kubectl get -f` and `kubectl get -k` */
   if (isFileRequest && !isEntityAndNameFormat) {
-    return doStatus(args, 'get', drilldownCommand, undefined, undefined, undefined, false)
+    return doStatus(args, 'get', drilldownCommand, undefined, undefined, undefined, isWatchRequest(args))
   }
 
   /** 2. table request, e.g. `kubectl get pods` and `kubectl get pod nginx` */

--- a/plugins/plugin-kubectl/src/controller/client/direct/status.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/status.ts
@@ -35,8 +35,10 @@ import { getCommandFromArgs } from '../../../lib/util/util'
 
 const debug = Debug('plugin-kubectl/controller/client/direct/status')
 
-function countNotReady(table: Table, finalState: FinalState) {
-  return table.body.reduce((N, row) => (isResourceReady(row, finalState) ? N : N + 1), 0)
+function countNotReady(table: Table, finalState?: FinalState) {
+  return finalState
+    ? table.body.reduce((N, row) => (isResourceReady(row, finalState) ? N : N + 1), 0)
+    : table.body.length
 }
 
 // this is still TODO; for now, we only handle the homogeneous case
@@ -156,7 +158,7 @@ interface WithIndex<T extends string | Table> {
 export default async function watchMulti(
   args: Arguments<KubeOptions>,
   groups: Group[],
-  finalState: FinalState,
+  finalState?: FinalState,
   drilldownCommand = getCommandFromArgs(args),
   file?: string,
   isWatchRequest = true

--- a/plugins/plugin-kubectl/src/controller/kubectl/options.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/options.ts
@@ -115,7 +115,7 @@ export function isTableRequest(args: Pick<Arguments<KubeOptions>, 'parsedOptions
 }
 
 export function isWatchRequest(args: Pick<Arguments<KubeOptions>, 'parsedOptions'>) {
-  return args.parsedOptions.w || args.parsedOptions.watch || args.parsedOptions['watch-only']
+  return !!(args.parsedOptions.w || args.parsedOptions.watch || args.parsedOptions['watch-only'])
 }
 
 export function watchRequestFrom(args: Arguments<KubeOptions>, forceWatch = false) {

--- a/plugins/plugin-kubectl/src/lib/model/resource.ts
+++ b/plugins/plugin-kubectl/src/lib/model/resource.ts
@@ -96,6 +96,7 @@ export function sameResourceVersion(a: MultiModalResponse<KubeResource>, b: Mult
 export type KubeMetadata = Partial<WithOwnerReferences> &
   Partial<WithResourceVersion> & {
     name: string
+    uid?: string
     namespace?: string
     labels?: { [key: string]: string }
     annotations?: object

--- a/plugins/plugin-kubectl/src/lib/view/formatTable.ts
+++ b/plugins/plugin-kubectl/src/lib/view/formatTable.ts
@@ -680,29 +680,15 @@ export async function toKuiTable(
 
   const nameColumnIdx = /Name/i.test(header.name) ? 0 : header.attributes.findIndex(_ => /Name/i.test(_.key)) + 1
 
-  const body = table.rows.map((row, idx) => {
+  const body = table.rows.map(row => {
     const cells = row.cells.filter((cell, idx) => includedColumns[idx])
     const name = cells[nameColumnIdx].toString()
-
-    /**
-     * rowKey is the unique string that distinguishes each row
-     * option 1. name
-     * option 2. `first column`-`name`, e.g. --all-namespaces
-     * option 3. `first column`-`idx` when there's no name column, e.g. k get events
-     *
-     */
-    const rowKey = name
-      ? forAllNamespaces
-        ? `${forAllNamespaces ? row.object.metadata.namespace : cells[0]}-${name}`
-        : name
-      : `${cells[0]}-${idx}`
-
     const onclick = onclickFor(row, name)
 
     return {
       object: row.object,
       key: forAllNamespaces ? row.object.metadata.namespace : columnDefinitions[0].name,
-      rowKey,
+      rowKey: `${name}_${drilldownKind}_${row.object.metadata.namespace}`,
       name: forAllNamespaces ? row.object.metadata.namespace : name,
       onclick: forAllNamespaces ? false : onclick,
       attributes: cells.slice(forAllNamespaces ? 0 : 1).map((cell, idx) => {


### PR DESCRIPTION
And uses kubernetes `name_kind_ns` as the rowKey of a Table Row
    
Fixes #6588
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
