### PR TITLE
chore: TabCompletion component has hard-coded use of Carbon Button

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/TabCompletion.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/TabCompletion.tsx
@@ -19,7 +19,6 @@
 import Debug from 'debug'
 import React from 'react'
 import minimist from 'yargs-parser'
-import { Button } from 'carbon-components-react'
 import {
   typeahead,
   getCurrentTab,
@@ -29,6 +28,7 @@ import {
   Split
 } from '@kui-shell/core'
 
+import Button from '../../../spi/Button'
 import { InputProvider as Input } from './Input'
 import '../../../../../web/css/static/TabCompletion.scss'
 
@@ -349,7 +349,7 @@ class TabCompletionStateWithMultipleSuggestions extends TabCompletionState {
 
     return (
       <div className="kui--tab-completions--option" key={idx} data-value={value}>
-        <Button href="#" size="small" tabIndex={1} onClick={() => this.completeWith(idx)}>
+        <Button size="small" tabIndex={1} onClick={() => this.completeWith(idx)}>
           <React.Fragment>
             <span className="kui--tab-completions--option-partial">{preText}</span>
             <span className="kui--tab-completions--option-completion">{postText}</span>

--- a/plugins/plugin-client-common/src/components/spi/Button/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Button/impl/PatternFly.tsx
@@ -25,6 +25,7 @@ export default function PatternFlyTag(props: Props) {
       onClick={props.onClick}
       variant={props.kind}
       isSmall={props.size === 'small'}
+      tabIndex={props.tabIndex}
       className={['kui--tag', props.className].join(' ')}
     >
       {props.children}

--- a/plugins/plugin-client-common/src/components/spi/Button/model.ts
+++ b/plugins/plugin-client-common/src/components/spi/Button/model.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-interface Props {
+import { PropsWithChildren } from 'react'
+
+type Props = PropsWithChildren<{
+  tabIndex?: number
   className?: string
   onClick?: () => void
   size?: 'small' | 'default'
   kind?: 'tertiary' | 'secondary' | 'primary'
-  children: string
-}
+}>
 
 export default Props

--- a/plugins/plugin-client-common/web/css/static/TabCompletion.scss
+++ b/plugins/plugin-client-common/web/css/static/TabCompletion.scss
@@ -1,10 +1,24 @@
-@import 'carbon-components/scss/components/button/_button.scss';
+/*
+ * Copyright 2020-2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 .kui--tab-completions {
   flex-basis: 100%;
 
   .kui--tab-completions--option {
-    .bx--btn--primary {
+    button {
       background-color: transparent;
       color: var(--color-text-01);
       padding: 0.1875em 0.5em;

--- a/plugins/plugin-core-support/tests/lib/core-support/tab-completion-util.js
+++ b/plugins/plugin-core-support/tests/lib/core-support/tab-completion-util.js
@@ -114,7 +114,7 @@ exports.tabbyWithOptions = (
             // then we expect non-visibility of the tab-completion popup
             // console.error('Expecting non-existence of popup')
             return ctx.app.client
-              .$(`${Selectors.PROMPT_BLOCK_N(count)} .kui--tab-completions .kui--tab-completions--option a`)
+              .$(`${Selectors.PROMPT_BLOCK_N(count)} .kui--tab-completions .kui--tab-completions--option button`)
               .then(_ =>
                 _.waitForDisplayed({
                   timeout: 10000,
@@ -128,14 +128,16 @@ exports.tabbyWithOptions = (
                 throw err
               })
           } else {
-            const selector = `${Selectors.PROMPT_BLOCK_N(count)} .kui--tab-completions .kui--tab-completions--option a`
+            const selector = `${Selectors.PROMPT_BLOCK_N(
+              count
+            )} .kui--tab-completions .kui--tab-completions--option button`
             // console.error('Expecting existence of popup', selector)
             return ctx.app.client.$(selector).then(_ => _.waitForDisplayed({ timeout: 10000 }))
           }
         })
         .then(() =>
           ctx.app.client
-            .$$(`${Selectors.PROMPT_BLOCK_N(count)} .kui--tab-completions .kui--tab-completions--option a`)
+            .$$(`${Selectors.PROMPT_BLOCK_N(count)} .kui--tab-completions .kui--tab-completions--option button`)
             .then(elements => Promise.all(elements.map(_ => _.getText())))
         )
         .then(expectArray(expected))
@@ -148,7 +150,7 @@ exports.tabbyWithOptions = (
             )} .kui--tab-completions .kui--tab-completions--option[data-value="${expected[click].replace(
               /\\/g,
               '\\\\'
-            )}"] a`
+            )}"] button`
             // console.error('clicking', click, selector)
             return ctx.app.client.$(selector).then(async _ => {
               await _.waitForDisplayed({ timeout: 10000 })
@@ -199,7 +201,9 @@ exports.tabbyWithOptionsThenCancel = (ctx, partial, expected) =>
         .then(() => ctx.app.client.$(Selectors.CURRENT_PROMPT))
         .then(setValue(`${partial}${Keys.TAB}`))
         .then(() =>
-          ctx.app.client.$(`${Selectors.PROMPT_BLOCK_N(count)} .kui--tab-completions .kui--tab-completions--option a`)
+          ctx.app.client.$(
+            `${Selectors.PROMPT_BLOCK_N(count)} .kui--tab-completions .kui--tab-completions--option button`
+          )
         )
         .then(_ => _.waitForDisplayed())
         .then(() =>


### PR DESCRIPTION
Part of #4364

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [x] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
