### PR TITLE
fix(plugins/plugin-kubectl): multikind table isn't unified correctly when some rows are offline

### DIFF
--- a/plugins/plugin-kubectl/src/controller/client/direct/unify.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/unify.ts
@@ -89,21 +89,21 @@ export function unifyRow(row: Row, kind: string): Row {
   const trafficLight = badgeColumnIdx >= 0 ? toTrafficLight(row.attributes[badgeColumnIdx].css) : TrafficLight.Gray
 
   const extraAttrs: Cell[] = []
-  if (row.object) {
-    const tier =
-      getFromLabel(row.object, 'tier') ||
+  const tier = row.object
+    ? getFromLabel(row.object, 'tier') ||
       getFromLabel(row.object, 'app.kubernetes.io/component') ||
       getFromSelector(row.object, 'tier')
+    : ''
 
-    extraAttrs.push({ key: 'Tier', value: tier || '' })
+  extraAttrs.push({ key: 'Tier', value: tier })
 
-    const app =
-      getFromLabel(row.object, 'app') ||
+  const app = row.object
+    ? getFromLabel(row.object, 'app') ||
       getFromLabel(row.object, 'app.kubernetes.io/name') ||
       getFromSelector(row.object, 'app')
+    : ''
 
-    extraAttrs.push({ key: 'Application', value: app || '' })
-  }
+  extraAttrs.push({ key: 'Application', value: app })
 
   return rowWith(name, kind, status, trafficLight, row, extraAttrs)
 }


### PR DESCRIPTION

![Screen Shot 2021-01-29 at 5 24 30 PM](https://user-images.githubusercontent.com/21212160/106333524-d9758800-6256-11eb-9be6-e9ced68ebaa2.png)



Fixes #6865

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
