### PR TITLE
fix(plugins/plugin-client-common): "lost connection to your cluster" alert takes up the full window height

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Alert/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Alert/PatternFly.scss
@@ -17,6 +17,10 @@
 .kui--toolbar-alert {
   white-space: normal;
 
+  &.kui--connection-lost {
+    position: absolute;
+  }
+
   h4 {
     margin: 0;
     font-size: inherit;


### PR DESCRIPTION
Fixes #7018
![Screen Shot 2021-02-16 at 2 31 00 PM](https://user-images.githubusercontent.com/21212160/108112076-980d1700-7063-11eb-8e4b-61fe5be0e1b0.png)


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
