### PR TITLE
fix(plugins/plugin-kubectl): `oc login` does not invalidate the kubectl proxy

### DIFF
--- a/plugins/plugin-kubectl/oc/src/controller/oc/login.ts
+++ b/plugins/plugin-kubectl/oc/src/controller/oc/login.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 IBM Corporation
+ * Copyright 2021 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,12 @@
  */
 
 import { Registrar } from '@kui-shell/core'
+import { doExecWithPty, commandPrefix, emitKubectlConfigChangeEvent } from '@kui-shell/plugin-kubectl'
 
-import raw from './controller/raw'
-import login from './controller/oc/login'
-import getProjects from './controller/oc/get/projects'
-import delegates from './controller/kubectl/delegates'
-import catchall from './controller/kubectl/catchall'
-
-export default (registrar: Registrar) => {
-  delegates(registrar)
-  getProjects(registrar)
-  raw(registrar)
-  login(registrar)
-  catchall(registrar)
+export default function registerOcLogin(registrar: Registrar) {
+  registrar.listen(`/${commandPrefix}/oc/login`, async args => {
+    const response = await doExecWithPty(args)
+    emitKubectlConfigChangeEvent('SetNamespaceOrContext')
+    return response
+  })
 }


### PR DESCRIPTION
Fixes #6955

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
