### PR TITLE
10.1.4

### DIFF
--- a/plugins/plugin-bash-like/src/test/bash-like/ls.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/ls.ts
@@ -43,6 +43,36 @@ describe(`directory listing ${process.env.MOCHA_RUN_TARGET || ''}`, function(thi
       .then(ReplExpect.okWith('package.json'))
       .catch(Common.oops(this)))
 
+  // pipe to wc
+  it('should use ls ../../package.json | wc -l', () =>
+    CLI.command(`ls ../../package.json | wc -l`, this.app)
+      .then(ReplExpect.okWithString('1'))
+      .catch(Common.oops(this)))
+
+  // pipe to grep to wc
+  it('should use ls ../../ | grep package.json | wc -l', () =>
+    CLI.command(`ls ../../ | grep package.json | wc -l`, this.app)
+      .then(ReplExpect.okWithString('1'))
+      .catch(Common.oops(this)))
+
+  // pipe to grep
+  it('should use ls ../../ | grep package.json', () =>
+    CLI.command(`ls ../../ | grep package.json`, this.app)
+      .then(ReplExpect.okWithString('package.json'))
+      .catch(Common.oops(this)))
+  it('should use ls ../../ | grep p*', () =>
+    CLI.command(`ls ../../ | grep p*`, this.app)
+      .then(ReplExpect.okWithString('package.json'))
+      .catch(Common.oops(this)))
+  it('should use ls -l ../../ | grep package.json', () =>
+    CLI.command(`ls -l ../../ | grep package.json`, this.app)
+      .then(ReplExpect.okWith('package.json'))
+      .catch(Common.oops(this)))
+  it('should use ls -l ../../ | grep p*son', () =>
+    CLI.command(`ls -l ../../ | grep p*son`, this.app)
+      .then(ReplExpect.okWith('package.json'))
+      .catch(Common.oops(this)))
+
   const doListAndMetaClick = async () => {
     const holdDown = Keys.holdDownKey.bind(this)
     const release = Keys.releaseKey.bind(this)

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Output.tsx
@@ -266,6 +266,7 @@ export default class Output extends React.PureComponent<Props, State> {
         isHTML(response) ||
         isMarkdownResponse(response) ||
         (typeof response === 'string' && response.length > 0) ||
+        typeof response === 'number' ||
         isTable(response) ||
         isMixedResponse(response) ||
         (isXtermResponse(response) && response.rows && response.rows.length !== 0) ||

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -53,6 +53,7 @@ import {
   Finished,
   Announcement,
   Cancelled,
+  isCancelled,
   Rerun,
   isRerunable,
   isBeingRerun,
@@ -1249,7 +1250,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
 
                 return (
                   <Block
-                    key={hasUUID(_) ? _.execUUID : idx}
+                    key={hasUUID(_) ? _.execUUID : `${idx}-${isActive(_)}-${isCancelled(_)}`}
                     idx={idx}
                     displayedIdx={displayedIdx}
                     model={_}


### PR DESCRIPTION
[10.1.4 a60dccdfb] fix: ctrl+c then clear results in wrong command being executed
 Date: Mon Feb 8 11:35:44 2021 -0500
 2 files changed, 53 insertions(+), 28 deletions(-)

[10.1.4 8b54aca05] fix(plugins/plugin-client-common): numeric responses may not be displayed
 Date: Sun Feb 7 13:52:25 2021 -0500
 1 file changed, 1 insertion(+)

[10.1.4 9a6a1e578] fix(plugins/plugin-bash-like): ls | grep or ls | wc do not work
 Date: Sun Feb 7 15:19:59 2021 -0500
 2 files changed, 57 insertions(+), 4 deletions(-)