### PR TITLE
fix(plugins/plugin-client-common): Dropdown hover effect in PatternFly4 Dark has no contrast

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/DropDown/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/DropDown/PatternFly.scss
@@ -15,22 +15,8 @@
  */
 
 @import '../StatusStripe/mixins';
+@import '../StatusStripe/StatusStripe.scss';
 @import '../Terminal/mixins';
-
-body[kui-theme-style='light'] {
-  @include StatusStripeElement {
-    .pf-c-dropdown__menu .pf-c-dropdown__menu-item {
-      color: var(--color-base00);
-    }
-  }
-}
-body[kui-theme-style='dark'] {
-  @include StatusStripeElement {
-    .pf-c-dropdown__menu .pf-c-dropdown__menu-item {
-      color: var(--color-text-01);
-    }
-  }
-}
 
 body[kui-theme-style] {
   @include BlockOutput {
@@ -42,6 +28,14 @@ body[kui-theme-style] {
   @include StatusStripeElement {
     .pf-c-dropdown__menu {
       max-height: 35rem;
+      background-color: $bg-type-default;
+
+      .pf-c-dropdown__menu-item {
+        &:hover,
+        &:focus {
+          background-color: $status-stripe-hover-bg-color;
+        }
+      }
     }
     .kui--dropdown__toggle {
       padding: 0;
@@ -50,11 +44,6 @@ body[kui-theme-style] {
       margin-left: 0.5rem;
       margin-right: 0;
     }
-
-    .pf-c-dropdown__toggle,
-    .pf-c-dropdown__toggle-text {
-      color: var(--color-text-01);
-    }
   }
 
   .pf-c-dropdown__toggle,
@@ -62,6 +51,7 @@ body[kui-theme-style] {
     display: flex;
     font-size: inherit;
     font-family: var(--font-sans-serif);
+    color: var(--color-text-01);
   }
 
   .pf-c-dropdown__toggle {
@@ -78,8 +68,14 @@ body[kui-theme-style] {
     background-color: var(--color-dropdown);
 
     .pf-c-dropdown__menu-item {
+      color: var(--color-text-01);
       font-size: inherit;
       font-family: var(--font-sans-serif);
+
+      &:hover,
+      &:focus {
+        background-color: var(--color-base02);
+      }
 
       svg[data-mode='selected container'] {
         /* need to override some enclosing hover effects from sidecar toolbar */

--- a/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
+++ b/plugins/plugin-client-common/web/scss/components/StatusStripe/StatusStripe.scss
@@ -32,6 +32,8 @@ $bg-type-red: var(--color-red);
 
 $element-padding: 1rem;
 
+$status-stripe-hover-bg-color: var(--color-table-border3);
+
 @include StatusStripe {
   display: flex;
   flex-basis: 2.25rem;
@@ -124,7 +126,7 @@ $element-padding: 1rem;
     &:not(.kui--status-stripe-tag-element) {
       cursor: pointer;
       color: $fg-type-default;
-      background-color: var(--color-table-border3);
+      background-color: $status-stripe-hover-bg-color;
     }
   }
 


### PR DESCRIPTION

![Screen Shot 2021-01-26 at 4 38 27 PM](https://user-images.githubusercontent.com/21212160/105908968-ebf08700-5ff4-11eb-99ac-280e2f29a18c.png)
![Screen Shot 2021-01-26 at 4 38 39 PM](https://user-images.githubusercontent.com/21212160/105908989-f3b02b80-5ff4-11eb-9098-9cc4c072d4ef.png)
![Screen Shot 2021-01-26 at 4 39 50 PM](https://user-images.githubusercontent.com/21212160/105909099-1cd0bc00-5ff5-11eb-8f56-6133962246b2.png)
![Screen Shot 2021-01-26 at 4 39 56 PM](https://user-images.githubusercontent.com/21212160/105909104-20644300-5ff5-11eb-94be-e5436d914b0a.png)





Fixes #6744

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
