### PR TITLE
fix(plugins/plugin-kubectl): get without kind doesn't fail back to the old get impl

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/explain.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/explain.ts
@@ -307,16 +307,18 @@ async function fetch(command: string, args: Arguments, kindAsProvidedByUser: str
 }
 
 export function getKindAndVersion(command: string, args: Arguments, kindAsProvidedByUser: string): Promise<Explained> {
-  const fastPath = fastPathCases[kindAsProvidedByUser]
-  if (fastPath) {
-    // we have precomputed some of the common cases
-    return Promise.resolve(fastPath)
-  } else if (!cache[kindAsProvidedByUser]) {
-    // otherwise, we need to do a more expensive call to `kubectl`
-    cache[kindAsProvidedByUser] = fetch(command, args, kindAsProvidedByUser)
-  }
+  if (kindAsProvidedByUser) {
+    const fastPath = fastPathCases[kindAsProvidedByUser]
+    if (fastPath) {
+      // we have precomputed some of the common cases
+      return Promise.resolve(fastPath)
+    } else if (!cache[kindAsProvidedByUser]) {
+      // otherwise, we need to do a more expensive call to `kubectl`
+      cache[kindAsProvidedByUser] = fetch(command, args, kindAsProvidedByUser)
+    }
 
-  return cache[kindAsProvidedByUser]
+    return cache[kindAsProvidedByUser]
+  }
 }
 
 /**

--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -263,8 +263,9 @@ async function rawGet(
 ) {
   const command = _command === 'k' ? 'kubectl' : _command
   const isGetAll = args.argvNoOptions[args.argvNoOptions.indexOf('get') + 1] === 'all'
+  const requestWithoutKind = isGetAll || (!fileOf(args) && !_kind)
 
-  if ((command === 'oc' || command === 'kubectl') && !args.argvNoOptions.includes('|') && !isGetAll) {
+  if ((command === 'oc' || command === 'kubectl') && !args.argvNoOptions.includes('|') && !requestWithoutKind) {
     // try talking to the apiServer directly
     const response = await getDirect(args, _kind)
     if (response) {

--- a/plugins/plugin-kubectl/src/test/k8s2/get-pod.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/get-pod.ts
@@ -93,6 +93,18 @@ commands.forEach(command => {
         .catch(Common.oops(this, true))
     })
 
+    it(`should error out when getting without kind`, () => {
+      return CLI.command(`${command} get ${inNamespace}`, this.app)
+        .then(ReplExpect.error(500))
+        .catch(Common.oops(this, true))
+    })
+
+    it(`should error out when getting -o name without kind`, () => {
+      return CLI.command(`${command} get -o name ${inNamespace}`, this.app)
+        .then(ReplExpect.error(500))
+        .catch(Common.oops(this, true))
+    })
+
     /**
      * NOTE [myan 20190816]: In the test case below, The error message is different based on kube version
      * With version 1.12, the output is 'Error from server (NotFound): pods "shouldNotExist1" not found' only.


### PR DESCRIPTION
Fixes #6719

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
