### PR TITLE
fix(plugins/plugin-electron-components): UpdateChecker should ignore prereleases

### DIFF
--- a/plugins/plugin-electron-components/src/components/UpdateChecker.tsx
+++ b/plugins/plugin-electron-components/src/components/UpdateChecker.tsx
@@ -122,7 +122,15 @@ export default class UpdateChecker extends React.PureComponent<Props, State> {
   private checkForUpdates() {
     needle('get', FEED, { json: true })
       .then(res => {
-        const entryForLatestVersion = res.body.children.filter(_ => _.name === 'entry')[0]
+        const entryForLatestVersion = res.body.children
+          .filter(_ => _.name === 'entry')
+          .find(_ =>
+            _.children.find(
+              _ =>
+                _.name === 'title' && !_.value.includes('beta') && !_.value.includes('alpha') && !_.value.includes('rc')
+            )
+          )
+
         this.setState({
           entryForLatestVersion: {
             title: this.atomValueFor('title', res.body),


### PR DESCRIPTION
Fixes #6655

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
