### PR TITLE
fix(plugins/plugin-kubectl): Kui fetches wrong content when command l…

### DIFF
--- a/plugins/plugin-kubectl/src/controller/client/direct/create.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/create.ts
@@ -63,7 +63,16 @@ export default async function createDirect(
 
     const kindIdx = args.argvNoOptions.indexOf('create') + 1
     const names = args.argvNoOptions.slice(kindIdx + 1)
-    if (verb === 'create' && kind === 'Namespace' && version === 'v1' && names.length > 0) {
+
+    // re: context and kubeconfig, see https://github.com/IBM/kui/issues/7023
+    if (
+      verb === 'create' &&
+      kind === 'Namespace' &&
+      version === 'v1' &&
+      names.length > 0 &&
+      !args.parsedOptions.context &&
+      !args.parsedOptions.kubeconfig
+    ) {
       // WARNING: this is namespace-specific for now!
       const data = names.map(name => ({
         apiVersion: 'v1',

--- a/plugins/plugin-kubectl/src/controller/client/direct/delete.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/delete.ts
@@ -33,11 +33,14 @@ const debug = Debug('plugin-kubectl/controller/client/direct/delete')
 
 export default async function deleteDirect(args: Arguments<KubeOptions>, _kind?: Promise<Explained>) {
   // For now, we only handle delete-by-name
+  // re: context and kubeconfig, see https://github.com/IBM/kui/issues/7023
   if (
     !getFileFromArgv(args) &&
     !getLabel(args) &&
     !args.parsedOptions['dry-run'] &&
-    !args.parsedOptions['field-selector']
+    !args.parsedOptions['field-selector'] &&
+    !args.parsedOptions.context &&
+    !args.parsedOptions.kubeconfig
   ) {
     const explainedKind = await (_kind ||
       getKindAndVersion(getCommandFromArgs(args), args, args.argvNoOptions[args.argvNoOptions.indexOf('delete') + 1]))

--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -265,7 +265,14 @@ async function rawGet(
   const isGetAll = args.argvNoOptions[args.argvNoOptions.indexOf('get') + 1] === 'all'
   const requestWithoutKind = isGetAll || (!fileOf(args) && !_kind)
 
-  if ((command === 'oc' || command === 'kubectl') && !args.argvNoOptions.includes('|') && !requestWithoutKind) {
+  // re: context and kubeconfig, see https://github.com/IBM/kui/issues/7023
+  if (
+    (command === 'oc' || command === 'kubectl') &&
+    !args.argvNoOptions.includes('|') &&
+    !requestWithoutKind &&
+    !args.parsedOptions.context &&
+    !args.parsedOptions.kubeconfig
+  ) {
     // try talking to the apiServer directly
     const response = await getDirect(args, _kind)
     if (response) {


### PR DESCRIPTION
…ine specifies --context or --kubeconfig

Fixes #7023

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
