### PR TITLE
fix: In PatternFly4 Light and Carbon Gray90 themes, new tab/new split buttons lack hover effect

### DIFF
--- a/plugins/plugin-carbon-themes/web/scss/colors.scss
+++ b/plugins/plugin-carbon-themes/web/scss/colors.scss
@@ -76,7 +76,7 @@
   --color-light-green: hsla(143, 73%, 43%, 50%);
   --color-light-yellow: hsla(46, 99%, 59%, 50%);
 
-  --color-table-border3: var(--color-base03);
+  --color-table-border3: var(--color-base04);
 }
 
 @mixin colors-light {

--- a/plugins/plugin-patternfly4-themes/web/scss/patternfly4-light.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/patternfly4-light.scss
@@ -48,7 +48,7 @@ body.kui--patternfly4[kui-theme='PatternFly4 Light'][kui-theme-style] {
 
   --color-table-border1: var(--pf-global--palette--black-200);
   --color-table-border2: var(--pf-global--palette--black-600);
-  --color-table-border3: var(--pf-global--palette--black-400);
+  --color-table-border3: var(--pf-global--palette--black-500);
 
   --color-sidecar-toolbar-background: var(--pf-global--palette--black-300);
 


### PR DESCRIPTION
PF4 Light theme:
![Screen Shot 2021-01-28 at 4 37 24 PM](https://user-images.githubusercontent.com/21212160/106201868-1a9e6700-6187-11eb-87e3-2226613733fe.png)

Carbon Gray 90:
![Screen Shot 2021-01-28 at 4 37 45 PM](https://user-images.githubusercontent.com/21212160/106201900-27bb5600-6187-11eb-8222-18b3138fb70d.png)



Fixes #6804

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
