### PR TITLE
fix: ls does not show mounts, but tab completion does

### DIFF
--- a/plugins/plugin-bash-like/fs/src/vfs/delegates.ts
+++ b/plugins/plugin-bash-like/fs/src/vfs/delegates.ts
@@ -103,7 +103,7 @@ export async function ls(...parameters: Parameters<VFS['ls']>): Promise<DirEntry
   }
 
   const [mountContent, vfsContent] = await Promise.all([
-    Promise.all(parameters[1].map(lsMounts)).then(flatten),
+    Promise.all((parameters[1].length === 0 ? [process.env.PWD] : parameters[1]).map(lsMounts)).then(flatten),
     Promise.all(mounts.map(({ filepaths, mount }) => mount.ls(parameters[0], filepaths))).then(flatten)
   ])
 

--- a/plugins/plugin-client-test/src/test/api2/vfs.ts
+++ b/plugins/plugin-client-test/src/test/api2/vfs.ts
@@ -65,4 +65,27 @@ describe('ls versus vfs', function(this: Common.ISuite) {
     CLI.command('ls -l /kuifake/fake2/', this.app)
       .then(ReplExpect.okWith('F2'))
       .catch(Common.oops(this, true)))
+
+  // now try cd / and make sure ls works against PWD
+  it('should cd /', () =>
+    CLI.command('cd /', this.app)
+      .then(ReplExpect.okWithString('/'))
+      .catch(Common.oops(this, true)))
+  it('should ls and show kuifake', () =>
+    CLI.command('ls -l', this.app)
+      .then(ReplExpect.okWith('kuifake'))
+      .catch(Common.oops(this, true)))
+
+  // now try cd /kuifake and make sure ls works against PWD
+  /* requires the fix for https://github.com/IBM/kui/issues/6988
+  it('should cd /kuifake', () => CLI.command('cd /kuifake', this.app).then(ReplExpect.okWithString('/kuifake')).catch(Common.oops(this, true)))
+  it('should ls and show fake1', () =>
+    CLI.command('ls -l', this.app)
+      .then(ReplExpect.okWith('fake1'))
+      .catch(Common.oops(this, true)))
+  it('should ls and show fake2', () =>
+    CLI.command('ls -l', this.app)
+      .then(ReplExpect.okWith('fake2'))
+     .catch(Common.oops(this, true)))
+  */
 })


### PR DESCRIPTION
Fixes #6997

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
