### PR TITLE
feat: show placeholder text to explain that ctrl+d closes split

### DIFF
--- a/plugins/plugin-client-common/i18n/resources_en_US.json
+++ b/plugins/plugin-client-common/i18n/resources_en_US.json
@@ -4,6 +4,7 @@
   "Cancel edit": "Currently in edit mode. Click to cancel.",
   "Remove": "Remove",
   "ok": "ok",
+  "Use Ctrl+D to close this split": "Use Ctrl+D to close this split",
 
   "Done": "Done",
   "Revert": "Revert",

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -456,6 +456,28 @@ export default class Input extends InputProvider {
     })
   })
 
+  /**
+   * The current logic here is to obey any `promptPlaceholder`
+   * property from the `<Kui/>` top-level property first. If that
+   * hasn't been set, then we fall back on using a "this is how to
+   * close this split" message, but only if there is more than one split,
+   * and even then only if the block is currently focused.
+   *
+   * @return placeholder text for input elements within Active blocks
+   *
+   */
+  private placeholderForActiveBlocks(): string {
+    return (
+      this.props.promptPlaceholder ||
+      (this.props.isFocused && // block is focused
+      typeof this.props.nSplits === 'number' &&
+      this.props.nSplits > 1 && // more than one split
+      this.props.idx <= 1 // only for the first few blocks
+        ? strings('Use Ctrl+D to close this split')
+        : '')
+    )
+  }
+
   /** the element that represents the command being/having been/going to be executed */
   protected input() {
     const active = isActive(this.props.model) || this.state.isReEdit
@@ -492,7 +514,7 @@ export default class Input extends InputProvider {
             className={'repl-input-element' + (this.state.isearch ? ' repl-input-hidden' : '')}
             aria-label="Command Input"
             tabIndex={1}
-            placeholder={this.props.promptPlaceholder}
+            placeholder={this.placeholderForActiveBlocks()}
             data-scrollback-uuid={this.props.uuid}
             data-input-count={this.props.idx}
             onBlur={this._onBlur}

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
@@ -33,6 +33,9 @@ import {
 } from './BlockModel'
 
 export type BlockViewTraits = {
+  /** number of splits currently in this tab */
+  nSplits?: number
+
   isExperimental?: boolean
   isFocused?: boolean
   isPartOfMiniSplit?: boolean

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollableTerminal.tsx
@@ -1256,6 +1256,7 @@ export default class ScrollableTerminal extends React.PureComponent<Props, State
                     isBeingRerun={isBeingRerun(_)}
                     uuid={scrollback.uuid}
                     tab={tab}
+                    nSplits={this.state.splits.length}
                     noActiveInput={this.props.noActiveInput || isOfflineClient()}
                     onFocus={scrollback.onFocus}
                     willRemove={scrollback.willRemoveBlock}

--- a/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Block.scss
@@ -38,6 +38,15 @@ $focus-color: var(--color-brand-01);
   }
 }
 
+/** Placeholder text styling */
+@include Input {
+  &::placeholder {
+    opacity: 0.3;
+    font-size: 0.875em;
+    color: var(--color-text-02);
+  }
+}
+
 /** We are using <li> for the blocks, but don't want any standard browser styling */
 @include Block {
   list-style: none;


### PR DESCRIPTION
part of #7060

![ezgif com-gif-maker](https://user-images.githubusercontent.com/4741620/108786960-c21e7780-7542-11eb-885b-e64817fbc7ca.gif)

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
