### PR TITLE
fix: kui fails to show numeric namespace for kubectl config commands

### DIFF
--- a/plugins/plugin-bash-like/src/lib/cmds/catchall.ts
+++ b/plugins/plugin-bash-like/src/lib/cmds/catchall.ts
@@ -70,7 +70,7 @@ export const dispatchToShell = async ({
       return response
     } else if (useRaw && typeof response === 'string') {
       try {
-        return JSON.parse(response)
+        return !isNaN(parseInt(response)) ? response : JSON.parse(response) // prevents numeric conversion e.g. JSON.parse('1') = 1
       } catch (err) {
         // debug('response maybe is not JSON', response)
       }

--- a/plugins/plugin-kubectl/src/controller/kubectl/contexts.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/contexts.ts
@@ -89,8 +89,10 @@ export async function getCurrentDefaultNamespace({ REPL }: { REPL: REPLType }): 
   }
 
   const cmdline = `kubectl config view --minify --output "jsonpath={..namespace}"`
-  const ns = await REPL.qexec<string>(cmdline)
-    .then(ns => {
+  const ns = await REPL.qexec<string | number>(cmdline)
+    .then(_ns => {
+      const ns = typeof _ns === 'number' ? _ns.toString() : _ns // ns might be number
+
       if (typeof ns !== 'string' || ns.length === 0) {
         // e.g. microk8s
         console.error('Suspicious return value for current namespace', ns, cmdline)


### PR DESCRIPTION
Fixes #7032

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
