### PR TITLE
fix(plugins/plugin-kubectl): k get resourcequota fails badly if your cluster has no quotas

### DIFF
--- a/plugins/plugin-kubectl/src/controller/client/direct/get.ts
+++ b/plugins/plugin-kubectl/src/controller/client/direct/get.ts
@@ -110,7 +110,7 @@ export async function getTable(
       if (
         args.execOptions.type === ExecType.TopLevel &&
         metaTable &&
-        metaTable.rows.length === 0 &&
+        (!metaTable.rows || metaTable.rows.length === 0) &&
         !isWatchRequest(args)
       ) {
         return `No resources found in **${namespace}** namespace.`


### PR DESCRIPTION
Fixes #7143
![Screen Shot 2021-03-08 at 3 06 40 PM](https://user-images.githubusercontent.com/21212160/110375383-e472c380-801f-11eb-8171-b6c28757afed.png)


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
