### PR TITLE
feat: add typeahead to kubernetes context and namespace select widget

### DIFF
--- a/plugins/plugin-client-common/src/components/spi/Select/impl/PatternFly.tsx
+++ b/plugins/plugin-client-common/src/components/spi/Select/impl/PatternFly.tsx
@@ -36,12 +36,14 @@ export default class PatternFlySelect extends React.PureComponent<Props, State> 
   }
 
   private onToggle(expanded: boolean) {
-    if (expanded) {
-      if (!this.state.isOpen) {
-        this.setState({ isOpen: true })
+    if (this.props.isClosable !== false) {
+      if (expanded) {
+        if (!this.state.isOpen) {
+          this.setState({ isOpen: true })
+        }
+      } else {
+        this.setState({ isOpen: false })
       }
-    } else {
-      this.setState({ isOpen: false })
     }
   }
 
@@ -68,9 +70,10 @@ export default class PatternFlySelect extends React.PureComponent<Props, State> 
         className={'kui--select' + (this.props.className ? ' ' + this.props.className : '')}
         isOpen={this.state.isOpen}
         variant={this.props.variant}
+        typeAheadAriaLabel="Select from the Options"
         selections={this.state.selected}
         maxHeight={this.props.maxHeight}
-        onToggle={this.props.isClosable !== false && this._onToggle}
+        onToggle={this._onToggle}
         onSelect={this._onSelect}
       >
         {this.props.options.map((option, index) => (

--- a/plugins/plugin-client-common/web/scss/components/Popover/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Popover/PatternFly.scss
@@ -24,20 +24,19 @@
 
   &.kui--popover-select {
     .pf-c-popover__content {
-      width: 22rem;
-      height: 20rem;
+      width: $popover-width;
+      .pf-c-select__menu {
+        top: 4px;
+        position: relative;
+      }
     }
   }
-
   .pf-c-popover__content {
-    width: $popover-width;
-    .pf-c-select__menu {
-      top: 4px;
-      position: relative;
-    }
+    max-height: 40rem; /* Neither PatternFly nor Carbon let us specify this via props */
+    overflow-y: auto;
   }
 
-  .pf-c-button {
+  .pf-c-button[aria-label='Close'] {
     padding: 0;
   }
 }

--- a/plugins/plugin-client-common/web/scss/components/Popover/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Popover/_mixins.scss
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-$popover-width: 22rem;
+$popover-width: 30rem;
 
 @mixin Popover {
   .kui--popover {

--- a/plugins/plugin-client-common/web/scss/components/Select/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Select/PatternFly.scss
@@ -21,6 +21,11 @@
 .kui--popover .kui--select {
   font-size: 0.75rem;
 
+  .pf-c-select__toggle-typeahead {
+    font-size: 0.75rem;
+    font-family: var(--font-sans-serif);
+  }
+
   button {
     padding-top: 0.25em;
     padding-bottom: 0.25em;

--- a/plugins/plugin-kubectl/components/src/CurrentContext.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentContext.tsx
@@ -169,8 +169,8 @@ export default class CurrentContext extends React.PureComponent<{}, State> {
     return (
       <React.Suspense fallback={<div />}>
         <Select
-          variant={'single'}
-          maxHeight="9rem"
+          variant="typeahead"
+          maxHeight="11rem"
           className="small-top-pad"
           selected={this.state.currentContext}
           options={options}

--- a/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
@@ -175,8 +175,8 @@ export default class CurrentNamespace extends React.PureComponent<{}, State> {
     return (
       <React.Suspense fallback={<div />}>
         <Select
-          variant="single"
-          maxHeight="9rem"
+          variant="typeahead"
+          maxHeight="11rem"
           className="small-top-pad"
           selected={this.state.currentNamespace}
           options={options}


### PR DESCRIPTION
Fixes #7034


https://user-images.githubusercontent.com/21212160/108276468-df6bd400-7145-11eb-8806-bf8015540eb2.mov




<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
