### PR TITLE
feat(packages/core): Allow clients to define the contents of the Note…

### DIFF
--- a/packages/core/src/main/notebooks.ts
+++ b/packages/core/src/main/notebooks.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MenuItemConstructorOptions, webContents } from 'electron'
+
+import tellRendererToExecute from './tell'
+import encodeComponent from '../repl/encode'
+
+interface OpenNotebookItem {
+  label: string
+  click: () => void
+}
+
+interface NotebookDefinitionMenuItem {
+  notebook: string
+  filepath: string
+}
+
+interface SeparatorMenuItem {
+  type: 'separator'
+}
+
+type NotebookMenuItem = NotebooksMenu | NotebookDefinitionMenuItem | SeparatorMenuItem
+
+interface NotebooksMenu {
+  label: string
+  submenu: NotebookMenuItem[]
+}
+
+/** Open a new window or tab and replay the contents of the given `filepath` */
+export function replay(filepath: string, createWindow: (executeThisArgvPlease?: string[]) => void) {
+  try {
+    // if we have no open kui windows, open a new one; otherwise,
+    // use a tab in an existing window
+    if (webContents.getAllWebContents().length === 0) {
+      createWindow(['replay', filepath])
+    } else {
+      tellRendererToExecute(`replay ${encodeComponent(filepath)}`, 'pexec')
+    }
+  } catch (err) {
+    console.log(err)
+  }
+}
+
+/** @return a menu item that opens the given notebook */
+export function openNotebook(
+  createWindow: (executeThisArgvPlease?: string[]) => void,
+  label: string,
+  filepath: string
+): OpenNotebookItem {
+  return {
+    label,
+    click: () => replay(filepath, createWindow)
+  }
+}
+
+function isNotebooksMenu(item: NotebookMenuItem): item is NotebooksMenu {
+  const menu = item as NotebooksMenu
+  return typeof menu.label === 'string' && Array.isArray(menu.submenu)
+}
+
+function isNotebookDefinitionMenuItem(item: NotebookMenuItem): item is NotebookDefinitionMenuItem {
+  const nbItem = item as NotebookDefinitionMenuItem
+  return typeof nbItem.notebook === 'string' && typeof nbItem.filepath === 'string'
+}
+
+/** We only need to replace the NotebookDefinitionMenuItem with calls to our `notebook` helper */
+export function clientNotebooksDefinitionToElectron(
+  defn: NotebooksMenu,
+  notebook: (label: string, filepath: string) => OpenNotebookItem
+): MenuItemConstructorOptions {
+  if (defn) {
+    return Object.assign(
+      {},
+      {
+        label: defn.label,
+        submenu: defn.submenu.map(item => {
+          if (isNotebooksMenu(item)) {
+            return clientNotebooksDefinitionToElectron(item, notebook)
+          } else if (isNotebookDefinitionMenuItem(item)) {
+            // this is the only mogrifier
+            return notebook(item.notebook, item.filepath)
+          } else {
+            // separator, no change
+            return item
+          }
+        })
+      }
+    )
+  }
+}
+
+/** @return the client's definition of a Notebooks menu */
+export function loadClientNotebooksMenuDefinition(): NotebooksMenu {
+  try {
+    return require('@kui-shell/client/config.d/notebooks.json') as NotebooksMenu
+  } catch (err) {
+    return undefined
+  }
+}

--- a/packages/core/src/main/open.ts
+++ b/packages/core/src/main/open.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { replay } from './menu'
+import { replay } from './notebooks'
 
 export const filters = [{ name: 'Kui snapshot', extensions: ['kui', 'json'] }]
 

--- a/packages/core/src/main/spawn-electron.ts
+++ b/packages/core/src/main/spawn-electron.ts
@@ -600,7 +600,7 @@ export async function initElectron(
 
   // See menu.ts; Open Recent leads here
   app.on('open-file', async (evt: Event, filepath: string) => {
-    const { replay } = await import('./menu')
+    const { replay } = await import('./notebooks')
     replay(filepath, createWindowWithArgv)
   })
 

--- a/plugins/plugin-client-default/config.d/notebooks.json
+++ b/plugins/plugin-client-default/config.d/notebooks.json
@@ -1,0 +1,30 @@
+{
+  "label": "Notebooks",
+  "submenu": [
+    { "notebook": "Welcome to Kui", "filepath": "/kui/welcome.json" },
+    { "type": "separator" },
+    {
+      "label": "Learning Kubernetes",
+      "submenu": [
+        {
+          "label": "Kubernetes",
+          "submenu": [
+            { "notebook": "CRUD Operations", "filepath": "/kui/kubernetes/crud-operations.json" },
+            { "notebook": "Working with Jobs", "filepath": "/kui/kubernetes/create-jobs.json" },
+            { "notebook": "Deploying Applications", "filepath": "/kui/kubernetes/deploy-applications.json" }
+          ]
+        },
+        {
+          "label": "iter8",
+          "submenu": [{ "notebook": "Welcome to iter8", "filepath": "/kui/iter8/welcome.json" }]
+        }
+      ]
+    },
+    {
+      "label": "Dashboard",
+      "submenu": [{ "notebook": "Kubernetes Dashboard", "filepath": "/kui/kubernetes/dashboard.json" }]
+    },
+    { "type": "separator" },
+    { "notebook": "Make Your Own Notebook", "filepath": "/kui/make-notebook.json" }
+  ]
+}


### PR DESCRIPTION
…books menu.

Previously, the contents of this menu were hard-coded into menu.ts. Now, they can be defined in config.d/notebooks.json.

See plugin-client-default/config.d/notebooks.json for an example.

The schema of this file matches that of electron's MenuItemConstructorOptions, except that the non-separator, non-submenu, menu items (i.e. those that launch a notebook) have this schema:

```typescript
{
  /* The label to use for the menu item. Usually the title of a notebook */
  notebook: string

  /* The Kui VFS filepath to this notebook, e.g. /kui/kubernetes/crud.json */
  filepath: string
}
```

To mount a notebook in the VFS, see the calls to `notebookVFS.mkdir` and `notebookVFS.cp` in plugin-kubectl/src/non-headless-preload.ts.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
