### PR TITLE
fix(plugins/plugin-kubectl): allow clients to define a default kubectl CLI

### DIFF
--- a/plugins/plugin-kubectl/components/src/CurrentContext.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentContext.tsx
@@ -31,6 +31,7 @@ import {
   i18n
 } from '@kui-shell/core'
 import {
+  kubectl,
   getAllContexts,
   KubeContext,
   onKubectlConfigChangeEvents,
@@ -164,7 +165,7 @@ export default class CurrentContext extends React.PureComponent<{}, State> {
       label: this.renderName(context.metadata.name),
       isSelected: context.spec.isCurrent,
       description: context.spec.isCurrent ? strings('This is your current context') : undefined,
-      command: `kubectl config use-context ${encodeComponent(context.metadata.name)}`
+      command: `${kubectl} config use-context ${encodeComponent(context.metadata.name)}`
     }))
 
     return (

--- a/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
@@ -32,6 +32,7 @@ import {
 } from '@kui-shell/core'
 
 import {
+  kubectl,
   KubeContext,
   getCurrentDefaultNamespace,
   onKubectlConfigChangeEvents,
@@ -90,7 +91,7 @@ export default class CurrentNamespace extends React.PureComponent<{}, State> {
     try {
       const [currentNamespace, allNamespaces] = await Promise.all([
         getCurrentDefaultNamespace(tab),
-        tab.REPL.qexec<string>('kubectl get ns -o name').then(_ =>
+        tab.REPL.qexec<string>(`${kubectl} get ns -o name`).then(_ =>
           _.split(/\n/).map(_ => _.replace(/^namespace\//, ''))
         )
       ])
@@ -143,7 +144,7 @@ export default class CurrentNamespace extends React.PureComponent<{}, State> {
 
   private listNamespace() {
     return (
-      <a href="#" onClick={() => pexecInCurrentTab('kubectl get namespace')}>
+      <a href="#" onClick={() => pexecInCurrentTab(`${kubectl} get namespace`)}>
         {strings('Show Full Details')}
       </a>
     )
@@ -177,7 +178,7 @@ export default class CurrentNamespace extends React.PureComponent<{}, State> {
       label: ns,
       isSelected,
       description: isSelected ? strings('This is your current namespace') : undefined,
-      command: `kubectl config set-context --current --namespace=${ns}`
+      command: `${kubectl} config set-context --current --namespace=${ns}`
     }
   }
 

--- a/plugins/plugin-kubectl/src/controller/cli.ts
+++ b/plugins/plugin-kubectl/src/controller/cli.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Debug from 'debug'
+const debug = Debug('plugin-kubectl/controller/cli')
+
+/**
+ * The kubectl cli we want to use for all kubectl commands. For example,
+ * `kubectl = oc `;`${kubectl} get pods`
+ *
+ */
+function _kubectl(): string {
+  const _default = process.env.KUI_DEFAULT_KUBECTL || 'kubectl'
+
+  try {
+    const { defaultKubectl } = require('@kui-shell/client/config.d/exec.json')
+    return defaultKubectl || _default
+  } catch (err) {
+    debug('Client did not define a default kubectl CLI, assuming default kubectl')
+    return _default
+  }
+}
+
+export default _kubectl()

--- a/plugins/plugin-kubectl/src/index.ts
+++ b/plugins/plugin-kubectl/src/index.ts
@@ -62,6 +62,8 @@ export { doExecRaw, doNativeExec } from './controller/kubectl/raw'
 
 export { default as commandPrefix } from './controller/command-prefix'
 
+export { default as kubectl } from './controller/cli'
+
 export { default as defaultFlags, flags } from './controller/kubectl/flags'
 
 export {


### PR DESCRIPTION
This PR allows client to default kubectl cli in `client/config.d/exec.json`. The type spec being:

```typescript
{ defaultKubectl : 'oc' | 'kubectl' }
```

Fixes #7051

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
