### PR TITLE
fix(plugins/plugin-kubectl): kubectl direct watcher does not properly filter events and resource updates

### DIFF
--- a/plugins/plugin-kubectl/src/controller/client/direct/group.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/group.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Explained } from '../../kubectl/explain'
+
+export interface Group {
+  names: string[]
+  namespace: string
+  explainedKind: Explained
+}
+
+export function isObjectInGroups(groups: Group[], kind: string, name: string) {
+  return (
+    groups.length === 0 ||
+    groups.findIndex(({ explainedKind, names }) => {
+      const isKindMatch = explainedKind.kind.toLowerCase() === kind.toLowerCase()
+      const noNamesInGroup = names.length === 0
+      const isNameMatch = names.includes(name)
+
+      return isKindMatch && (isNameMatch || noNamesInGroup)
+    }) !== -1
+  )
+}

--- a/plugins/plugin-kubectl/src/controller/kubectl/status.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/status.ts
@@ -36,7 +36,8 @@ import {
 import { getKindAndVersion } from './explain'
 import { fqnOfRef, ResourceRef, versionOf } from './fqn'
 import { initialCapital } from '../../lib/view/formatTable'
-import statusDirect, { Group } from '../client/direct/status'
+import statusDirect from '../client/direct/status'
+import { Group } from '../client/direct/group'
 import KubeOptions, {
   KubeOptions as Options,
   fileOf,


### PR DESCRIPTION
Fixes #6599 

The movie here shows how this PR watch resource correctly:

https://user-images.githubusercontent.com/21212160/104780012-179a8400-574e-11eb-80de-36fa0d7d6a2c.mov




<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
