### PR TITLE
fix(plugins/plugin-client-common): Sidecar sticks to a short height w…

### DIFF
--- a/packages/test/src/api/util.ts
+++ b/packages/test/src/api/util.ts
@@ -278,10 +278,13 @@ export function uniqueFileForSnapshot() {
 /** Click the close button on a block, and expect it to be gone */
 export async function removeBlock(res: AppAndCount) {
   const N = res.count
-  await res.app.client.$(Selectors.PROMPT_N(N)).then(_ => _.moveTo())
+  const prompt = await res.app.client.$(Selectors.PROMPT_N(N))
+  await prompt.scrollIntoView()
+  await prompt.moveTo()
 
   const removeButton = await res.app.client.$(Selectors.BLOCK_REMOVE_BUTTON(N))
-  await removeButton.waitForDisplayed()
+  await removeButton.scrollIntoView()
+  await removeButton.waitForDisplayed({ timeout: CLI.waitTimeout })
   await removeButton.click()
 }
 

--- a/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
+++ b/plugins/plugin-client-common/src/components/Content/KuiContent.tsx
@@ -117,7 +117,6 @@ export default class KuiContent extends React.Component<KuiMMRProps, State> {
           <Editor
             content={mode}
             readOnly={false}
-            sizeToFit
             willUpdateToolbar={willUpdateToolbar}
             response={response}
             repl={tab.REPL}
@@ -131,7 +130,6 @@ export default class KuiContent extends React.Component<KuiMMRProps, State> {
           contentType={mode.contentType}
           originalContent={mode.content.a}
           modifiedContent={mode.content.b}
-          sizeToFit
           response={response}
           renderSideBySide
           tabUUID={tab.uuid}

--- a/plugins/plugin-client-common/web/scss/components/Editor/Editor.scss
+++ b/plugins/plugin-client-common/web/scss/components/Editor/Editor.scss
@@ -34,6 +34,7 @@
 
   .monaco-editor {
     display: block;
+    min-height: 23rem;
   }
   .monaco-editor {
     background: transparent;


### PR DESCRIPTION
…hen switching from Yaml -> Summary -> Yaml tab

Fixed by removing sizeToFit in Editor and setting monaco-editor min-height to 20rem

Fixes #6913
Closes #6924

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
