### PR TITLE
fix(plugins/plugin-kubectl): events watching returns an empty table with just a streaming events footer

### DIFF
--- a/packages/test/src/api/repl-expect.ts
+++ b/packages/test/src/api/repl-expect.ts
@@ -307,6 +307,28 @@ export const okWithDropDownList = (openAndExpectLabel: string, click = false) =>
     })
 }
 
+const currentEventCount = async (app: Application, outputCount: number): Promise<number> => {
+  const events = await app.client.$$(Selectors.TABLE_FOOTER(outputCount))
+  const res = !events ? 0 : events.length
+  return res
+}
+
+export const okWithEvents = async (ctx: ISuite, res: AppAndCount) => {
+  let idx = 0
+  await ctx.app.client.waitUntil(
+    async () => {
+      const actualEventCount = await currentEventCount(ctx.app, res.count)
+      if (++idx > 5) {
+        console.error('still waiting for events')
+      }
+      console.log('actualEventCount', actualEventCount)
+      return actualEventCount > 0
+    },
+    { timeout: waitTimeout }
+  )
+  return res
+}
+
 /** as long as its ok, accept anything */
 export const okWithAny = async (res: AppAndCount) => expectOK(res)
 

--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -57,7 +57,7 @@ export const SIDECAR_PACKAGE_NAME_TITLE = (N: number, splitIndex = 1) =>
   `${SIDECAR(N, splitIndex)} .kui--sidecar-entity-namespace .bx--link`
 export const SIDECAR_POPUP_TITLE = SIDECAR_TITLE
 export const SIDECAR_POPUP_HERO_TITLE = SIDECAR_HERO_TITLE
-export const SIDECAR_KIND = (N: number, splitIndex = 1) => `${SIDECAR(N, splitIndex)} .kui--sidecar-kind .bx--link`
+export const SIDECAR_KIND = (N: number, splitIndex = 1) => `${SIDECAR(N, splitIndex)} .kui--sidecar-kind`
 export const SIDECAR_CONTENT = (N: number, splitIndex = 1) => `${SIDECAR(N, splitIndex)} .sidecar-content`
 export const SIDECAR_WEB_ACTION_URL = (N: number, splitIndex = 1) =>
   `${SIDECAR(N, splitIndex)} .sidecar-header .entity-web-export-url.has-url`

--- a/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
@@ -314,6 +314,7 @@ export default class PaginatedTable<P extends Props, S extends State> extends Re
           sortRow={sortRow}
           render={renderOpts => (
             <TableContainer
+              data-is-empty={response.body.length === 0}
               className={
                 'kui--data-table-container' +
                 (this.props.title ? ' kui--data-table-container-with-toolbars' : '') +

--- a/plugins/plugin-client-common/web/scss/components/Table/tables.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/tables.scss
@@ -242,7 +242,7 @@ body[kui-theme-style] .kui--data-table-wrapper {
 
 /** inner scrolling for tall tables, when not in a minisplit */
 .kui--scrollback:not([data-is-minisplit]):not([data-is-width-constrained]) {
-  .kui--data-table-container {
+  .kui--data-table-container:not([data-is-empty]) {
     min-width: $min-body-width;
     /* max-height: $max-body-height; see https://github.com/IBM/kui/issues/5221 */
     min-height: $min-body-height;

--- a/plugins/plugin-kubectl/src/controller/client/direct/status.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/status.ts
@@ -92,7 +92,7 @@ class MultiKindWatcher implements Abortable, Watcher {
           this.finalState,
           this.initialRowKeys[idx],
           this.nNotReady[idx],
-          this.monitorEvents,
+          { doWatch: this.monitorEvents, watchEventsOnly: false },
           true // yes, make sure there is a status column
         )
 
@@ -224,7 +224,7 @@ export default async function watchMulti(
           finalState,
           tables[0].table.body.map(row => ({ rowKey: row.rowKey, isReady: isResourceReady(row, finalState) })),
           nNotReady,
-          true, // watch events
+          undefined,
           true // yes, make sure there is a status column
         )
       }


### PR DESCRIPTION
![Screen Shot 2021-01-19 at 6 08 17 PM](https://user-images.githubusercontent.com/21212160/105105033-521f5c00-5a81-11eb-829f-ef71dfa768e5.png)
Fixes #2771

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
