### PR TITLE
fix(plugins/plugin-kubectl): event watcher doesn't render well in minisplit

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableCell.tsx
@@ -126,7 +126,7 @@ export default function renderCell(table: KuiTable, kuiRow: KuiRow, justUpdated:
         key={cidx}
         className={cellClassName}
         onClick={onClickForCell(kuiRow, tab, repl, attributes[cidx - 1], table)}
-        modifier={!/NAME|NAMESPACE/i.test(key) ? 'fitContent' : undefined}
+        modifier={/MESSAGE/i.test(key) ? 'wrap' : !/NAME|NAMESPACE/i.test(key) ? 'fitContent' : undefined}
       >
         <span data-key={key} data-value={value} data-tag={tag} className={outerClassName}>
           {tag === 'badge' && (

--- a/plugins/plugin-kubectl/src/controller/client/direct/columns.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/columns.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Arguments } from '@kui-shell/core'
+import { formatOf, KubeOptions } from '../../kubectl/options'
+
+export default (kind: string, args: Pick<Arguments<KubeOptions>, 'parsedOptions'>) => {
+  return kind === 'Event' && formatOf(args) !== 'wide' ? ['Object', 'Reason', 'Message', 'Last Seen'] : undefined
+}

--- a/plugins/plugin-kubectl/src/lib/view/formatTable.ts
+++ b/plugins/plugin-kubectl/src/lib/view/formatTable.ts
@@ -91,7 +91,7 @@ const cssForKey = {
   NAME: 'entity-name',
   SOURCE: 'lighter-text smaller-text',
   SUBOBJECT: 'lighter-text smaller-text',
-  MESSAGE: 'somewhat-smaller-text pre-wrap slightly-deemphasize',
+  MESSAGE: 'somewhat-smaller-text pre-wrap',
   'CREATED AT': 'lighter-text smaller-text',
 
   AGE: 'slightly-deemphasize',
@@ -645,12 +645,20 @@ export function toKuiTable(
   kind: string,
   args: Pick<Arguments<KubeOptions>, 'parsedOptions' | 'execOptions' | 'REPL'>,
   drilldownCommand: string,
-  needsStatusColumn = false
+  needsStatusColumn = false,
+  customColumns?: string[]
 ): Table {
   const format = formatOf(args)
   const forAllNamespaces = isForAllNamespaces(args.parsedOptions)
-  const includedColumns = table.columnDefinitions.map(_ => format === 'wide' || _.priority === 0)
-  const columnDefinitions = table.columnDefinitions.filter(_ => format === 'wide' || _.priority === 0)
+  const includedColumns = table.columnDefinitions.map(_ =>
+    customColumns ? customColumns.includes(_.name) : format === 'wide' || _.priority === 0
+  )
+  const _columnDefinitions = table.columnDefinitions.filter(_ =>
+    customColumns ? customColumns.includes(_.name) : format === 'wide' || _.priority === 0
+  )
+  const columnDefinitions = customColumns
+    ? _columnDefinitions.slice().sort((a, b) => customColumns.indexOf(a.name) - customColumns.indexOf(b.name))
+    : _columnDefinitions
 
   const drilldownVerb = 'get'
   const drilldownKind = kind
@@ -681,14 +689,23 @@ export function toKuiTable(
   const nameColumnIdx = /Name/i.test(header.name) ? 0 : header.attributes.findIndex(_ => /Name/i.test(_.key)) + 1
 
   const body = table.rows.map(row => {
-    const cells = row.cells.filter((cell, idx) => includedColumns[idx])
+    const cells = row.cells
+      .filter((_, idx) => includedColumns[idx])
+      .map((cell, index) => ({ cell, index }))
+      .sort(
+        (a, b) =>
+          columnDefinitions.findIndex(_ => _.name === _columnDefinitions[a.index].name) -
+          columnDefinitions.findIndex(_ => _.name === _columnDefinitions[b.index].name)
+      )
+      .map(_ => _.cell)
+
     const name = cells[nameColumnIdx].toString()
-    const onclick = onclickFor(row, name)
+    const onclick = onclickFor(row, row.object.metadata.name)
 
     return {
       object: row.object,
-      key: forAllNamespaces ? row.object.metadata.namespace : columnDefinitions[0].name,
-      rowKey: `${name}_${drilldownKind}_${row.object.metadata.namespace}`,
+      key: forAllNamespaces ? row.object.metadata.namespace : columnDefinitions[0].name.toUpperCase(),
+      rowKey: `${row.object.metadata.name}_${drilldownKind}_${row.object.metadata.namespace}`,
       name: forAllNamespaces ? row.object.metadata.namespace : name,
       onclick: forAllNamespaces ? false : onclick,
       attributes: cells.slice(forAllNamespaces ? 0 : 1).map((cell, idx) => {

--- a/plugins/plugin-kubectl/src/test/k8s2/events-in-table.ts
+++ b/plugins/plugin-kubectl/src/test/k8s2/events-in-table.ts
@@ -59,7 +59,7 @@ commands.forEach(command => {
 
     it(`should open a events watcher and expect at least one event, since we just created the resource`, async () => {
       try {
-        await ReplExpect.okWithEvents(this, watchEventsRes)
+        await ReplExpect.okWithCustom({ selector: Selectors.TABLE_CELL(`pod/${name}`, 'OBJECT') })(watchEventsRes)
       } catch (err) {
         return Common.oops(this, true)(err)
       }


### PR DESCRIPTION
Fixes #6772

![Screen Shot 2021-01-27 at 4 16 12 PM](https://user-images.githubusercontent.com/21212160/106055133-fa08db00-60ba-11eb-985c-40cb6d8de826.png)
![Screen Shot 2021-01-27 at 4 16 23 PM](https://user-images.githubusercontent.com/21212160/106055150-012fe900-60bb-11eb-8d05-8d44dd6b34f1.png)
![Screen Shot 2021-01-27 at 4 16 31 PM](https://user-images.githubusercontent.com/21212160/106055163-05f49d00-60bb-11eb-8a85-2d06b038c482.png)


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
