### PR TITLE
fix(plugins/plugin-kubectl): direct/watch may update rows in a wrong order

### DIFF
--- a/plugins/plugin-kubectl/src/controller/client/direct/status.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/status.ts
@@ -254,7 +254,7 @@ export default async function watchMulti(
 
     const unifiedTable: Table = {
       title,
-      breadcrumbs,
+      breadcrumbs: !isWatchRequest ? breadcrumbs : undefined,
       header,
       body
     }

--- a/plugins/plugin-kubectl/src/test/k8s2/aaaa-get-dashf.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/aaaa-get-dashf.ts
@@ -48,7 +48,7 @@ commands.forEach(command => {
           ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME('nginx') })
         )
         .then(selector => waitForGreen(this.app, selector))
-        .catch(Common.oops(this))
+        .catch(Common.oops(this, true))
     })
 
     it(`should get sample pod from local file via ${command}`, () => {
@@ -57,7 +57,7 @@ commands.forEach(command => {
           ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME('nginx') })
         )
         .then(selector => waitForGreen(this.app, selector))
-        .catch(Common.oops(this))
+        .catch(Common.oops(this, true))
     })
 
     it(`should watch sample pod from local file and delete it via ${command}`, () => {
@@ -74,7 +74,7 @@ commands.forEach(command => {
 
           await waitForRed(this.app, watchSelector)
         })
-        .catch(Common.oops(this))
+        .catch(Common.oops(this, true))
     })
 
     const dir = `${ROOT}/data/k8s/application/guestbook`
@@ -93,7 +93,7 @@ commands.forEach(command => {
           ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME('frontend') })
         )
         .then(selector => waitForGreen(this.app, selector))
-        .catch(Common.oops(this))
+        .catch(Common.oops(this, true))
     })
 
     it(`should get sample application from local directory via ${command}`, () => {
@@ -102,7 +102,7 @@ commands.forEach(command => {
           ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME('frontend') })
         )
         .then(selector => waitForGreen(this.app, selector))
-        .catch(Common.oops(this))
+        .catch(Common.oops(this, true))
     })
 
     const duplicatedName = 'redis-master'
@@ -115,7 +115,7 @@ commands.forEach(command => {
           return watchSelector
         })
         .then(selector => waitForGreen(this.app, selector))
-        .catch(Common.oops(this))
+        .catch(Common.oops(this, true))
     })
 
     it(`should should delete ${duplicatedName} service via ${command}`, () => {
@@ -124,11 +124,11 @@ commands.forEach(command => {
           ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME(duplicatedName) })
         )
         .then(selector => waitForRed(this.app, selector))
-        .catch(Common.oops(this))
+        .catch(Common.oops(this, true))
     })
 
     it(`should watch ${duplicatedName} deployment still green`, () => {
-      return waitForGreen(this.app, watchSelector).catch(Common.oops(this))
+      return waitForGreen(this.app, watchSelector).catch(Common.oops(this, true))
     })
 
     it(`should should delete ${duplicatedName} deployment via ${command}`, () => {
@@ -137,11 +137,11 @@ commands.forEach(command => {
           ReplExpect.okWithCustom<string>({ selector: Selectors.BY_NAME(duplicatedName) })
         )
         .then(selector => waitForRed(this.app, selector))
-        .catch(Common.oops(this))
+        .catch(Common.oops(this, true))
     })
 
     it(`should watch ${duplicatedName} deployment to be red`, () => {
-      return waitForRed(this.app, watchSelector).catch(Common.oops(this))
+      return waitForRed(this.app, watchSelector).catch(Common.oops(this, true))
     })
 
     deleteNS(this, ns)


### PR DESCRIPTION
This PR also changes`toKuiTable` to get `namespace breadcrumb` from `PartialObject`. The PR removes `the namespace breadcrumb` for `heterogeneous get`, since a watch pusher currently doesn't support updating the header. If the heterogeneous watch involves resources with different scopes, the header might be wrong.

![Screen Shot 2021-01-21 at 2 02 13 PM](https://user-images.githubusercontent.com/21212160/105399204-51a5d300-5bf1-11eb-9cee-aed386a1b50f.png)
Fixes #6642

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
