### PR TITLE
fix(plugins/plugin-kubectl): kubectl sourceRef fetching is expensive

### DIFF
--- a/plugins/plugin-kubectl/src/controller/client/direct/unify.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/unify.ts
@@ -72,7 +72,7 @@ export function unifyHeaders(headers: Table['header'][]): Table['header'] {
 }
 
 function getFromLabel(object: Row['object'], field: string): string {
-  return object.metadata.labels[field]
+  return object.metadata && object.metadata.labels ? object.metadata.labels[field] : undefined
 }
 
 function getFromSelector(object: Row['object'], field: string) {

--- a/plugins/plugin-kubectl/src/controller/kubectl/create.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/create.ts
@@ -15,7 +15,7 @@
  */
 
 import Debug from 'debug'
-import { Registrar, Arguments, WithSourceReferences, Table, isTable } from '@kui-shell/core'
+import { Registrar, Arguments } from '@kui-shell/core'
 
 import defaultFlags from './flags'
 import { isDryRun, isEntityFormat, KubeOptions, formatOf } from './options'
@@ -25,7 +25,6 @@ import createDirect from '../client/direct/create'
 
 import { FinalState } from '../../lib/model/states'
 import { isUsage, doHelp } from '../../lib/util/help'
-import getSourceRefs from './source'
 import { doGetAsEntity, viewTransformer } from './get'
 
 const debug = Debug('plugin-kubectl/controller/kubectl/create')
@@ -61,14 +60,9 @@ export const doCreate = (verb: 'create' | 'apply', command = 'kubectl') => async
         }
       }
 
-      const kuiSourceRef = getSourceRefs(args)
-      const table = await doExecWithStatus(verb, FinalState.OnlineLike, command)(args)
-      if (isTable(table)) {
-        const response: Table & WithSourceReferences = Object.assign({}, table, { kuiSourceRef: await kuiSourceRef })
-        return response
-      } else {
-        return table
-      }
+      // Note: the kuiSourceRef info will be added by `doStatus` in
+      // ./status.ts, which is called by `doExecWithStatus`
+      return doExecWithStatus(verb, FinalState.OnlineLike, command)(args)
     }
   }
 }

--- a/plugins/plugin-kubectl/src/controller/kubectl/source.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/source.ts
@@ -14,50 +14,20 @@
  * limitations under the License.
  */
 
-import { Arguments, WithSourceReferences } from '@kui-shell/core'
+import { fileOfWithDetail } from './options'
+import { WithSourceReferences } from '@kui-shell/core'
 
-import { fetchKusto, fetchFilesVFS } from '../../lib/util/fetch-file'
-import { kustomizeOf, KubeOptions, fileOfWithDetail, isTableRequest } from './options'
-
-/**
- * Fetch any references to --file sources, so that the views can show
- * the user what happened in more detail.
- *
- */
-export default async function withSourceRefs(
-  args: Arguments<KubeOptions>
-): Promise<WithSourceReferences['kuiSourceRef']> {
-  const { filepath, isFor } = fileOfWithDetail(args)
-  const kusto = kustomizeOf(args)
-
-  if (isTableRequest(args)) {
-    try {
-      if (filepath) {
-        const files = await fetchFilesVFS(args, filepath, true)
-        return {
-          templates: files.map(({ filepath, data }) => ({
-            filepath,
-            data,
-            isFor,
-            kind: 'source' as const,
-            contentType: 'yaml'
-          }))
-        }
-      } else if (kusto) {
-        const { customization, templates } = await fetchKusto(args, kusto)
-        return {
-          customization: { filepath: customization.filepath, data: customization.data, isFor: 'k' },
-          templates: templates.map(({ filepath, data }) => ({
-            filepath,
-            data,
-            isFor,
-            kind: 'source' as const,
-            contentType: 'yaml'
-          }))
-        }
-      }
-    } catch (err) {
-      console.error('Error fetching source ref', err)
-    }
+export default function toSourceRefs(
+  files: { filepath: string; data: string }[],
+  isFor: ReturnType<typeof fileOfWithDetail>['isFor']
+): WithSourceReferences['kuiSourceRef'] {
+  return {
+    templates: files.map(({ filepath, data }) => ({
+      filepath,
+      data,
+      isFor,
+      kind: 'source' as const,
+      contentType: 'yaml'
+    }))
   }
 }

--- a/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
+++ b/plugins/plugin-kubectl/src/lib/util/fetch-file.ts
@@ -315,7 +315,11 @@ export async function fetchRawFiles(args: Arguments<KubeOptions>, filepath: stri
 
 export default fetchFileString
 
-export async function fetchFilesVFS(args: Arguments<KubeOptions>, filepath: string, fetchNestedYamls?: boolean) {
+export async function fetchFilesVFS(
+  args: Arguments<KubeOptions>,
+  filepath: string,
+  fetchNestedYamls?: boolean
+): Promise<{ filepath: string; data: string }[]> {
   const path = fetchNestedYamls ? `${encodeComponent(filepath)} ${encodeComponent(filepath)}/**/*.{yaml,yml}` : filepath
   const paths = new Set((await args.REPL.rexec<DirEntry[]>(`vfs ls ${path}`)).content.map(_ => _.path))
   const raw = await fetchFileString(args.REPL, paths.size === 0 ? filepath : Array.from(paths).join(','))
@@ -346,8 +350,8 @@ export async function fetchKusto(args: Arguments<KubeOptions>, kusto: string) {
       .join(' ')
     const files = await fetchFilesVFS(args, resources)
     return {
-      customization: { filepath: kusto, data: raw.data },
-      templates: files.map(({ filepath, data }) => ({ filepath, data }))
+      customization: { filepath: kusto, data: raw.data, contentType: 'yaml', isFor: 'k' },
+      templates: files.map(({ filepath, data }) => ({ filepath, data, contentType: 'yaml', isFor: 'k' }))
     }
   }
 }

--- a/plugins/plugin-kubectl/src/test/k8s3/source-ref.ts
+++ b/plugins/plugin-kubectl/src/test/k8s3/source-ref.ts
@@ -94,16 +94,21 @@ describe(`kubectl source ref ${process.env.MOCHA_RUN_TARGET || ''}`, function(th
 
   it('should create with kustomization and see source ref', async () => {
     try {
-      const res = await CLI.command(`kubectl create -k ${ROOT}/data/k8s/kustomize/base ${inNamespace}`, this.app)
+      console.error('SRK1')
+      const res = await CLI.command(`kubectl apply -k ${ROOT}/data/k8s/kustomize/base ${inNamespace}`, this.app)
 
       const confirm = confirmState.bind(this, res)
       const toggle = clickToToggle.bind(this, res)
 
       let isExpanded = false // default isExpanded?
       for (let idx = 0; idx < 5; idx++) {
+        console.error(`SRK2.${idx}`)
         await confirm(isExpanded, 'Deployment')
+        console.error(`SRK3.${idx}`)
         isExpanded = await toggle(isExpanded)
+        console.error(`SRK4.${idx}`)
       }
+      console.error('SRK5')
     } catch (err) {
       await Common.oops(this, true)(err)
     }


### PR DESCRIPTION
Fixes #6662

This PR also fixes a minor issue with `-k` sourceRefs. The editor did not syntax color `-k` sourceRefs (though it was properly coloring `-f` sourceRefs)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
