### PR TITLE
fix(plugins/plugin-client-common): Markdown links should have a tooltip

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Markdown.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown.tsx
@@ -25,6 +25,7 @@ import { REPL, Tab as KuiTab, getPrimaryTabId } from '@kui-shell/core'
 // GitHub Flavored Markdown plugin; see https://github.com/IBM/kui/issues/6563
 import gfm from 'remark-gfm'
 
+import Tooltip from '../spi/Tooltip'
 import CodeSnippet from '../spi/CodeSnippet'
 const SimpleEditor = React.lazy(() => import('./Editor/SimpleEditor'))
 
@@ -176,7 +177,11 @@ export default class Markdown extends React.PureComponent<Props> {
             } else if (!isLocal && this.props.noExternalLinks) {
               return <span className={this.props.className}>{props.href}</span>
             } else {
-              return <a className="bx--link" {...props} target={target} onClick={onClick} />
+              return (
+                <Tooltip markdown={`### External Link\n#### ${props.href}\n\n\`Link will open in a separate window\``}>
+                  <a className="bx--link" {...props} target={target} onClick={onClick} />
+                </Tooltip>
+              )
             }
           },
           code: props => {

--- a/plugins/plugin-client-common/src/index.ts
+++ b/plugins/plugin-client-common/src/index.ts
@@ -58,6 +58,7 @@ export { default as Button } from './components/spi/Button'
 export { default as Card } from './components/spi/Card'
 export { default as Popover } from './components/spi/Popover'
 export { default as Tag } from './components/spi/Tag'
+export { default as Tooltip } from './components/spi/Tooltip'
 
 // Input components
 export {

--- a/plugins/plugin-client-common/web/scss/components/Tooltip/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Tooltip/PatternFly.scss
@@ -48,6 +48,10 @@ $bgcolor: var(--color-base06);
       color: var(--color-base02);
       font-family: var(--font-sans-serif);
     }
+
+    a[href] {
+      color: var(--color-base0F);
+    }
   }
 
   & > div {


### PR DESCRIPTION
This PR also exports the Tooltip spi from plugin-client-common.

Fixes #6939

See the issue for a screenshot.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
