### PR TITLE
fix(plugins/plugin-client-common): Sidecar sticks to a short height when switching from Yaml -> Summary -> Yaml tab

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
+++ b/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
@@ -117,7 +117,6 @@ export default class KuiContent extends React.Component<KuiMMRProps, State> {
           <Editor
             content={mode}
             readOnly={false}
-            sizeToFit
             willUpdateToolbar={willUpdateToolbar}
             response={response}
             repl={tab.REPL}
@@ -131,7 +130,6 @@ export default class KuiContent extends React.Component<KuiMMRProps, State> {
           contentType={mode.contentType}
           originalContent={mode.content.a}
           modifiedContent={mode.content.b}
-          sizeToFit
           response={response}
           renderSideBySide
           tabUUID={tab.uuid}

--- a/plugins/plugin-client-common/web/scss/components/Editor/Editor.scss
+++ b/plugins/plugin-client-common/web/scss/components/Editor/Editor.scss
@@ -34,6 +34,7 @@
 
   .monaco-editor {
     display: block;
+    min-height: 20rem;
   }
   .monaco-editor {
     background: transparent;


### PR DESCRIPTION
Fixed by removing sizeToFit in Editor and setting monaco-editor min-height to 20rem
![Screen Shot 2021-02-01 at 5 19 30 PM](https://user-images.githubusercontent.com/21212160/106525223-a7139700-64b1-11eb-915d-1c76925a4b8c.png)

Fixes #6913

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
