### PR TITLE
fix(plugins/plugin-kubectl): kubectl Logs tab does not handle Idle state

### DIFF
--- a/plugins/plugin-kubectl/src/lib/view/modes/logs.tsx
+++ b/plugins/plugin-kubectl/src/lib/view/modes/logs.tsx
@@ -86,6 +86,10 @@ export class Logs extends Terminal<State> {
         message: 'Logs are live streaming.',
         type: 'info' as const
       },
+      Idle: {
+        message: 'Log streaming is idle.',
+        type: 'warning' as const
+      },
       Paused: {
         message: 'Log streaming is paused.',
         type: 'warning' as const


### PR DESCRIPTION
Fixes #7103

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
