### PR TITLE
fix: LivePaginatedTable implements WatchPusher's update incorrectly

### DIFF
--- a/packages/core/src/core/jobs/watchable.ts
+++ b/packages/core/src/core/jobs/watchable.ts
@@ -44,7 +44,7 @@ export interface WatchPusher {
    * update should be visualized as a change to the model [default:
    * true]
    */
-  update: (response: Row, batch?: boolean, changed?: boolean) => void
+  update: (response: Row, batch?: boolean, changed?: boolean, idxToUpdate?: number) => void
 
   /** set table body */
   setBody: (response: Row[]) => void

--- a/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Table/LivePaginatedTable.tsx
@@ -169,7 +169,7 @@ export default class LivePaginatedTable extends PaginatedTable<LiveProps, LiveSt
       const foundIndex = lookup(this.props.response.body, newKuiRow)
       if (foundIndex === -1 || !sameRow(newKuiRow, this.props.response.body[foundIndex])) {
         doUpdate = true
-        this.update(newKuiRow, true, foundIndex)
+        this.update(newKuiRow, true, undefined, foundIndex)
       }
     })
 
@@ -226,7 +226,8 @@ export default class LivePaginatedTable extends PaginatedTable<LiveProps, LiveSt
    * update consumes the update notification and apply it to the table view
    *
    */
-  private update(newKuiRow: KuiRow, batch = false, idxToUpdate?: number) {
+  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+  private update(newKuiRow: KuiRow, batch = false, justUpdated = true, idxToUpdate?: number) {
     if (!this.props.response.header) {
       const header = kuiHeaderFromBody([newKuiRow])
       if (header) {


### PR DESCRIPTION
Fixes #7203

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
