### PR TITLE
fix(plugins/plugin-kubectl): `k get all` with direct/get doesn't fail back to the old impl of get

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -265,10 +265,14 @@ async function rawGet(
 
   if ((command === 'oc' || command === 'kubectl') && !args.argvNoOptions.includes('|')) {
     // try talking to the apiServer directly
-    const response = await getDirect(args, _kind)
-    if (response) {
-      // that worked!
-      return response
+    try {
+      const response = await getDirect(args, _kind)
+      if (response) {
+        // that worked!
+        return response
+      }
+    } catch (err) {
+      console.error('direct/get failed; fall back to kubectl get', err)
     }
   }
 


### PR DESCRIPTION

![Screen Shot 2021-01-21 at 5 05 50 PM](https://user-images.githubusercontent.com/21212160/105418316-ec5edb80-5c0a-11eb-9a72-2e7822375488.png)
Fixes #6643

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
