### PR TITLE
fix(plugins/plugin-kubectl): `k get all` with direct/get doesn't fail back to the old impl of get

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -262,8 +262,9 @@ async function rawGet(
     : getKindAndVersion(_command, args, args.argvNoOptions[args.argvNoOptions.indexOf('get') + 1])
 ) {
   const command = _command === 'k' ? 'kubectl' : _command
+  const isGetAll = args.argvNoOptions[args.argvNoOptions.indexOf('get') + 1] === 'all'
 
-  if ((command === 'oc' || command === 'kubectl') && !args.argvNoOptions.includes('|')) {
+  if ((command === 'oc' || command === 'kubectl') && !args.argvNoOptions.includes('|') && !isGetAll) {
     // try talking to the apiServer directly
     const response = await getDirect(args, _kind)
     if (response) {


### PR DESCRIPTION
Fixes #6643

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
