### PR TITLE
10.2.1

### DIFF
--- a/plugins/plugin-client-common/web/css/static/sidecar-main.css
+++ b/plugins/plugin-client-common/web/css/static/sidecar-main.css
@@ -120,6 +120,11 @@ $toolbar-height: 1.5rem;
     overflow: visible; /* for tooltip visibility */
   }
 
+  .sidecar-toolbar-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   .sidecar-toolbar-text svg path {
     fill: var(--color-sidecar-toolbar-foreground);
     &[data-icon-path="inner-path"] {
@@ -165,6 +170,10 @@ $toolbar-height: 1.5rem;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    p {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
   .sidecar-bottom-stripe-button {
     display: flex;

--- a/plugins/plugin-client-common/web/scss/components/Editor/Editor.scss
+++ b/plugins/plugin-client-common/web/scss/components/Editor/Editor.scss
@@ -163,3 +163,16 @@
 .kui--editor-line-highlight {
   background-color: var(--color-base03);
 }
+
+/** TEMPORARY WORKAROUND FOR https://github.com/microsoft/monaco-editor/issues/2168 
+ Please remove this hack once the fix is released; some version > 0.22.3 of monaco-editor */
+.monaco-aria-container {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+}


### PR DESCRIPTION
[10.2.1 1c0cf42e6] fix(plugins/plugin-client-common): sidecar toolbar text can overflow
 Author: Mengting Yan <mengting.yan1@ibm.com>
 Date: Wed Mar 3 10:09:22 2021 -0500
 1 file changed, 9 insertions(+)

[10.2.1 c3388bf53] fix(plugins/plugin-client-common): opening monaco-editor component causes 1px of vertical scrolling at the root level
 Date: Wed Mar 3 10:16:32 2021 -0500
 1 file changed, 13 insertions(+)