### PR TITLE
fix: ctrl+c then clear results in wrong command being executed

### DIFF
--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -53,6 +53,7 @@ import {
   Finished,
   Announcement,
   Cancelled,
+  isCancelled,
   Rerun,
   isRerunable,
   isBeingRerun,
@@ -1249,7 +1250,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
 
                 return (
                   <Block
-                    key={hasUUID(_) ? _.execUUID : idx}
+                    key={hasUUID(_) ? _.execUUID : `${idx}-${isActive(_)}-${isCancelled(_)}`}
                     idx={idx}
                     displayedIdx={displayedIdx}
                     model={_}


### PR DESCRIPTION
Fixes #6979

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
