### PR TITLE
fix(plugins/plugin-client-common): opening monaco-editor component ca…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Editor/Editor.scss
+++ b/plugins/plugin-client-common/web/scss/components/Editor/Editor.scss
@@ -163,3 +163,16 @@
 .kui--editor-line-highlight {
   background-color: var(--color-base03);
 }
+
+/** TEMPORARY WORKAROUND FOR https://github.com/microsoft/monaco-editor/issues/2168 
+ Please remove this hack once the fix is released; some version > 0.22.3 of monaco-editor */
+.monaco-aria-container {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+}


### PR DESCRIPTION
…uses 1px of vertical scrolling at the root level

This PR introduces a TEMPORARY hack to work around a monaco-editor css bug.
https://github.com/microsoft/monaco-editor/issues/2168

All it does is copy over the css fix into Editor.scss

Fixes #7113

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
