### PR TITLE
fix: kubectl direct/get does not specify that get tables have the `on…

### DIFF
--- a/packages/test/src/api/util.ts
+++ b/packages/test/src/api/util.ts
@@ -321,12 +321,10 @@ export async function openSidecarByClick(
   selector: string,
   name: string,
   mode?: string,
-  activationId?: string
+  activationId?: string,
+  splitIndex = 2 // after we click, we expect two splits
 ) {
   const app = ctx.app
-
-  // after we click, we expect two splits
-  const splitIndex = 2
 
   // Note! if we already have 2 splits, we need to grab the count before we click! see https://github.com/IBM/kui/issues/6636
   const currentSplitCount = (await app.client.$$(Selectors.SPLITS)).length

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Snapshot.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Snapshot.ts
@@ -153,8 +153,8 @@ export class FlightRecorder {
         if (row.onclickIdempotent) {
           // look for onclicks in either the row, or a cell NAME
           const onclickHome =
-            typeof row.onclick === 'string' ? row : row.attributes.find(_ => _.onclick && _.key === 'NAME')
-          if (onclickHome) {
+            typeof row.onclick === 'string' ? row : row.attributes.find(_ => _.onclick && /Name/i.test(_.key))
+          if (onclickHome && typeof onclickHome.onclick === 'string') {
             const fakeTab = Object.assign({}, this.tab, { uuid: uuid() })
             const command = onclickHome.onclick
             onclickHome.onclick = {}
@@ -171,6 +171,8 @@ export class FlightRecorder {
 
             try {
               await fakeTab.REPL.pexec(command, { tab: fakeTab })
+            } catch (err) {
+              console.error('Error recording click', command, err)
             } finally {
               eventBus.offCommandStart(fakeTab.uuid, onCommandStart)
               eventBus.offCommandComplete(fakeTab.uuid, onCommandComplete)
@@ -196,7 +198,7 @@ export class FlightRecorder {
               await Promise.all(
                 _.completeEvent.response.modes.map(async mode => {
                   if (isScalarContent(mode)) {
-                     if (isTable(mode.content)) {
+                    if (isTable(mode.content)) {
                       await this.recordTable(mode.content)
                     }
                   }

--- a/plugins/plugin-kubectl/src/lib/view/formatTable.ts
+++ b/plugins/plugin-kubectl/src/lib/view/formatTable.ts
@@ -690,7 +690,10 @@ export function toKuiTable(
       key: forAllNamespaces ? row.object.metadata.namespace : columnDefinitions[0].name,
       rowKey: `${name}_${drilldownKind}_${row.object.metadata.namespace}`,
       name: forAllNamespaces ? row.object.metadata.namespace : name,
+
+      onclickIdempotent: true,
       onclick: forAllNamespaces ? false : onclick,
+
       attributes: cells.slice(forAllNamespaces ? 0 : 1).map((cell, idx) => {
         const key = columnDefinitions[forAllNamespaces ? idx : idx + 1].name.toUpperCase()
         const value = cell.toString()

--- a/plugins/plugin-kubectl/src/test/k8s3/replay.ts
+++ b/plugins/plugin-kubectl/src/test/k8s3/replay.ts
@@ -143,7 +143,9 @@ describe(`kubectl replay with clicks ${process.env.MOCHA_RUN_TARGET || ''}`, asy
         this,
         `${Selectors.OUTPUT_LAST} ${Selectors.BY_NAME('nginx')} .clickable`,
         'nginx',
-        defaultModeForGet
+        defaultModeForGet,
+        undefined,
+        1 // replayed clicks currently don't support opening in a split; see https://github.com/IBM/kui/issues/6785
       )
     } catch (err) {
       await Common.oops(this, true)(err)


### PR DESCRIPTION
…clickIdempotent` property

This also adds a minor improvement to the notebook snapshotter w.r.t. the NAME column. It was hard-coded to be "NAME"

Fixes #6778

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
