### PR TITLE
test(plugins/plugin-kubectl): kubectl source ref test fails sometimes…

### DIFF
--- a/plugins/plugin-kubectl/src/test/k8s3/source-ref.ts
+++ b/plugins/plugin-kubectl/src/test/k8s3/source-ref.ts
@@ -20,7 +20,7 @@ import { createNS, allocateNS, deleteNS } from '@kui-shell/plugin-kubectl/tests/
 import { dirname } from 'path'
 const ROOT = dirname(require.resolve('@kui-shell/plugin-kubectl/tests/package.json'))
 
-const timeout = 8000
+const timeout = 20000
 
 /** confirm the given toggler state */
 async function confirmState(this: Common.ISuite, res: ReplExpect.AppAndCount, isExpanded: boolean, kind: string) {


### PR DESCRIPTION
… in travis

Let's see if increasing that timeout from 8s to 20s helps stabilize travis.

Fixes #6702

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
