### PR TITLE
feat: update core watch command to return watchable table

### DIFF
--- a/packages/core/src/core/jobs/watchable.ts
+++ b/packages/core/src/core/jobs/watchable.ts
@@ -46,6 +46,9 @@ export interface WatchPusher {
    */
   update: (response: Row, batch?: boolean, changed?: boolean) => void
 
+  /** set table body */
+  setBody: (response: Row[]) => void
+
   /** A batch of calls to `update` is complete */
   batchUpdateDone: () => void
 

--- a/plugins/plugin-bash-like/src/test/bash-like/watch-ls.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/watch-ls.ts
@@ -42,9 +42,9 @@ describe(`watch directory listing ${process.env.MOCHA_RUN_TARGET || ''}`, functi
       .catch(Common.oops(this)))
 
   it('should watch ls -l /tmp', () =>
-    CLI.command(`watch ls /tmp`, this.app)
-      .then(ReplExpect.ok)
+    CLI.command(`watch ls -l /tmp`, this.app)
       .then(async res => {
+        await ReplExpect.okWith(names[0])(res)
         const fileName = names[1]
         await CLI.command(`touch /tmp/${fileName}`, this.app).then(ReplExpect.ok)
 

--- a/plugins/plugin-client-common/i18n/resources_en_US.json
+++ b/plugins/plugin-client-common/i18n/resources_en_US.json
@@ -61,6 +61,7 @@
   "Switch theme": "Switch theme",
   "No results found": "No results found",
   "Show as table in terminal": "Show as table in terminal",
+  "Abort watcher": "Abort this watcher",
   "Pause watcher": "Pause this watcher",
   "Resume watcher": "Resume this watcher",
   "Close watcher": "Close and terminate this watcher"

--- a/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/PaginatedTable.tsx
@@ -255,6 +255,7 @@ export default class PaginatedTable<P extends Props, S extends State> extends Re
     const hasTimelineButton = false // disabled for now, see https://github.com/IBM/kui/issues/5864
 
     const needsBottomToolbar =
+      this.caption() ||
       this.isPaginated() ||
       (gridableColumn >= 0 && (this.props.response.body.length > 1 || isWatchable(this.props.response))) ||
       isTableWithTimestamp(this.props.response)


### PR DESCRIPTION
This PR adds a call to the table watching api: `setBody` that allows push providers to replace the entire table body with a new one.

Fixes #7119

https://user-images.githubusercontent.com/21212160/109876370-b6683a80-7c3f-11eb-8807-cac703886e31.mov


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [ ] 💅 Enhancement
- [x] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
