### PR TITLE
fix: kubectl direct streaming fails to register a stream.on('error')

### DIFF
--- a/packages/core/src/main/headless.ts
+++ b/packages/core/src/main/headless.ts
@@ -39,12 +39,8 @@ setMedia(Media.Headless)
 let exitCode = 0
 
 // electron pops up a window by default, for uncaught exceptions
-process.on('uncaughtException', async (err: Error) => {
-  debug('uncaughtException')
-  debug(err)
-  const colors = await import('colors/safe')
-  console.error(colors.red(err.toString()))
-  process.exit(1)
+process.on('uncaughtException', (err: Error) => {
+  console.error('Uncaught Exception', err)
 })
 
 process.on('exit', code => {

--- a/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
+++ b/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
@@ -94,8 +94,18 @@ export async function openStream<T extends object>(
     })
 
     stream.on('error', err => {
-      debug('stream suddenly died', err)
-      throw new Error(err)
+      //
+      // It's highly likely to be ok if the stream went away. This is
+      // usually a sign that we are in the Kui proxy, and the Kui browser
+      // client simply went away.
+      //
+      // !!DANGER!!: do not throw an exception here, as it will currently
+      //             percolate all the way up and result in a Kui proxy
+      //             failure due to an uncaughtException.
+      //
+      if (err.code !== 'ERR_STREAM_DESTROYED') {
+        console.error('stream suddenly died', err)
+      }
     })
 
     JSONStream(stream, await onData, mgmt.onExit)


### PR DESCRIPTION
This PR also updates the uncaughtException handler so as not the exit.

Fixes #6616

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
