### PR TITLE
fix(plugins/plugin-client-common): blocks with Processing commands cannot be removed

### DIFF
--- a/plugins/plugin-bash-like/web/scss/xterm.scss
+++ b/plugins/plugin-bash-like/web/scss/xterm.scss
@@ -114,7 +114,7 @@ body[kui-theme-style] .kui--tab-content {
   }
   .xterm-container .xterm-rows:not(.xterm-focus) .xterm-cursor.xterm-cursor-block {
     background-color: var(--color-base03);
-    outline-color: transparent;
+    outline-color: var(--color-base04);
   }
 
   /* rules for terminated xterm */

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Actions.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Actions.tsx
@@ -20,7 +20,7 @@ import { Tab, i18n, isOfflineClient } from '@kui-shell/core'
 import { InputOptions } from './Input'
 import { SupportedIcon } from '../../../spi/Icons'
 import TwoFaceIcon from '../../../spi/Icons/TwoFaceIcon'
-import BlockModel, { hasUUID, isOutputOnly } from './BlockModel'
+import BlockModel, { hasUUID, isOutputOnly, isRerunable } from './BlockModel'
 
 const strings = i18n('plugin-client-common')
 
@@ -53,6 +53,7 @@ export default class Actions extends React.PureComponent<Props> {
     if (
       !isOfflineClient() &&
       hasUUID(this.props.model) &&
+      isRerunable(this.props.model) &&
       !isOutputOnly(this.props.model) &&
       this.props.tab &&
       this.props.command

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -610,7 +610,7 @@ export default class Input extends InputProvider {
 
   /** DropDown menu for completed blocks */
   private actions(command: string) {
-    if (isFinished(this.props.model) && !!this.props.tab && !!this.props.model) {
+    if ((isFinished(this.props.model) || isProcessing(this.props.model)) && !!this.props.tab && !!this.props.model) {
       return <Actions command={command} idx={this.props.idx} {...this.props} />
     }
   }


### PR DESCRIPTION
Also improves the cursor discoverability in an unfocused pty block

Fixes #6954

![Screen Shot 2021-02-04 at 3 10 24 PM](https://user-images.githubusercontent.com/21212160/106949561-1c25dd00-66fb-11eb-9048-10aa9cc048b8.png)


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
