### PR TITLE
10.1.2

### DIFF
--- a/packages/core/src/main/menu.ts
+++ b/packages/core/src/main/menu.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-18 IBM Corporation
+ * Copyright 2017-21 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,7 +133,7 @@ export const install = (createWindow: (executeThisArgvPlease?: string[]) => void
       }
     ]
 
-    const menuTemplate: MenuItemConstructorOptions[] = [
+    const fileMenu: MenuItemConstructorOptions[] = [
       {
         label: 'File',
         submenu: fileMenuItems
@@ -151,8 +151,10 @@ export const install = (createWindow: (executeThisArgvPlease?: string[]) => void
           { role: 'delete' },
           { role: 'selectAll' }
         ]
-      },
+      }
+    ]
 
+    const viewMenu: MenuItemConstructorOptions[] = [
       {
         label: 'View',
         submenu: [
@@ -171,8 +173,10 @@ export const install = (createWindow: (executeThisArgvPlease?: string[]) => void
           { type: 'separator' },
           { role: 'togglefullscreen' }
         ]
-      },
-      notebookMenuItem,
+      }
+    ]
+
+    const windowMenu: MenuItemConstructorOptions[] = [
       {
         role: 'window',
         submenu: [{ role: 'minimize' }, { role: 'close', accelerator: closeAccelerator }]
@@ -183,6 +187,11 @@ export const install = (createWindow: (executeThisArgvPlease?: string[]) => void
         submenu: helpMenuItems
       }
     ]
+
+    const menuTemplate: MenuItemConstructorOptions[] = fileMenu
+      .concat(viewMenu)
+      .concat(notebookMenuItem ? [notebookMenuItem] : [])
+      .concat(windowMenu)
 
     const about: MenuItemConstructorOptions = {
       label: `About ${productName}`,

--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -223,6 +223,7 @@ export const TABLE_AS_SEQUENCE = (N: number) => `${OUTPUT_N(N)} .kui--data-table
 export const TABLE_AS_SEQUENCE_BAR = (N: number) => `${TABLE_AS_SEQUENCE(N)} .kui--bar`
 export const TABLE_AS_SEQUENCE_BAR_WIDTH = (N: number, width: string) =>
   `${TABLE_AS_SEQUENCE(N)} .kui--bar[data-width="${width}]`
+export const _TABLE_EMPTY = `.kui--table-like-wrapper tbody td[data-is-empty="true"]`
 
 const _TABLE_TITLE = `.kui--data-table-title`
 export const TABLE_TITLE = (N: number) => `${OUTPUT_N(N)} ${_TABLE_TITLE}`

--- a/plugins/plugin-bash-like/web/scss/xterm.scss
+++ b/plugins/plugin-bash-like/web/scss/xterm.scss
@@ -114,7 +114,7 @@ body[kui-theme-style] .kui--tab-content {
   }
   .xterm-container .xterm-rows:not(.xterm-focus) .xterm-cursor.xterm-cursor-block {
     background-color: var(--color-base03);
-    outline-color: transparent;
+    outline-color: var(--color-base04);
   }
 
   /* rules for terminated xterm */

--- a/plugins/plugin-client-common/i18n/resources_en_US.json
+++ b/plugins/plugin-client-common/i18n/resources_en_US.json
@@ -58,6 +58,7 @@
   "Try getting started": "Try getting started",
   "Settings": "Settings",
   "Switch theme": "Switch theme",
+  "No results found": "No results found",
   "Show as table in terminal": "Show as table in terminal",
   "Pause watcher": "Pause this watcher",
   "Resume watcher": "Resume this watcher",

--- a/plugins/plugin-client-common/src/components/Content/Markdown.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Markdown.tsx
@@ -140,14 +140,16 @@ export default class Markdown extends React.PureComponent<Props> {
           },
 
           link: props => {
+            const isKuiCommand = props.href.startsWith('#kuiexec?command=')
             const isLocal = !/^http/i.test(props.href)
             const target = !isLocal ? '_blank' : undefined
+
             const onClick = !isLocal
               ? (evt: React.MouseEvent) => evt.stopPropagation()
               : async (evt: React.MouseEvent) => {
                   evt.stopPropagation()
                   let file = props.href
-                  if (props.href.startsWith('#kuiexec?command=')) {
+                  if (isKuiCommand) {
                     const raw = props.href.match(/#kuiexec\?command=([^&]+)(&quiet)?/)
                     if (raw) {
                       const cmdline = decodeURIComponent(raw[1])
@@ -177,9 +179,15 @@ export default class Markdown extends React.PureComponent<Props> {
             } else if (!isLocal && this.props.noExternalLinks) {
               return <span className={this.props.className}>{props.href}</span>
             } else {
+              const tip = isKuiCommand
+                ? `### Command Execution\n#### ${decodeURIComponent(
+                    props.href.slice(props.href.indexOf('=') + 1)
+                  )}\n\n\`Link will execute a command\``
+                : `### External Link\n#### ${props.href}\n\n\`Link will open in a separate window\``
+
               return (
-                <Tooltip markdown={`### External Link\n#### ${props.href}\n\n\`Link will open in a separate window\``}>
-                  <a className="bx--link" {...props} target={target} onClick={onClick} />
+                <Tooltip markdown={tip}>
+                  <a {...props} target={target} onClick={onClick} />
                 </Tooltip>
               )
             }

--- a/plugins/plugin-client-common/src/components/Content/Table/TableBody.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/TableBody.tsx
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-import { Table, Tab, REPL } from '@kui-shell/core'
+import { i18n, Table, Tab, REPL } from '@kui-shell/core'
 
 import React from 'react'
-import { Tbody, Tr } from '@patternfly/react-table'
+import { Tbody, Tr, Td } from '@patternfly/react-table'
+import { EmptyState, EmptyStateVariant, Bullseye, Title, EmptyStateIcon } from '@patternfly/react-core'
+import { SearchIcon } from '@patternfly/react-icons'
 
 import renderCell from './TableCell'
+
+const strings = i18n('plugin-client-common')
 
 /**
  * Render the TableBody part
@@ -34,24 +38,42 @@ export default function renderBody(
   repl: REPL,
   offset: number
 ) {
+  const emptyState = () => {
+    return (
+      <Tr>
+        <Td data-is-empty={true} colSpan={kuiTable.header ? kuiTable.header.attributes.length + 1 : 0}>
+          <Bullseye>
+            <EmptyState variant={EmptyStateVariant.small}>
+              <EmptyStateIcon icon={SearchIcon} />
+              <Title headingLevel="h2" size="lg">
+                {strings('No results found')}
+              </Title>
+            </EmptyState>
+          </Bullseye>
+        </Td>
+      </Tr>
+    )
+  }
   return (
     <Tbody>
-      {kuiTable.body.map((kuiRow, ridx) => {
-        const updated = justUpdated[kuiRow.rowKey || kuiRow.name]
-        const cell = renderCell(kuiTable, kuiRow, updated, tab, repl)
+      {kuiTable.body.length === 0
+        ? emptyState()
+        : kuiTable.body.map((kuiRow, ridx) => {
+            const updated = justUpdated[kuiRow.rowKey || kuiRow.name]
+            const cell = renderCell(kuiTable, kuiRow, updated, tab, repl)
 
-        const key = kuiRow.key || (kuiTable.header ? kuiTable.header.key || kuiTable.header.name : undefined)
+            const key = kuiRow.key || (kuiTable.header ? kuiTable.header.key || kuiTable.header.name : undefined)
 
-        return (
-          <Tr key={ridx} data-row-key={kuiRow.rowKey} data-name={kuiTable.body[offset + ridx].name}>
-            {cell(key, kuiRow.name, undefined, kuiRow.outerCSS, kuiRow.css, kuiRow.onclick, 0)}
-            {kuiRow.attributes &&
-              kuiRow.attributes.map((attr, idx) =>
-                cell(attr.key, attr.value, attr.tag, attr.outerCSS, attr.css, attr.onclick, idx + 1)
-              )}
-          </Tr>
-        )
-      })}
+            return (
+              <Tr key={ridx} data-row-key={kuiRow.rowKey} data-name={kuiTable.body[offset + ridx].name}>
+                {cell(key, kuiRow.name, undefined, kuiRow.outerCSS, kuiRow.css, kuiRow.onclick, 0)}
+                {kuiRow.attributes &&
+                  kuiRow.attributes.map((attr, idx) =>
+                    cell(attr.key, attr.value, attr.tag, attr.outerCSS, attr.css, attr.onclick, idx + 1)
+                  )}
+              </Tr>
+            )
+          })}
     </Tbody>
   )
 }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Actions.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Actions.tsx
@@ -20,7 +20,7 @@ import { Tab, i18n, isOfflineClient } from '@kui-shell/core'
 import { InputOptions } from './Input'
 import { SupportedIcon } from '../../../spi/Icons'
 import TwoFaceIcon from '../../../spi/Icons/TwoFaceIcon'
-import BlockModel, { hasUUID, isOutputOnly } from './BlockModel'
+import BlockModel, { hasUUID, isOutputOnly, isRerunable } from './BlockModel'
 
 const strings = i18n('plugin-client-common')
 
@@ -53,6 +53,7 @@ export default class Actions extends React.PureComponent<Props> {
     if (
       !isOfflineClient() &&
       hasUUID(this.props.model) &&
+      isRerunable(this.props.model) &&
       !isOutputOnly(this.props.model) &&
       this.props.tab &&
       this.props.command

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -610,7 +610,7 @@ export default class Input extends InputProvider {
 
   /** DropDown menu for completed blocks */
   private actions(command: string) {
-    if (isFinished(this.props.model) && !!this.props.tab && !!this.props.model) {
+    if ((isFinished(this.props.model) || isProcessing(this.props.model)) && !!this.props.tab && !!this.props.model) {
       return <Actions command={command} idx={this.props.idx} {...this.props} />
     }
   }

--- a/plugins/plugin-client-common/web/scss/components/Table/tables.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/tables.scss
@@ -232,6 +232,12 @@ body[kui-theme-style] .kui--data-table-wrapper {
       th {
         padding-left: var(--pf-c-card--child--PaddingLeft);
       }
+
+      td {
+        h2 {
+          margin: 0;
+        }
+      }
     }
 
     .pf-m-wrap {

--- a/plugins/plugin-client-common/web/scss/components/Tooltip/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Tooltip/PatternFly.scss
@@ -38,6 +38,13 @@ $bgcolor: var(--color-base06);
     }
     h3 + h4 {
       padding-top: 0;
+
+      a:only-child {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
 
     p + p {

--- a/plugins/plugin-core-support/src/test/core-support2/history.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/history.ts
@@ -106,7 +106,7 @@ describe('command history plain', function(this: Common.ISuite) {
 
   it(`should list history with filter, expect nothing`, () =>
     CLI.command(`history gumbogumbo`, this.app)
-      .then(ReplExpect.justOK) // some random string that won't be in the command history
+      .then(ReplExpect.okWithCustom({ selector: Selectors._TABLE_EMPTY }))
       .catch(Common.oops(this, true)))
 
   it(`should delete command history`, () =>
@@ -116,7 +116,7 @@ describe('command history plain', function(this: Common.ISuite) {
 
   it(`should list history with no args after delete and expect nothing`, () =>
     CLI.command(`history`, this.app)
-      .then(ReplExpect.justOK)
+      .then(ReplExpect.okWithCustom({ selector: Selectors._TABLE_EMPTY }))
       .catch(Common.oops(this, true)))
 
   it(`should list history with idx arg after delete and expect only the previous`, () =>
@@ -131,6 +131,6 @@ describe('command history plain', function(this: Common.ISuite) {
 
   it(`should list history with idx and filter args after delete and expect nothing`, () =>
     CLI.command(`history 10 lls`, this.app)
-      .then(ReplExpect.justOK) // some random string that won't be in the command history
+      .then(ReplExpect.okWithCustom({ selector: Selectors._TABLE_EMPTY }))
       .catch(Common.oops(this, true)))
 })

--- a/plugins/plugin-kubectl/oc/src/controller/oc/login.ts
+++ b/plugins/plugin-kubectl/oc/src/controller/oc/login.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 IBM Corporation
+ * Copyright 2021 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,12 @@
  */
 
 import { Registrar } from '@kui-shell/core'
+import { doExecWithPty, commandPrefix, emitKubectlConfigChangeEvent } from '@kui-shell/plugin-kubectl'
 
-import raw from './controller/raw'
-import login from './controller/oc/login'
-import getProjects from './controller/oc/get/projects'
-import delegates from './controller/kubectl/delegates'
-import catchall from './controller/kubectl/catchall'
-
-export default (registrar: Registrar) => {
-  delegates(registrar)
-  getProjects(registrar)
-  raw(registrar)
-  login(registrar)
-  catchall(registrar)
+export default function registerOcLogin(registrar: Registrar) {
+  registrar.listen(`/${commandPrefix}/oc/login`, async args => {
+    const response = await doExecWithPty(args)
+    emitKubectlConfigChangeEvent('SetNamespaceOrContext')
+    return response
+  })
 }


### PR DESCRIPTION
[10.1.2 bc2dd7a60] fix(plugins/plugin-kubectl): `oc login` does not invalidate the kubectl proxy
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Thu Feb 4 11:24:08 2021 -0500
 2 files changed, 28 insertions(+)
 create mode 100644 plugins/plugin-kubectl/oc/src/controller/oc/login.ts

[10.1.2 50ca15693] fix(plugins/plugin-client-common): Tooltips for kuiexec markdown links have incorrect tooltip content
 Date: Thu Feb 4 12:45:30 2021 -0500
 2 files changed, 18 insertions(+), 3 deletions(-)

[10.1.2 f75098226] fix(plugins/plugin-client-common): blocks with Processing commands cannot be removed
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Thu Feb 4 14:27:13 2021 -0500
 4 files changed, 34 insertions(+), 9 deletions(-)
 rename plugins/plugin-core-support/src/test/core-support2/{remove-output.ts => remove-block.ts} (54%)

[10.1.2 36b91c83d] fix(packages/core): menu.ts assumes the client defines a list of notebooks
 Date: Thu Feb 4 15:09:58 2021 -0500
 1 file changed, 14 insertions(+), 5 deletions(-)

[10.1.2 5dd9ed0cd] feat(plugins/plugin-client-common): empty tables use PatternFly's "empty state" UI
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Thu Feb 4 16:18:35 2021 -0500
 5 files changed, 49 insertions(+), 19 deletions(-)
