### PR TITLE
fix: ls clicks that do another ls should not open a split

### DIFF
--- a/packages/core/src/webapp/models/table.ts
+++ b/packages/core/src/webapp/models/table.ts
@@ -147,6 +147,13 @@ export class Table<RowType extends Row = Row> {
   /** This field helps with watching/paginating */
   resourceVersion?: number | string
 
+  /**
+   * Should drilldowns go to a side split, or to this split? Default:
+   * `side-split`, unless the user chords the click with the Meta key
+   * (which is Command on macOS, and Option on Linux/Windows
+   */
+  drilldownTo?: 'side-split' | 'this-split'
+
   /** Default presentation? */
   defaultPresentation?: PresentationStyle
 

--- a/plugins/plugin-bash-like/fs/src/lib/ls.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/ls.ts
@@ -231,6 +231,7 @@ function toTable(entries: GlobStats[], args: Arguments<LsOptions>): Table {
     noSort: true,
     defaultPresentation,
     allowedPresentations,
+    drilldownTo: 'this-split',
     style: wide ? undefined : TableStyle.Light
   }
 }

--- a/plugins/plugin-client-common/src/components/Content/Table/Grid.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/Grid.tsx
@@ -102,7 +102,7 @@ export default class Grid<P extends Props> extends React.PureComponent<P, State>
           <div key={_.name} data-name={_.name} className={_.css}>
             <span
               className={_.onclick && 'clickable'}
-              onClick={onClickForCell(_, this.props.tab, this.props.repl, _.onclick)}
+              onClick={onClickForCell(_, this.props.tab, this.props.repl, _.onclick, this.props.response)}
             >
               {_.name}
             </span>
@@ -144,7 +144,8 @@ export default class Grid<P extends Props> extends React.PureComponent<P, State>
               kuiRow,
               tab,
               repl,
-              kuiRow.attributes.find(_ => _.onclick)
+              kuiRow.attributes.find(_ => _.onclick),
+              this.props.response
             )
           }
 

--- a/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
@@ -47,8 +47,10 @@ export function onClickForCell(
   tab: Tab,
   repl: REPL,
   cell?: KuiCell,
-  selectRow: () => void = () => undefined
+  opts?: Pick<KuiTable, 'drilldownTo'> & { selectRow?: () => void }
 ): CellOnClickHandler {
+  const { drilldownTo = 'side-split', selectRow = () => undefined } = opts || {}
+
   const handler = cell && cell.onclick ? cell.onclick : row.onclick
   if (handler === false) {
     return () => handler
@@ -71,7 +73,7 @@ export function onClickForCell(
       return whenNothingIsSelected((evt: React.MouseEvent) => {
         evt.stopPropagation()
         selectRow()
-        if (!XOR(evt.metaKey, !!process.env.KUI_SPLIT_DRILLDOWN)) {
+        if (drilldownTo === 'side-split' && !XOR(evt.metaKey, !!process.env.KUI_SPLIT_DRILLDOWN)) {
           pexecInCurrentTab(`split --ifnot is-split --cmdline "${handler}"`, undefined, false, true)
         } else {
           repl.pexec(handler, opts)
@@ -126,7 +128,7 @@ export default function renderCell(table: KuiTable, kuiRow: KuiRow, justUpdated:
       <TableCell
         key={cell.id}
         className={cellClassName}
-        onClick={onClickForCell(kuiRow, tab, repl, kuiRow.attributes[cidx - 1])}
+        onClick={onClickForCell(kuiRow, tab, repl, kuiRow.attributes[cidx - 1], table)}
       >
         <span
           data-key={cidx === 0 ? kuiRow.key : kuiRow.attributes[cidx - 1].key}


### PR DESCRIPTION
This PR introduces the drilldownTo attribute of Table.

Fixes #6565

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
