### PR TITLE
fix(plugins/plugin-client-common): width-constrained NavResponse UI should spend more space on content

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Navigation/Patternfly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Navigation/Patternfly.scss
@@ -19,6 +19,18 @@
 @import '../../PatternFly/common';
 
 body[kui-theme-style] {
+  @include NestedLeftNavWidthConstrained {
+    .pf-c-nav {
+      max-width: 15em;
+    }
+  }
+
+  @include NestedLeftNavInMinisplit {
+    .pf-c-nav {
+      max-width: 10em;
+    }
+  }
+
   @include Sidecar {
     .pf-c-nav {
       --pf-c-nav__list-toggle--FontSize: 1em;

--- a/plugins/plugin-client-common/web/scss/components/Sidecar/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Sidecar/_mixins.scss
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@import '../Terminal/_mixins';
+
 @mixin sidecar-maximized-no-user {
   .toggle-sidecar-maximization-button {
     display: none;
@@ -69,6 +71,22 @@
 @mixin NestedLeftNav {
   @include NestedSidecar {
     &[data-view='leftnav'] {
+      @content;
+    }
+  }
+}
+
+@mixin NestedLeftNavWidthConstrained {
+  @include WidthConstrained {
+    @include NestedLeftNav {
+      @content;
+    }
+  }
+}
+
+@mixin NestedLeftNavInMinisplit {
+  @include MiniSplit {
+    @include NestedLeftNav {
       @content;
     }
   }


### PR DESCRIPTION
Fixes #6742
![Screen Shot 2021-01-26 at 2 35 36 PM](https://user-images.githubusercontent.com/21212160/105895642-c27b2f80-5fe3-11eb-8930-c4b1c88258b8.png)
![Screen Shot 2021-01-26 at 2 35 58 PM](https://user-images.githubusercontent.com/21212160/105895686-cf981e80-5fe3-11eb-9cf7-e229e94f1dd8.png)


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
