### PR TITLE
chore: remove carbon components icon package.json deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -428,7 +428,6 @@
     "@kui-shell/plugin-client-common": {
       "version": "file:plugins/plugin-client-common",
       "requires": {
-        "@carbon/icons-react": "10.20.0",
         "@patternfly/react-core": "4.84.4",
         "carbon-components": "10.23.2",
         "carbon-components-react": "7.23.2",
@@ -560,7 +559,6 @@
     "@kui-shell/react": {
       "version": "file:packages/react",
       "requires": {
-        "@types/carbon__icons-react": "10.21.0",
         "react": "16.13.1",
         "react-dom": "16.13.1"
       }
@@ -879,11 +877,6 @@
         "@types/react": "*",
         "flatpickr": "4.6.1"
       }
-    },
-    "@types/carbon__icons-react": {
-      "version": "10.21.0",
-      "resolved": "https://registry.npmjs.org/@types/carbon__icons-react/-/carbon__icons-react-10.21.0.tgz",
-      "integrity": "sha512-QEEzUwyEVT+aLw8/f284bZVx5AfU03UxDsRPjAinMuPTWVZGzIwMuqMZv9gUSg9IqYUheLfnbf4uRs/knimVlw=="
     },
     "@types/cookie": {
       "version": "0.4.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,7 +15,6 @@
     "url": "git+https://github.com/IBM/kui.git"
   },
   "dependencies": {
-    "@types/carbon__icons-react": "10.21.0",
     "react": "16.13.1",
     "react-dom": "16.13.1"
   },

--- a/plugins/plugin-client-common/package.json
+++ b/plugins/plugin-client-common/package.json
@@ -20,7 +20,6 @@
   "module": "mdist/index.js",
   "types": "mdist/index.d.ts",
   "dependencies": {
-    "@carbon/icons-react": "10.20.0",
     "@patternfly/react-core": "4.84.4",
     "carbon-components": "10.23.2",
     "carbon-components-react": "7.23.2",


### PR DESCRIPTION
We unfortunately still need to include the `carbon-icons` dependence, as `carbon-components-react1 has an unstated dependence on this package. We won't be able to remove it until we remove carbon entirely.

Fixes #6683

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
