### PR TITLE
fix(plugins/plugin-client-common): improve platform compatibility of …

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/OnKeyDown.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/OnKeyDown.ts
@@ -53,6 +53,7 @@ const setCaretPosition = (ctrl: HTMLInputElement, pos: number) => {
   }
 }
 
+const setCaretPositionToStart = (input: HTMLInputElement) => setCaretPosition(input, 0)
 const setCaretPositionToEnd = (input: HTMLInputElement) => setCaretPosition(input, input.value.length)
 
 /** Update the given input to reflect the given HistoryLine */
@@ -161,22 +162,12 @@ export default function onKeyDown(this: Input, event: KeyboardEvent) {
     // restore the prompt cursor position
     // debug('restoring cursor position', currentCursorPosition)
     // getCurrentPrompt().setSelectionRange(currentCursorPosition, currentCursorPosition)
-  } else if (char === KeyCodes.HOME) {
-    // go to first command in history
-    setTimeout(async () => {
-      const historyModel = await (await import('@kui-shell/core')).History(tab)
-      const entry = historyModel.first()
-      if (entry) {
-        updateInputAndMoveCaretToEOL(this, entry)
-      }
-    })
-  } else if (char === KeyCodes.END) {
-    // go to last command in history
-    setTimeout(async () => {
-      const historyModel = await (await import('@kui-shell/core')).History(tab)
-      const entry = historyModel.last()
-      updateInputAndMoveCaretToEOL(this, entry)
-    })
+  } else if (event.key === 'Home' && event.shiftKey && process.platform === 'darwin') {
+    // go to beginning of line
+    setCaretPositionToStart(prompt)
+  } else if (event.key === 'End' && event.shiftKey && process.platform === 'darwin') {
+    // go to end of line
+    setCaretPositionToEnd(prompt)
   } else if (char === KeyCodes.DOWN || (char === KeyCodes.N && event.ctrlKey)) {
     // going DOWN past the last history item will result in '', i.e. a blank line
     setTimeout(async () => {


### PR DESCRIPTION
…Home and End keys

This PR addresses both shift+Home/End behavior on macOS, and Home/End behavior on Linux/Windows. In both cases, Kui's behavior should now match that of the platform terminal.

Note: browsers on macOS seem to interpret shift+Home as meaning "select all to beginning of line", whereas macOS Terminal interprets shift+Home to mean "move caret to beginning of line". Thus, Kui still (for darwin only) needs to override the default behavior, though just for this one case.

Fixes #3267

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
