### PR TITLE
9.3.11

### DIFF
--- a/plugins/plugin-electron-components/src/components/UpdateChecker.tsx
+++ b/plugins/plugin-electron-components/src/components/UpdateChecker.tsx
@@ -119,7 +119,15 @@ export default class UpdateChecker extends React.PureComponent<Props, State> {
   private checkForUpdates() {
     needle('get', FEED, { json: true })
       .then(res => {
-        const entryForLatestVersion = res.body.children.filter(_ => _.name === 'entry')[0]
+        const entryForLatestVersion = res.body.children
+          .filter(_ => _.name === 'entry')
+          .find(_ =>
+            _.children.find(
+              _ =>
+                _.name === 'title' && !_.value.includes('beta') && !_.value.includes('alpha') && !_.value.includes('rc')
+            )
+          )
+
         this.setState({
           entryForLatestVersion: {
             title: this.atomValueFor('title', res.body),


### PR DESCRIPTION
[9.3.11 2a6e90b79] fix(plugins/plugin-electron-components): UpdateChecker should ignore prereleases
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Thu Jan 21 17:44:38 2021 -0500
 1 file changed, 9 insertions(+), 1 deletion(-)