### PR TITLE
10.1.0

### DIFF
--- a/packages/core/src/core/jobs/job.ts
+++ b/packages/core/src/core/jobs/job.ts
@@ -24,5 +24,11 @@ export interface FlowControllable {
   write(data: string): void
 }
 
+export type Suspendable = Omit<FlowControllable, 'write'>
+
 /** in the future, a WatchableJob may be more than Abortable, e.g. Suspendable */
-export type WatchableJob = Abortable
+export type WatchableJob = Abortable & Partial<Suspendable>
+
+export function isSuspendable(watch: Partial<Suspendable>) {
+  return watch.xon && watch.xoff
+}

--- a/packages/core/src/core/jobs/watchable.ts
+++ b/packages/core/src/core/jobs/watchable.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Abortable } from './job'
+import { WatchableJob } from './job'
 import { Entity } from '../../models/entity'
 import { Row } from '../../webapp/models/table'
 
@@ -28,7 +28,7 @@ export interface Watcher {
 }
 
 export interface Watchable {
-  watch: Watcher & Abortable
+  watch: Watcher & WatchableJob
 }
 
 /** callbacks to indicate state changes */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -102,7 +102,7 @@ export {
   isMetadataBearing as isResourceWithMetadata
 } from './models/entity'
 export { isWatchable, Watchable, Watcher, WatchPusher } from './core/jobs/watchable'
-export { Abortable, FlowControllable } from './core/jobs/job'
+export { Abortable, FlowControllable, Suspendable, isSuspendable } from './core/jobs/job'
 import { Tab } from './webapp/tab'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { getHistoryForTab } from './models/history'

--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -198,6 +198,10 @@ export const TABLE_CELL = (rowKey: string, cellKey: string) => `tbody [data-name
 export const TABLE_SHOW_AS_GRID = (N: number) => `${OUTPUT_N(N)} .kui--toolbar-button-as-grid`
 export const TABLE_SHOW_AS_SEQUENCE = (N: number) => `${OUTPUT_N(N)} .kui--toolbar-button-as-sequence`
 export const TABLE_SHOW_AS_LIST = (N: number) => `${OUTPUT_N(N)} .kui--toolbar-button-as-list`
+export const WATCH_LIVE_BUTTON = (N: number, splitIndex = 1) =>
+  `${OUTPUT_N(N, splitIndex)} .kui--toolbar-button-watch[data-online="true"]`
+export const WATCH_OFFLINE_BUTTON = (N: number, splitIndex = 1) =>
+  `${OUTPUT_N(N, splitIndex)} .kui--toolbar-button-watch[data-online="false"]`
 export const TABLE_PAGINATION_FORWARD = (N: number) =>
   `${OUTPUT_N(N)} .kui--data-table-toolbar-pagination button.bx--pagination__button--forward`
 export const TABLE_PAGINATION_BACKWARD = (N: number) =>

--- a/plugins/plugin-client-common/i18n/resources_en_US.json
+++ b/plugins/plugin-client-common/i18n/resources_en_US.json
@@ -59,5 +59,7 @@
   "Settings": "Settings",
   "Switch theme": "Switch theme",
   "Show as table in terminal": "Show as table in terminal",
+  "Pause watcher": "Pause this watcher",
+  "Resume watcher": "Resume this watcher",
   "Close watcher": "Close and terminate this watcher"
 }

--- a/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
@@ -117,7 +117,7 @@ export default class LivePaginatedTable extends PaginatedTable<LiveProps, LiveSt
   protected caption() {
     if (this.state.lastUpdatedMillis) {
       const icon = this.state.isWatching ? 'Eye' : 'EyeSlash'
-      const iconColor = this.state.isWatching ? 'green-text' : 'red-text'
+      const iconColor = this.state.isWatching ? 'green-text' : 'sub-text'
       const watchControlDescription = this.state.isWatching ? strings('Pause watcher') : strings('Resume watcher')
 
       return (

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -1072,7 +1072,10 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
       scrollback.facade.splitCount = () => this.state.splits.length
       scrollback.facade.hasSideBySideTerminals = () =>
         this.theseAreMiniSplits[this.state.splits.length].findIndex((isMini, idx, S) => {
-          return !isMini && idx < S.length - 1 && !S[idx + 1]
+          return (
+            (!isMini && idx < S.length - 1 && !S[idx + 1]) ||
+            (!isMini && idx === S.length - 1 && S[idx - 1] && S[idx - 2])
+          ) // e.g. 3 splits
         }) >= 0
 
       scrollback.facade.scrollToBottom = () => {

--- a/plugins/plugin-kubectl/src/controller/client/direct/watch.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/watch.ts
@@ -15,7 +15,7 @@
  */
 
 import Debug from 'debug'
-import { Abortable, Arguments, FlowControllable, Row, Table, Watchable, Watcher, WatchPusher } from '@kui-shell/core'
+import { Abortable, Arguments, Row, Suspendable, Table, Watchable, Watcher, WatchPusher } from '@kui-shell/core'
 
 import { Group, isObjectInGroup } from './group'
 import columnsOf from './columns'
@@ -42,12 +42,12 @@ interface WatchUpdate {
   object: MetaTable
 }
 
-export abstract class DirectWatcher implements Watcher, Abortable, Omit<FlowControllable, 'write'> {
+export abstract class DirectWatcher implements Watcher, Abortable, Suspendable {
   /** The table push API */
   protected pusher: WatchPusher
 
   /** The current stream jobs. These will be aborted/flow-controlled as directed by the associated view. */
-  protected jobs: (Abortable & FlowControllable)[] = []
+  protected jobs: (Abortable & Suspendable)[] = []
 
   abstract init(pusher: WatchPusher): void
 
@@ -274,7 +274,7 @@ export class SingleKindDirectWatcher extends DirectWatcher implements Abortable,
   }
 
   /** The streamer is almost ready. We give it back a stream to push data to */
-  public onInitForBodyUpdates(job: Abortable & FlowControllable) {
+  public onInitForBodyUpdates(job: Abortable & Suspendable) {
     this.jobs.push(job)
     return this.onData.bind(this)
   }

--- a/plugins/plugin-kubectl/src/test/k8s1/aaa-get-namespaces-with-watch-via-table.ts
+++ b/plugins/plugin-kubectl/src/test/k8s1/aaa-get-namespaces-with-watch-via-table.ts
@@ -148,6 +148,19 @@ const watchNS = function(this: Common.ISuite, kubectl: string) {
 
         // and, conversely, that watch had better eventually show Offline
         await this.app.client.$(watchBadgeButOffline).then(_ => _.waitForExist())
+
+        // hit the pause watcher button in get -w
+        await this.app.client.$(Selectors.WATCH_LIVE_BUTTON(testWatch.count)).then(_ => _.click())
+        await this.app.client.$(Selectors.WATCH_OFFLINE_BUTTON(testWatch.count))
+        // create again
+        await waitForOnline(await CLI.command(`${kubectl} create ns ${nsNameForIter}`, this.app))
+        // get -w should stay red
+        await this.app.client.$(watchBadgeButOffline).then(_ => _.waitForExist())
+        // hit the resume watcher button in get -w
+        await this.app.client.$(Selectors.WATCH_OFFLINE_BUTTON(testWatch.count)).then(_ => _.click())
+        await this.app.client.$(Selectors.WATCH_LIVE_BUTTON(testWatch.count))
+        // get -w should be green
+        await this.app.client.$(watchBadge).then(_ => _.waitForExist())
       } catch (err) {
         await Common.oops(this, true)(err)
       }


### PR DESCRIPTION
[10.1.0 279ceeaa3] feat: pause and resume watchable jobs
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Tue Feb 2 10:45:26 2021 -0500
 8 files changed, 73 insertions(+), 10 deletions(-)

[10.1.0 fab7ab940] fix(plugins/plugin-client-common): The pause watching icon should be grey
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Tue Feb 2 17:26:03 2021 -0500
 1 file changed, 1 insertion(+), 1 deletion(-)

Auto-merging plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
[10.1.0 4fca72bc5] fix(plugins/plugin-client-common): when there're 3 splits, clicking table in the first split will create the 4th split
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Tue Feb 2 17:04:42 2021 -0500
 1 file changed, 4 insertions(+), 1 deletion(-)

Auto-merging plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
[10.1.0 afa4c5882] fix(plugins/plugin-client-common): redirectToPlainSplitIfNeeded may favor smaller terminals
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Tue Feb 2 16:09:00 2021 -0500
 1 file changed, 21 insertions(+), 5 deletions(-)