### PR TITLE
10.1.3

### DIFF
--- a/plugins/plugin-bash-like/fs/src/lib/ls.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/ls.ts
@@ -117,8 +117,8 @@ function cssOf(glob: GlobStats): string {
  * Decorate the name according to its nature
  *
  */
-function nameOf(glob: GlobStats, wide: boolean): string {
-  return `${wide ? glob.nameForDisplay : glob.name}${
+function nameOf(glob: GlobStats): string {
+  return `${glob.nameForDisplay}${
     glob.dirent.isDirectory
       ? !glob.nameForDisplay.endsWith('/')
         ? '/'
@@ -200,7 +200,7 @@ function toTable(entries: GlobStats[], args: Arguments<LsOptions>): Table {
   const hasMtime = entries.some(_ => _.stats && _.stats.mtimeMs)
 
   const body = entries.sort(sorter).map(_ => ({
-    name: nameOf(_, args.parsedOptions.l),
+    name: nameOf(_),
     css: cssOf(_),
     onclickExec: 'pexec' as const,
     onclick: `${_.dirent.isDirectory ? (args.parsedOptions.l ? 'ls -l' : 'ls') : 'open'} ${encodeComponent(_.path)}`,

--- a/plugins/plugin-bash-like/fs/src/lib/ls.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/ls.ts
@@ -67,7 +67,7 @@ function prettyTime(ms: number): string {
   return dateFormatter(new Date(ms)).replace(/(\s)0/g, '$1 ')
 }
 
-interface LsOptions extends ParsedOptions {
+interface TheLsOptions {
   l: boolean // wide output
   a: boolean // list with dots except for . and ..
   A: boolean // list with dots
@@ -77,6 +77,8 @@ interface LsOptions extends ParsedOptions {
   t: boolean // sort by last modified time
   d: boolean // don't traverse directories
 }
+
+type LsOptions = TheLsOptions & ParsedOptions
 
 /** sort by size */
 const bySize = (rev: -1 | 1) => (a: GlobStats, b: GlobStats): number => {
@@ -236,6 +238,11 @@ function toTable(entries: GlobStats[], args: Arguments<LsOptions>): Table {
   }
 }
 
+/** Format a dash option, if specified */
+function opt(o: keyof TheLsOptions, opts: Arguments<LsOptions>) {
+  return opts.parsedOptions[o] ? ` -${o} ` : ''
+}
+
 /**
  * ls command handler
  *
@@ -257,7 +264,7 @@ const doLs = (cmd: string) => async (opts: Arguments<LsOptions>): Promise<MixedR
   //
   const srcs = opts.command.replace(/^\s*ls/, '').replace(/\s--?\S+/g, '')
 
-  const cmdline = 'vfs ls ' + (opts.parsedOptions.l || cmd === 'lls' ? '-l ' : '') + srcs
+  const cmdline = 'vfs ls ' + (opts.parsedOptions.l || cmd === 'lls' ? '-l ' : '') + opt('d', opts) + srcs
 
   if (cmd === 'lls') {
     opts.parsedOptions.l = true

--- a/plugins/plugin-bash-like/fs/src/lib/tab-completion.ts
+++ b/plugins/plugin-bash-like/fs/src/lib/tab-completion.ts
@@ -52,14 +52,17 @@ function findMatchingFilesFrom(files: GlobStats[], dirToScan: string, last: stri
   return {
     mode: 'raw',
     content: matches.map(matchStats => {
-      const match = matchStats.name
+      const match = matchStats.nameForDisplay
       const completion = lastIsDir ? match : match.substring(partial.length)
 
       // show a special label only if we have a dirname prefix
       const label = lastHasPath ? basename(matchStats.nameForDisplay) : undefined
 
       if (matchStats.dirent.isDirectory) {
-        return { completion: `${completion}/`, label: label ? `${label}/` : undefined }
+        return {
+          completion: !/\/$/.test(completion) ? `${completion}/` : completion,
+          label: label ? (!/\/$/.test(label) ? `${label}/` : label) : undefined
+        }
       } else {
         return { completion, addSpace: true, label }
       }

--- a/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
@@ -26,9 +26,9 @@ import {
 } from '@kui-shell/core'
 
 import React from 'react'
-import { TableComposable } from '@patternfly/react-table'
+import { SortByDirection, TableComposable } from '@patternfly/react-table'
 
-// import sortRow from './sort'
+import sortRow from './sort'
 import Card from '../../spi/Card'
 import Timeline from './Timeline'
 import renderBody from './TableBody'
@@ -90,6 +90,10 @@ export type State<T extends KuiTable = KuiTable> = ToolbarProps & {
 
   page: number
   pageSize: number
+
+  /* sorting */
+  activeSortIdx: number
+  activeSortDir: SortByDirection
 }
 
 export function getBreadcrumbsFromTable(response: KuiTable, prefixBreadcrumbs: BreadcrumbView[]) {
@@ -165,6 +169,8 @@ export default class PaginatedTable<P extends Props, S extends State> extends Re
         footer,
         header,
         asSequence,
+        activeSortIdx: -1,
+        activeSortDir: undefined,
         response: props.response,
         pageSize: props.pageSize || defaults.pageSize
       }
@@ -334,6 +340,17 @@ export default class PaginatedTable<P extends Props, S extends State> extends Re
       : 'compact' */
 
     const isSortable = response.body.length > 1
+
+    const onSort = (key: string, cidx: number, clickColIdx: number, clickDir: SortByDirection) => {
+      response.body.sort((a, b) => sortRow(a, b, key, cidx, clickDir))
+
+      this.setState({
+        body,
+        activeSortDir: clickDir,
+        activeSortIdx: clickColIdx
+      })
+    }
+
     const dataTable = (visibleRows: KuiRow[], offset = 0) => (
       <div
         className={
@@ -347,7 +364,8 @@ export default class PaginatedTable<P extends Props, S extends State> extends Re
         data-is-empty={response.body.length === 0}
       >
         <TableComposable className="kui--table-like-wrapper" variant={variant} isStickyHeader gridBreakPoint="">
-          {header && renderHeader(header)}
+          {header &&
+            renderHeader(header, isSortable, this.state.activeSortIdx, this.state.activeSortDir, onSort.bind(this))}
           {renderBody(response, this.justUpdatedMap(), tab, repl, offset)}
         </TableComposable>
       </div>

--- a/plugins/plugin-client-common/src/components/Content/Table/sort.ts
+++ b/plugins/plugin-client-common/src/components/Content/Table/sort.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 IBM Corporation
+ * Copyright 2021 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-/* const byte = 1
+import { Row } from '@kui-shell/core'
+import { SortByDirection } from '@patternfly/react-table'
+
+const byte = 1
 const kilobyte = 1024 * byte
 const megabyte = 1024 * kilobyte
 const gigabyte = 1024 * megabyte
@@ -30,21 +33,26 @@ function toSize(val: string): number {
   return mult * parseInt(val.slice(0, val.length - 2), 10)
 }
 
-function sortBySize(cellA: string, cellB, dir: number): number {
+function sortBySize(rowA: Row, rowB: Row, cidx: number, dir: number): number {
+  const cellA = rowA.attributes[cidx - 1].value
+  const cellB = rowB.attributes[cidx - 1].value
+
   return (toSize(cellA) - toSize(cellB)) * dir
 }
 
-function sortRowWithDir(cellA: string, cellB: string, key: string, state: DataTableSortState): number {
-  const dir = state === 'ASC' ? 1 : state === 'NONE' ? 0 : -1
-
+function sortRowWithDir(rowA: Row, rowB: Row, key: string, cidx: number, direction: SortByDirection): number {
+  const dir = direction === 'asc' ? 1 : -1
   if (key === 'SIZE') {
-    return sortBySize(cellA, cellB, dir)
+    return sortBySize(rowA, rowB, cidx, dir)
   } else {
-    return cellA.localeCompare(cellB) * dir
+    return rowA.name.localeCompare(rowB.name) * dir
   }
 }
 
-export default function sortRow(cellA: string, cellB: string, data: SortRowData): number {
-  return sortRowWithDir(cellA, cellB, data.key, data.sortDirection)
+export default function sortRow(rowA: Row, rowB: Row, key: string, cidx: number, direction: SortByDirection): number {
+  return sortRowWithDir(rowA, rowB, key.toUpperCase(), cidx, direction)
 }
-*/
+
+export function isSortableCol(key: string) {
+  return /NAME|SIZE|NAMESPACE|OBJECT/i.test(key.toUpperCase())
+}

--- a/plugins/plugin-client-common/web/scss/components/Table/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/PatternFly.scss
@@ -26,6 +26,14 @@
 
   @include TableHeadCell {
     color: var(--color-text-01);
+    & .pf-c-table__button {
+      .pf-c-table__text {
+        color: var(--color-text-01);
+      }
+      .pf-c-table__sort-indicator {
+        color: var(--color-ui-05);
+      }
+    }
   }
   @include TableCell {
     color: var(--color-text-01);

--- a/plugins/plugin-client-common/web/scss/components/Table/tables.scss
+++ b/plugins/plugin-client-common/web/scss/components/Table/tables.scss
@@ -160,10 +160,6 @@ body .bx--data-table {
     width: 100%;
   }
 
-  .kui--header-cell svg {
-    display: none;
-  }
-
   .bx--data-table-container {
     width: 100%;
     .bx--data-table {

--- a/plugins/plugin-core-support/src/test/core-support2/history.ts
+++ b/plugins/plugin-core-support/src/test/core-support2/history.ts
@@ -93,7 +93,8 @@ describe('command history plain', function(this: Common.ISuite) {
     try {
       const res = await CLI.command('history 5 lls', this.app)
       const N = ((await ReplExpect.okWithCustom({ passthrough: true })(res)) as any) as number
-      const selector = `${Selectors.LIST_RESULTS_N(N)}:last-child .entity-name`
+      const selector = `${Selectors.LIST_RESULTS_N(N)}:last-child .entity-name .clickable`
+      await this.app.client.$(selector).then(_ => _.waitForDisplayed())
       await this.app.client.$(selector).then(_ => _.click())
       return ReplExpect.okWith('README.md')(await CLI.lastBlock(this.app, 2))
     } catch (err) {


### PR DESCRIPTION
[10.1.3 7ef4d8a81] fix(plugins/plugin-bash-like): tab completion sometimes adds double trailing slashes
 Date: Fri Feb 5 12:51:41 2021 -0500
 1 file changed, 5 insertions(+), 2 deletions(-)

[10.1.3 a5eae3593] fix(plugins/plugin-bash-like): ls command does not pass some options to the VFS impl
 Date: Fri Feb 5 11:44:44 2021 -0500
 1 file changed, 9 insertions(+), 2 deletions(-)

[10.1.3 c3b18ceaf] fix(plugins/plugin-bash-like): internal: ls should always use `nameForDisplay`
 Date: Fri Feb 5 12:20:32 2021 -0500
 1 file changed, 3 insertions(+), 3 deletions(-)

[10.1.3 4ac42d335] fix(plugins/plugin-client-common): Markdown kuiexec drilldowns do not work if Markdown isn't passed a REPL controller
 Date: Fri Feb 5 14:59:17 2021 -0500
 1 file changed, 34 insertions(+), 29 deletions(-)

[10.1.3 d1dac8999] fix(plugins/plugin-client-common): restore Table sorting
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Fri Feb 5 14:05:40 2021 -0500
 6 files changed, 93 insertions(+), 35 deletions(-)