### PR TITLE
fix(plugins/plugin-kubectl): Kui should fall back to Kubectl CLI when kubernetes direct accesss fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,13 @@ jobs:
       script:
         - concurrently -n K8S3,K8S4 'npm run test1 k8s3' 'npm run test2 k8s4'
         - concurrently -n K8S2 'npm run test1 k8s2'
+    
+    #
+    # Kubernetes Tests, using a browser-based client, test kubectl CLI
+    #
+    - env: N="k8s2-chaos browser" TRAVIS_CHAOS_TESTING=true NEEDS_K8S=true NEEDS_OC=true NEEDS_TOP=true MOCHA_RUN_TARGET=webpack
+      script:
+        - concurrently -n K8S2 'npm run test1 k8s2'    
 
     #
     # General Tests on macOS using an electron client

--- a/plugins/plugin-kubectl/src/controller/client/direct/errors.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/errors.ts
@@ -51,7 +51,7 @@ export default async function handleErrors(
 ): Promise<WithErrors> {
   const withErrors: (string | Buffer | object | CodedError)[] = await Promise.all(
     responses.map(async data => {
-      let errorData = isReturnedError(data) ? tryParseAsStatus(data.error.message) : isStatus(data) ? data : undefined
+      let errorData = isReturnedError(data) ? tryParseAsStatus(data.error) : isStatus(data) ? data : undefined
       if (errorData) {
         if (isStatus(errorData)) {
           // if we could not find the requested resource, do some

--- a/plugins/plugin-kubectl/src/controller/kubectl/get.ts
+++ b/plugins/plugin-kubectl/src/controller/kubectl/get.ts
@@ -274,10 +274,19 @@ async function rawGet(
     !args.parsedOptions.kubeconfig
   ) {
     // try talking to the apiServer directly
-    const response = await getDirect(args, _kind)
-    if (response) {
-      // that worked!
-      return response
+    try {
+      const response = await getDirect(args, _kind)
+      if (response) {
+        // that worked!
+        return response
+      }
+    } catch (err) {
+      if (err.code !== 500) {
+        // expected apiServer error, i.e. Kubernetes Status errors
+        throw err
+      } else {
+        console.error('unexpected apiServer error, intentionally fallback to kubectl CLI', err)
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #7050

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
