### PR TITLE
feat(plugins/plugin-kubectl): CLI-based kubectl polling does not allo…

### DIFF
--- a/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/watch/get-watch.ts
@@ -40,6 +40,7 @@ import {
   getNamespace,
   getResourceNamesForArgv,
   withKubeconfigFrom,
+  withKubeconfigAndCommandFrom,
   KubeOptions,
   KubeExecOptions
 } from '../options'
@@ -337,9 +338,9 @@ class KubectlWatcher implements Abortable, Watcher {
     namespace: string,
     rowNames: string[]
   ): Promise<Table | void> {
-    const getCommand = withKubeconfigFrom(
+    const getCommand = withKubeconfigAndCommandFrom(
       this.args,
-      `${getCommandFromArgs(this.args)} get ${kindPart(apiVersion, kind)} ${rowNames.join(' ')} -n ${namespace} ${
+      `get ${kindPart(apiVersion, kind)} ${rowNames.join(' ')} -n ${namespace} ${
         this.output ? `-o ${this.output}` : ''
       }`
     )

--- a/plugins/plugin-kubectl/src/lib/util/util.ts
+++ b/plugins/plugin-kubectl/src/lib/util/util.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/explicit-member-accessibility */
 import { Arguments } from '@kui-shell/core'
 
 import commandPrefix from '../../controller/command-prefix'
@@ -105,16 +104,16 @@ export class StatusError extends Error {}
 export class TryLaterError extends StatusError {}
 
 export class NotFoundError extends StatusError {
-  code: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  public code: any // eslint-disable-line @typescript-eslint/no-explicit-any
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(message: string, code: any = 404) {
+  public constructor(message: string, code: any = 404) {
     super(message)
     this.code = code
   }
 }
 
-export const getCommandFromArgs = (args: { argvNoOptions: string[] }) => {
+export const getCommandFromArgs = (args: Pick<Arguments, 'argvNoOptions'>): string => {
   const cmd = args.argvNoOptions[0] === commandPrefix ? args.argvNoOptions[1] : args.argvNoOptions[0]
   return cmd === 'k' ? 'kubectl' : cmd
 }


### PR DESCRIPTION
…w for flexible overrides of the command prefix

Fixes #7042

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
