### PR TITLE
fix: the x in the offline badge is sometimes low contrast, especially in dark themes

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Table/ErrorCell.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/ErrorCell.tsx
@@ -20,9 +20,9 @@ export default function ErrorCell() {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24">
       <g fill="none" fillRule="evenodd" stroke="none" strokeWidth="1">
-        <path fill="var(--color-base0E)" d="M0 0H24V24H0z"></path>
+        <path fill="var(--color-error-cell-bg)" d="M0 0H24V24H0z"></path>
         <path
-          fill="var(--color-base00)"
+          fill="var(--color-error-cell-text)"
           d="M15.0914286 16L12 12.9085714 8.90857143 16 8 15.0914286 11.0914286 12 8 8.90857143 8.90857143 8 12 11.0914286 15.0914286 8 16 8.90857143 12.9085714 12 16 15.0914286z"
         ></path>
       </g>

--- a/plugins/plugin-core-themes/web/scss/Mercury.scss
+++ b/plugins/plugin-core-themes/web/scss/Mercury.scss
@@ -70,6 +70,9 @@ $base0F: #a3685a;
   --color-green-rgb: var(--color-base0B-rgb);
 
   --color-table-border1: #82857b;
+
+  --color-error-cell-bg: var(--color-base0E);
+  --color-error-cell-text: var(--color-base05);
 }
 
 @mixin MercuryDark {

--- a/plugins/plugin-core-themes/web/scss/atelier-seaside.scss
+++ b/plugins/plugin-core-themes/web/scss/atelier-seaside.scss
@@ -41,4 +41,7 @@ body[kui-theme='Atelier'] {
   --color-latency-3: #f6e8c3;
   --color-latency-4: #d8b365;
   --color-latency-5: #8c510a;
+
+  --color-error-cell-bg: var(--color-base0E);
+  --color-error-cell-text: var(--color-base07);
 }

--- a/plugins/plugin-core-themes/web/scss/dracula.scss
+++ b/plugins/plugin-core-themes/web/scss/dracula.scss
@@ -48,4 +48,7 @@ body[kui-theme='Dracula'] {
   --color-latency-3: #e7d4e8;
   --color-latency-4: #af8dc3;
   --color-latency-5: #762a83;
+
+  --color-error-cell-bg: var(--color-base0E);
+  --color-error-cell-text: var(--color-base00);
 }

--- a/plugins/plugin-core-themes/web/scss/gruvbox-dark-medium.scss
+++ b/plugins/plugin-core-themes/web/scss/gruvbox-dark-medium.scss
@@ -36,4 +36,7 @@ body[kui-theme='Gruvbox'] {
   --color-latency-3: #e7d4e8;
   --color-latency-4: #af8dc3;
   --color-latency-5: #762a83;
+
+  --color-error-cell-bg: var(--color-base0E);
+  --color-error-cell-text: var(--color-base00);
 }

--- a/plugins/plugin-core-themes/web/scss/light.scss
+++ b/plugins/plugin-core-themes/web/scss/light.scss
@@ -122,4 +122,7 @@ body[kui-theme='Light'] {
   --color-stripe-02: var(--color-base04);
   --color-sidecar-toolbar-background: #d7dce3;
   --color-sidecar-toolbar-foreground: var(--color-base06);
+
+  --color-error-cell-bg: var(--color-base0E);
+  --color-error-cell-text: var(--color-base00);
 }

--- a/plugins/plugin-core-themes/web/scss/lucario.scss
+++ b/plugins/plugin-core-themes/web/scss/lucario.scss
@@ -40,4 +40,7 @@ body[kui-theme='Lucario'] {
   --color-latency-3: #e7d4e8;
   --color-latency-4: #af8dc3;
   --color-latency-5: #762a83;
+
+  --color-error-cell-bg: var(--color-base0E);
+  --color-error-cell-text: var(--color-base00);
 }

--- a/plugins/plugin-core-themes/web/scss/monokai.scss
+++ b/plugins/plugin-core-themes/web/scss/monokai.scss
@@ -29,4 +29,7 @@ body[kui-theme='Monokai'] {
   --color-red-rgb: var(--color-base08-rgb);
   --color-base0B-rgb: 166, 226, 46;
   --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-error-cell-bg: var(--color-base0E);
+  --color-error-cell-text: var(--color-base00);
 }

--- a/plugins/plugin-core-themes/web/scss/nord.scss
+++ b/plugins/plugin-core-themes/web/scss/nord.scss
@@ -43,4 +43,7 @@ body[kui-theme='Nord'] {
   --color-latency-3: #fee090;
   --color-latency-4: #fc8d59;
   --color-latency-5: #d73027;
+
+  --color-error-cell-bg: var(--color-latency-4);
+  --color-error-cell-text: var(--color-base00);
 }

--- a/plugins/plugin-core-themes/web/scss/paraiso.scss
+++ b/plugins/plugin-core-themes/web/scss/paraiso.scss
@@ -37,4 +37,7 @@ body[kui-theme='Paraiso'] {
   --color-latency-3: #fee0b6;
   --color-latency-4: #f1a340;
   --color-latency-5: #b35806;
+
+  --color-error-cell-bg: var(--color-base0E);
+  --color-error-cell-text: var(--color-base00);
 }

--- a/plugins/plugin-core-themes/web/scss/solarized-dark.scss
+++ b/plugins/plugin-core-themes/web/scss/solarized-dark.scss
@@ -43,4 +43,7 @@ body[kui-theme='Solarized'] {
   --color-latency-3: #fee090;
   --color-latency-4: #fc8d59;
   --color-latency-5: #d73027;
+
+  --color-error-cell-bg: var(--color-base0E);
+  --color-error-cell-text: var(--color-base00);
 }

--- a/plugins/plugin-core-themes/web/scss/tomorrow-night.scss
+++ b/plugins/plugin-core-themes/web/scss/tomorrow-night.scss
@@ -35,4 +35,7 @@ body[kui-theme='tomorrow-night'] {
   --color-red-rgb: var(--color-base08-rgb);
   --color-base0B-rgb: 181, 189, 104;
   --color-green-rgb: var(--color-base0B-rgb);
+
+  --color-error-cell-bg: var(--color-base0E);
+  --color-error-cell-text: var(--color-base00);
 }

--- a/plugins/plugin-patternfly4-themes/web/scss/patternfly4-dark.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/patternfly4-dark.scss
@@ -56,6 +56,9 @@ body.kui--patternfly4[kui-theme='PatternFly4 Dark'][kui-theme-style] {
 
   --color-dropdown: var(--pf-global--palette--black-700);
 
+  --color-error-cell-bg: var(--color-base0E);
+  --color-error-cell-text: var(--color-base07);
+
   @include charts-dark;
   @include patternfly-sidecar;
 

--- a/plugins/plugin-patternfly4-themes/web/scss/patternfly4-light.scss
+++ b/plugins/plugin-patternfly4-themes/web/scss/patternfly4-light.scss
@@ -60,6 +60,9 @@ body.kui--patternfly4[kui-theme='PatternFly4 Light'][kui-theme-style] {
   --color-yellow-sidecar: var(--pf-global--palette--gold-200);
   --color-green-sidecar: var(--pf-global--palette--green-200);
 
+  --color-error-cell-bg: var(--color-base0E);
+  --color-error-cell-text: var(--color-base00);
+
   @include patternfly-sidecar;
   @include charts-light;
 }


### PR DESCRIPTION
Fixes #6784

Fixed PF Dark, Nord, Solarized-dark, Atelier and Mercury
![Screen Shot 2021-01-29 at 4 38 00 PM](https://user-images.githubusercontent.com/21212160/106329950-5b15e780-6250-11eb-9327-a42ece97584e.png)
![Screen Shot 2021-01-29 at 4 38 22 PM](https://user-images.githubusercontent.com/21212160/106329978-6701a980-6250-11eb-9939-dcb74c2babdd.png)
![Screen Shot 2021-01-29 at 4 38 30 PM](https://user-images.githubusercontent.com/21212160/106329989-6bc65d80-6250-11eb-890e-02e0a0cc19fc.png)
![Screen Shot 2021-01-29 at 4 38 36 PM](https://user-images.githubusercontent.com/21212160/106329994-6ff27b00-6250-11eb-8f97-43b8adff0269.png)
![Screen Shot 2021-01-29 at 4 38 46 PM](https://user-images.githubusercontent.com/21212160/106330012-7680f280-6250-11eb-9729-7cd152f17366.png)





<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
