### PR TITLE
fix: `kubectl create ns 1` fails with status/direct

### DIFF
--- a/packages/core/src/models/command.ts
+++ b/packages/core/src/models/command.ts
@@ -273,6 +273,7 @@ export type CommandTreeResolution<T extends KResponse, O extends ParsedOptions> 
 export interface YargsParserFlags {
   configuration?: Partial<Yargs.Configuration>
   boolean?: string[]
+  string?: string[]
   narg?: Record<string, number>
   alias?: Record<string, string[]>
 }

--- a/packages/core/src/repl/enforce-usage.ts
+++ b/packages/core/src/repl/enforce-usage.ts
@@ -273,6 +273,7 @@ export default function enforceUsage<T extends KResponse, O extends ParsedOption
         (usage && usage.configuration) ||
         {}
     ),
+    string: Object.assign({}, commandFlags.string || {}),
     boolean: (commandFlags.boolean || []).concat(optionalBooleans || []),
     alias: Object.assign({}, commandFlags.alias || {}, optionalAliases || {}),
     narg: Object.assign(

--- a/packages/core/src/repl/exec.ts
+++ b/packages/core/src/repl/exec.ts
@@ -281,6 +281,7 @@ class InProcessExecutor implements Executor {
           (usage && usage.configuration) ||
           {}
       ),
+      string: commandFlags.string || [],
       boolean: (commandFlags.boolean || []).concat(optionalBooleans || []),
       alias: Object.assign({}, commandFlags.alias || {}, optionalAliases || {}),
       narg: Object.assign(

--- a/plugins/plugin-kubectl/src/controller/kubectl/flags.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/flags.ts
@@ -53,6 +53,7 @@ export function flags(booleans: string[] = []): CommandOptions {
       },
       // Notes on narg: to prevent yargs-parser from processing "--watch true" into watch:true
       narg: { w: 0, watch: 0, 'watch-only': 0 },
+      string: ['_'], // enforce positional arguments to be parsed as string
       boolean: booleans.concat(defaultBooleans)
     }
   }

--- a/plugins/plugin-kubectl/src/test/k8s/namespace.ts
+++ b/plugins/plugin-kubectl/src/test/k8s/namespace.ts
@@ -27,6 +27,8 @@ const ns1 = createNS()
 const ns2 = createNS()
 const ns3 = createNS()
 const ns4 = createNS()
+const ns5 = Math.floor(Math.random() * 100) + (1).toString()
+
 const synonyms = ['kubectl']
 
 describe(`kubectl namespace CRUD ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
@@ -217,7 +219,9 @@ describe(`kubectl namespace CRUD ${process.env.MOCHA_RUN_TARGET || ''}`, functio
     createPod(ns2)
     createIt(ns3)
     createIt(ns4)
+    createIt(ns5)
     deleteIt([ns1, ns3, ns4])
     deleteViaButton(ns2)
+    deleteViaButton(ns5)
   })
 })


### PR DESCRIPTION
Fixed by enforcing minimist to parse kubectl positional argument number as string
![Screen Shot 2021-02-16 at 1 53 39 PM](https://user-images.githubusercontent.com/21212160/108108249-6180cd80-705e-11eb-81c5-daa37a66913a.png)


Fixes #7016

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
